### PR TITLE
Clean up code + Add keyboard shortcut + Fix CBZ Archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
           Exec=usr/bin/mangayomi
           Icon=mangayomi
           Type=Application
-          Categories=Utility;
+          Categories=AudioVideo;
           EOF
           # Create AppRun file
           cat <<EOF > AppDir/AppRun
@@ -342,7 +342,7 @@ jobs:
           Exec=/usr/bin/mangayomi
           Icon=mangayomi
           Type=Application
-          Categories=Utility;
+          Categories=AudioVideo;
           EOL
           %files
           /usr/bin/*
@@ -356,7 +356,7 @@ jobs:
       - name: upload artifact linux zip
         uses: actions/upload-artifact@v4
         with:
-          name: Mangayomi-${{ github.ref_name }}-limux-zip
+          name: Mangayomi-${{ github.ref_name }}-linux-zip
           path: |
             build/linux/x64/release/bundle/Mangayomi-*.zip
             build/linux/x64/release/Mangayomi-*.AppImage

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -280,7 +280,7 @@
   "searching_for_updates": "Searching for updates...",
   "no_new_updates_available": "No new updates available",
   "uninstall": "Uninstall",
-  "uninstall_extension": "Uninstall {ext} extension ?",
+  "uninstall_extension": "Uninstall {ext} extension?",
   "langauage": "Language",
   "extension_detail": "Extension detail",
   "scale_type": "Scale type",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -201,7 +201,7 @@
   "searching_for_updates": "Vérification des mise à jours",
   "no_new_updates_available": "Aucune mise à jours disponible",
   "uninstall": "Désinstaller",
-  "uninstall_extension": "Désinstaller l'extension {ext} ?",
+  "uninstall_extension": "Désinstaller l'extension {ext}?",
   "langauage": "Langue",
   "extension_detail": "Informations de l'extension",
   "scale_type": "Type de mise à l'échelle",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1800,7 +1800,7 @@ abstract class AppLocalizations {
   /// No description provided for @uninstall_extension.
   ///
   /// In en, this message translates to:
-  /// **'Uninstall {ext} extension ?'**
+  /// **'Uninstall {ext} extension?'**
   String uninstall_extension(Object ext);
 
   /// No description provided for @langauage.

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -876,7 +876,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String uninstall_extension(Object ext) {
-    return 'Uninstall $ext extension ?';
+    return 'Uninstall $ext extension?';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -876,7 +876,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String uninstall_extension(Object ext) {
-    return 'Désinstaller l\'extension $ext ?';
+    return 'Désinstaller l\'extension $ext?';
   }
 
   @override

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -1290,6 +1290,9 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
                         doubleSpeed: (value) {
                           _isDoubleSpeed.value = value ?? false;
                         },
+                        defaultSkipIntroLength: ref.watch(
+                          defaultSkipIntroLengthStateProvider,
+                        ),
                       )
                       : MobileControllerWidget(
                         videoController: _controller,

--- a/lib/modules/anime/widgets/desktop.dart
+++ b/lib/modules/anime/widgets/desktop.dart
@@ -22,6 +22,7 @@ class DesktopControllerWidget extends StatefulWidget {
   final GlobalKey<VideoState> videoStatekey;
   final Widget bottomButtonBarWidget;
   final Widget seekToWidget;
+  final int defaultSkipIntroLength;
   const DesktopControllerWidget({
     super.key,
     required this.videoController,
@@ -32,6 +33,7 @@ class DesktopControllerWidget extends StatefulWidget {
     required this.seekToWidget,
     required this.tempDuration,
     required this.doubleSpeed,
+    required this.defaultSkipIntroLength,
   });
 
   @override
@@ -171,6 +173,12 @@ class _DesktopControllerWidgetState extends State<DesktopControllerWidget> {
           final rate =
               widget.videoController.player.state.position +
               const Duration(seconds: 10);
+          widget.videoController.player.seek(rate);
+        },
+        const SingleActivator(LogicalKeyboardKey.enter): () {
+          final rate =
+              widget.videoController.player.state.position +
+              Duration(seconds: widget.defaultSkipIntroLength);
           widget.videoController.player.seek(rate);
         },
         const SingleActivator(LogicalKeyboardKey.arrowLeft): () {

--- a/lib/modules/library/library_screen.dart
+++ b/lib/modules/library/library_screen.dart
@@ -59,7 +59,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   bool _isSearch = false;
   final List<Manga> _entries = [];
   final _textEditingController = TextEditingController();
-  late TabController tabBarController;
+  TabController? tabBarController;
   int _tabIndex = 0;
 
   @override
@@ -135,17 +135,29 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
 
                         final entr =
                             data.where((e) => !(e.hide ?? false)).toList();
-                        tabBarController = TabController(
-                          length:
-                              withoutCategory.isNotEmpty
-                                  ? entr.length + 1
-                                  : entr.length,
-                          vsync: this,
-                        );
-                        tabBarController.animateTo(_tabIndex);
-                        tabBarController.addListener(() {
-                          _tabIndex = tabBarController.index;
-                        });
+                        int tabCount =
+                            withoutCategory.isNotEmpty
+                                ? entr.length + 1
+                                : entr.length;
+                        if (tabBarController == null ||
+                            tabBarController!.length != tabCount) {
+                          int newTabIndex = _tabIndex;
+                          if (newTabIndex >= tabCount) {
+                            newTabIndex = tabCount - 1;
+                          }
+                          tabBarController?.dispose();
+                          tabBarController = TabController(
+                            length: tabCount,
+                            vsync: this,
+                            initialIndex: newTabIndex,
+                          );
+                          _tabIndex = newTabIndex;
+                          tabBarController!.addListener(() {
+                            setState(() {
+                              _tabIndex = tabBarController!.index;
+                            });
+                          });
+                        }
 
                         return Consumer(
                           builder: (context, ref, child) {

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -76,7 +76,7 @@ Future<void> downloadChapter(
           chapterDirectory.path,
           mangaMainDirectory!.path,
           chapter.name!,
-          pageUrls.map((e) => e.url).toList(),
+          pages.map((e) => e.fileName!).toList(),
         ).future,
       );
     }

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -82,32 +82,6 @@ class StorageProvider {
     return directory;
   }
 
-  Future<Directory?> getMangaChapterDirectory(Chapter chapter) async {
-    final manga = chapter.manga.value!;
-    String scanlator =
-        chapter.scanlator?.isNotEmpty ?? false
-            ? "${chapter.scanlator!.replaceForbiddenCharacters('_')}_"
-            : "";
-    final itemType = chapter.manga.value!.itemType;
-    final itemTypePath =
-        itemType == ItemType.manga
-            ? "Manga"
-            : itemType == ItemType.anime
-            ? "Anime"
-            : "Novel";
-    final dir = await getDirectory();
-    return Directory(
-      path.join(
-        dir!.path,
-        'downloads',
-        itemTypePath,
-        '${manga.source} ${manga.lang!.toUpperCase()}',
-        manga.name!.replaceForbiddenCharacters('_'),
-        scanlator + chapter.name!.replaceForbiddenCharacters('_'),
-      ),
-    );
-  }
-
   Future<Directory?> getMangaMainDirectory(Chapter chapter) async {
     final manga = chapter.manga.value!;
     final itemType = chapter.manga.value!.itemType;
@@ -123,8 +97,22 @@ class StorageProvider {
         dir!.path,
         'downloads',
         itemTypePath,
-        '${manga.source} ${manga.lang!.toUpperCase()}',
+        '${manga.source} (${manga.lang!.toUpperCase()})',
         manga.name!.replaceForbiddenCharacters('_'),
+      ),
+    );
+  }
+
+  Future<Directory?> getMangaChapterDirectory(Chapter chapter) async {
+    final basedir = await getMangaMainDirectory(chapter);
+    String scanlator =
+        chapter.scanlator?.isNotEmpty ?? false
+            ? "${chapter.scanlator!.replaceForbiddenCharacters('_')}_"
+            : "";
+    return Directory(
+      path.join(
+        basedir!.path,
+        scanlator + chapter.name!.replaceForbiddenCharacters('_'),
       ),
     );
   }

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -48,7 +48,7 @@ class StorageProvider {
       directory = Directory("/storage/emulated/0/Mangayomi/");
     } else {
       final dir = await getApplicationDocumentsDirectory();
-      directory = Directory("${dir.path}/Mangayomi/".fixSeparator);
+      directory = Directory(path.join(dir.path, 'Mangayomi'));
     }
     return directory;
   }
@@ -69,15 +69,15 @@ class StorageProvider {
 
   Future<Directory?> getDirectory() async {
     Directory? directory;
-    String path = isar.settings.getSync(227)!.downloadLocation ?? "";
+    String dPath = isar.settings.getSync(227)!.downloadLocation ?? "";
     if (Platform.isAndroid) {
       directory = Directory(
-        path.isEmpty ? "/storage/emulated/0/Mangayomi/" : "$path/",
+        dPath.isEmpty ? "/storage/emulated/0/Mangayomi/" : "$dPath/",
       );
     } else {
       final dir = await getApplicationDocumentsDirectory();
-      final p = path.isEmpty ? dir.path : path;
-      directory = Directory("$p/Mangayomi/".fixSeparator);
+      final p = dPath.isEmpty ? dir.path : dPath;
+      directory = Directory(path.join(p, 'Mangayomi'));
     }
     return directory;
   }
@@ -97,8 +97,14 @@ class StorageProvider {
             : "Novel";
     final dir = await getDirectory();
     return Directory(
-      "${dir!.path}downloads/$itemTypePath/${manga.source} (${manga.lang!.toUpperCase()})/${manga.name!.replaceForbiddenCharacters('_')}/$scanlator${chapter.name!.replaceForbiddenCharacters('_')}/"
-          .fixSeparator,
+      path.join(
+        dir!.path,
+        'downloads',
+        itemTypePath,
+        '${manga.source} ${manga.lang!.toUpperCase()}',
+        manga.name!.replaceForbiddenCharacters('_'),
+        scanlator + chapter.name!.replaceForbiddenCharacters('_'),
+      ),
     );
   }
 
@@ -113,8 +119,13 @@ class StorageProvider {
             : "Novel";
     final dir = await getDirectory();
     return Directory(
-      "${dir!.path}/downloads/$itemTypePath/${manga.source} (${manga.lang!.toUpperCase()})/${manga.name!.replaceForbiddenCharacters('_')}/"
-          .fixSeparator,
+      path.join(
+        dir!.path,
+        'downloads',
+        itemTypePath,
+        '${manga.source} ${manga.lang!.toUpperCase()}',
+        manga.name!.replaceForbiddenCharacters('_'),
+      ),
     );
   }
 
@@ -136,7 +147,6 @@ class StorageProvider {
     } else {
       gPath = path.join(gPath, 'Pictures');
     }
-    gPath = gPath.fixSeparator;
     await Directory(gPath).create(recursive: true);
     return Directory(gPath);
   }
@@ -179,8 +189,4 @@ class StorageProvider {
 
     return isar;
   }
-}
-
-extension StringPathExtension on String {
-  String get fixSeparator => replaceAll("/", path.separator);
 }

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -10,7 +10,7 @@ keywords:
 generic_name: Free and open source application that allows users to read manga and stream anime from a variety of sources including BitTorrent.
 
 categories:
-  - Utility
+  - AudioVideo
 
 startup_notify: true
 

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -18,7 +18,7 @@ postinstall_scripts:
   - echo "Installed Mangayomi successfully"
   
 postuninstall_scripts:
-  - echo "Unistalled Mangayomi successfully"
+  - echo "Uninstalled Mangayomi successfully"
 icon: assets/app_icons/icon-red.png
 
 keywords:
@@ -29,6 +29,6 @@ keywords:
 generic_name: Free and open source application that allows users to read manga and stream anime from a variety of sources including BitTorrent.
 
 categories:
-  - Utility
+  - AudioVideo
 
 startup_notify: true


### PR DESCRIPTION
- Changed the App Category to "AudioVideo" for the app to be in the correct category in Linux
- Added a keyboard shortcut (Enter-key) to skip the Anime intro (defaultSkipIntroLength).
- removed redundant fixSeparator method in storage_provider to use the path.join function directly.
- removed the redundat code from the getMangaChapterDirectory method in storage_provider
- Fixed the CBZ archive creation (#435)