### PR TITLE
Issue #331

### DIFF
--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -49,6 +49,7 @@ import 'package:photo_view/photo_view_gallery.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 import '../../../utils/constant.dart';
+import 'package:path/path.dart' as p;
 
 class MangaDetailView extends ConsumerStatefulWidget {
   final Function(bool) isExtended;
@@ -1457,7 +1458,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Text(widget.manga!.name!,
+        SelectableText(widget.manga!.name!,
             style: const TextStyle(
               fontSize: 20,
             )),
@@ -1744,7 +1745,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                             if (bytes != null &&
                                                 context.mounted) {
                                               final file = File(
-                                                  '${dir!.path}/${widget.manga!.name}.png');
+                                                  p.join(dir!.path, "${widget.manga!.name}.png"));
                                               file.writeAsBytesSync(bytes);
                                               botToast(context.l10n.cover_saved,
                                                   second: 3);

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -42,6 +42,7 @@ import 'package:photo_view/photo_view_gallery.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:window_manager/window_manager.dart';
+import 'package:path/path.dart' as p;
 
 typedef DoubleClickAnimationListener = void Function();
 
@@ -360,7 +361,7 @@ class _MangaChapterPageGalleryState
                             () async {
                           final dir =
                               await StorageProvider().getGalleryDirectory();
-                          final file = File("${dir!.path}/$name.png");
+                          final file = File(p.join(dir!.path, "$name.png"));
                           file.writeAsBytesSync(imageBytes);
                           if (context.mounted) {
                             botToast(context.l10n.picture_saved, second: 3);

--- a/lib/modules/more/backup_and_restore/providers/backup.dart
+++ b/lib/modules/more/backup_and_restore/providers/backup.dart
@@ -144,7 +144,8 @@ void doBackUp(Ref ref,
               "Backup created!",
               style: TextStyle(fontWeight: FontWeight.bold),
             ),
-        trailing: (_) => UnconstrainedBox(
+        trailing: Platform.isLinux ? null : // Don't show share button on Linux, as there is no share-feature
+            (_) => UnconstrainedBox(
               alignment: Alignment.topLeft,
               child: ElevatedButton(
                   onPressed: () {


### PR DESCRIPTION
- Missed a concatenated path in manga_detail_view and in reader_view
- Made the Manga / Anime title selectable, so one can copy the title if needed
- Hidden the Backup share-button, because Linux has no share-feature and the button simply does nothing.