### PR TITLE
image path fix

### DIFF
--- a/repo/config.json
+++ b/repo/config.json
@@ -5,5 +5,5 @@
     "app_name": "Mangayomi",
     "caption": "Update for Mangayomi now available!",
     "tint_colour": "EF4444",
-    "image_url": "https://raw.githubusercontent.com/kodjodevf/mangayomi/refs/heads/main/repo/images/news/update.webp"
+    "image_url": "https://raw.githubusercontent.com/kodjodevf/mangayomi/refs/heads/main/repo/images/news/update_default.webp"
 }

--- a/repo/source.json
+++ b/repo/source.json
@@ -96,7 +96,7 @@
       "caption": "Update for Mangayomi now available!",
       "date": "2025-04-02T13:40:06Z",
       "tintColor": "EF4444",
-      "imageURL": "https://raw.githubusercontent.com/kodjodevf/mangayomi/refs/heads/main/repo/images/news/update.webp",
+      "imageURL": "https://raw.githubusercontent.com/kodjodevf/mangayomi/refs/heads/main/repo/images/news/update_default.webp",
       "notify": true,
       "url": "https://github.com/kodjodevf/mangayomi/releases/tag/v0.6.0"
     }


### PR DESCRIPTION
# 🚀 Pull Request
**Description:**  
Fix the missing suffix for news image in the `config.json`.

**Summary of Changes:**  
`repo/config.json`
- Add the `_default` suffix to `update_default.webp`

`repo/source.json`
- Add the missing suffix to the existing news item for the `v0.6.0` release.

**Type of Changes:**  
- Fix

**Testing Notes:**  
N/A

**Additional Context:**  
N/A