### PR TITLE
Fix #444 + Kitsu detail change + episode/chapter name marquee effect

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:desktop_webview_window/desktop_webview_window.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -109,6 +110,16 @@ class _MyAppState extends ConsumerState<MyApp> {
         } else {
           ref.read(themeModeStateProvider.notifier).setDarkTheme();
         }
+        // Listen to System theme changes and adjust accordingly
+        final dispatcher = SchedulerBinding.instance.platformDispatcher;
+        dispatcher.onPlatformBrightnessChanged = () {
+          var newBrightness = dispatcher.platformBrightness;
+          if (newBrightness == Brightness.light) {
+            ref.read(themeModeStateProvider.notifier).setLightTheme();
+          } else {
+            ref.read(themeModeStateProvider.notifier).setDarkTheme();
+          }
+        };
       }
     });
   }

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -305,6 +305,7 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
 
   @override
   void initState() {
+    super.initState();
     _currentPositionSub;
     _currentTotalDurationSub;
     _completed;
@@ -332,7 +333,6 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
       _setPlaybackSpeed(ref.read(defaultPlayBackSpeedStateProvider));
       _initAniSkip();
     });
-    super.initState();
   }
 
   Future<void> _loadAndroidFont() async {

--- a/lib/modules/anime/widgets/custom_seekbar.dart
+++ b/lib/modules/anime/widgets/custom_seekbar.dart
@@ -31,6 +31,7 @@ class CustomSeekBarState extends State<CustomSeekBar> {
 
   @override
   void initState() {
+    super.initState();
     player.stream.position.listen((event) {
       if (mounted) {
         setState(() {
@@ -55,7 +56,6 @@ class CustomSeekBarState extends State<CustomSeekBar> {
     position = player.state.position;
     duration = player.state.duration;
     buffer = player.state.buffer;
-    super.initState();
   }
 
   final isDesktop = Platform.isMacOS || Platform.isWindows || Platform.isLinux;

--- a/lib/modules/anime/widgets/subtitle_view.dart
+++ b/lib/modules/anime/widgets/subtitle_view.dart
@@ -40,12 +40,12 @@ class _CustomSubtitleViewState extends ConsumerState<CustomSubtitleView> {
 
   @override
   void initState() {
+    super.initState();
     subscription = widget.controller.player.stream.subtitle.listen((value) {
       setState(() {
         subtitle = value;
       });
     });
-    super.initState();
   }
 
   @override

--- a/lib/modules/browse/extension/edit_code.dart
+++ b/lib/modules/browse/extension/edit_code.dart
@@ -63,6 +63,7 @@ class _CodeEditorPageState extends ConsumerState<CodeEditorPage> {
   final _scrollController = ScrollController();
   @override
   void initState() {
+    super.initState();
     _controller.text = source?.sourceCode ?? "";
     useLogger = true;
     _logStreamController.stream.asBroadcastStream().listen((event) async {
@@ -72,7 +73,6 @@ class _CodeEditorPageState extends ConsumerState<CodeEditorPage> {
         _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
       } catch (_) {}
     });
-    super.initState();
   }
 
   List<dynamic> filters = [];

--- a/lib/modules/browse/global_search/global_search_screen.dart
+++ b/lib/modules/browse/global_search/global_search_screen.dart
@@ -117,8 +117,8 @@ class SourceSearchScreen extends StatefulWidget {
 class _SourceSearchScreenState extends State<SourceSearchScreen> {
   @override
   void initState() {
-    _init();
     super.initState();
+    _init();
   }
 
   String _errorMessage = "";

--- a/lib/modules/history/history_screen.dart
+++ b/lib/modules/history/history_screen.dart
@@ -44,10 +44,10 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen>
 
   @override
   void initState() {
+    super.initState();
     _tabBarController = TabController(length: tabs, vsync: this);
     _tabBarController.animateTo(0);
     _tabBarController.addListener(tabListener);
-    super.initState();
   }
 
   final _textEditingController = TextEditingController();

--- a/lib/modules/library/widgets/list_tile_manga_category.dart
+++ b/lib/modules/library/widgets/list_tile_manga_category.dart
@@ -25,6 +25,7 @@ class ListTileMangaCategory extends StatefulWidget {
 class _ListTileMangaCategoryState extends State<ListTileMangaCategory> {
   @override
   void initState() {
+    super.initState();
     final res =
         widget.mangasList.where((element) {
           return element.categories == null
@@ -32,7 +33,6 @@ class _ListTileMangaCategoryState extends State<ListTileMangaCategory> {
               : element.categories!.contains(widget.category.id);
         }).toList();
     widget.res(res);
-    super.initState();
   }
 
   @override

--- a/lib/modules/manga/detail/manga_detail_main.dart
+++ b/lib/modules/manga/detail/manga_detail_main.dart
@@ -20,8 +20,8 @@ class MangaReaderDetail extends ConsumerStatefulWidget {
 class _MangaReaderDetailState extends ConsumerState<MangaReaderDetail> {
   @override
   void initState() {
-    _init();
     super.initState();
+    _init();
   }
 
   _init() async {

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -82,11 +82,11 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
     with TickerProviderStateMixin {
   @override
   void initState() {
+    super.initState();
     _scrollController =
         ScrollController()..addListener(() {
           ref.read(offetProvider.notifier).state = _scrollController.offset;
         });
-    super.initState();
   }
 
   final offetProvider = StateProvider((ref) => 0.0);

--- a/lib/modules/manga/detail/providers/track_state_providers.dart
+++ b/lib/modules/manga/detail/providers/track_state_providers.dart
@@ -54,24 +54,11 @@ class TrackState extends _$TrackState {
             )
             .updateLibAnime(track!),
       },
-      _ => switch (itemType) {
-        ItemType.manga => ref
-            .read(
-              kitsuProvider(
-                syncId: track!.syncId!,
-                itemType: itemType,
-              ).notifier,
-            )
-            .updateLibManga(track!),
-        _ => ref
-            .read(
-              kitsuProvider(
-                syncId: track!.syncId!,
-                itemType: itemType,
-              ).notifier,
-            )
-            .updateLibAnime(track!),
-      },
+      _ => ref
+          .read(
+            kitsuProvider(syncId: track!.syncId!, itemType: itemType).notifier,
+          )
+          .updateLib(track!, _isManga),
     };
 
     ref
@@ -205,18 +192,9 @@ class TrackState extends _$TrackState {
                   )
                   .addLibAnime(track);
     } else if (syncId == 3) {
-      findManga =
-          _isManga
-              ? await ref
-                  .read(
-                    kitsuProvider(syncId: syncId, itemType: itemType).notifier,
-                  )
-                  .addLibManga(track)
-              : await ref
-                  .read(
-                    kitsuProvider(syncId: syncId, itemType: itemType).notifier,
-                  )
-                  .addLibAnime(track);
+      findManga = await ref
+          .read(kitsuProvider(syncId: syncId, itemType: itemType).notifier)
+          .addLib(track, _isManga);
     }
 
     ref
@@ -266,24 +244,11 @@ class TrackState extends _$TrackState {
                   )
                   .aniListStatusListAnime;
     } else if (track!.syncId == 3) {
-      statusList =
-          _isManga
-              ? ref
-                  .read(
-                    kitsuProvider(
-                      syncId: track!.syncId!,
-                      itemType: itemType,
-                    ).notifier,
-                  )
-                  .kitsuStatusListManga
-              : ref
-                  .read(
-                    kitsuProvider(
-                      syncId: track!.syncId!,
-                      itemType: itemType,
-                    ).notifier,
-                  )
-                  .kitsuStatusListAnime;
+      statusList = ref
+          .read(
+            kitsuProvider(syncId: track!.syncId!, itemType: itemType).notifier,
+          )
+          .kitsuStatusList(_isManga);
     }
     for (var element in TrackStatus.values) {
       if (statusList.contains(element)) {
@@ -324,24 +289,11 @@ class TrackState extends _$TrackState {
                   )
                   .findLibAnime(track!);
     } else if (track!.syncId == 3) {
-      findManga =
-          _isManga
-              ? await ref
-                  .read(
-                    kitsuProvider(
-                      syncId: track!.syncId!,
-                      itemType: itemType,
-                    ).notifier,
-                  )
-                  .findLibManga(track!)
-              : await ref
-                  .read(
-                    kitsuProvider(
-                      syncId: track!.syncId!,
-                      itemType: itemType,
-                    ).notifier,
-                  )
-                  .findLibAnime(track!);
+      findManga = await ref
+          .read(
+            kitsuProvider(syncId: track!.syncId!, itemType: itemType).notifier,
+          )
+          .findLibItem(track!, _isManga);
     }
     return findManga;
   }
@@ -377,24 +329,11 @@ class TrackState extends _$TrackState {
                   )
                   .searchAnime(query);
     } else if (track!.syncId == 3) {
-      tracks =
-          _isManga
-              ? await ref
-                  .read(
-                    kitsuProvider(
-                      syncId: track!.syncId!,
-                      itemType: itemType,
-                    ).notifier,
-                  )
-                  .search(query)
-              : await ref
-                  .read(
-                    kitsuProvider(
-                      syncId: track!.syncId!,
-                      itemType: itemType,
-                    ).notifier,
-                  )
-                  .searchAnime(query);
+      tracks = await ref
+          .read(
+            kitsuProvider(syncId: track!.syncId!, itemType: itemType).notifier,
+          )
+          .search(query, _isManga);
     }
     return tracks;
   }

--- a/lib/modules/manga/detail/widgets/chapter_list_tile_widget.dart
+++ b/lib/modules/manga/detail/widgets/chapter_list_tile_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:marquee/marquee.dart';
 import 'package:mangayomi/models/chapter.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -64,13 +65,7 @@ class ChapterListTileWidget extends ConsumerWidget {
             chapter.isBookmarked!
                 ? Icon(Icons.bookmark, size: 16, color: context.primaryColor)
                 : Container(),
-            Flexible(
-              child: Text(
-                chapter.name!,
-                style: const TextStyle(fontSize: 13),
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
+            Flexible(child: _buildTitle(chapter.name!, context)),
           ],
         ),
         subtitle: Row(
@@ -139,6 +134,42 @@ class ChapterListTileWidget extends ConsumerWidget {
                 ? null
                 : ChapterPageDownload(chapter: chapter),
       ),
+    );
+  }
+
+  Widget _buildTitle(String text, BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final textPainter = TextPainter(
+          text: TextSpan(text: text, style: const TextStyle(fontSize: 13)),
+          maxLines: 1,
+          textDirection: TextDirection.ltr,
+        )..layout(
+          maxWidth: (constraints.maxWidth - (35 + 5)),
+        ); // - Download icon size (download_page_widget.dart, Widget Build SizedBox width: 35)
+
+        final isOverflowing = textPainter.didExceedMaxLines;
+
+        if (isOverflowing) {
+          return SizedBox(
+            height: 20,
+            child: Marquee(
+              text: text,
+              style: const TextStyle(fontSize: 13),
+              blankSpace: 40.0,
+              velocity: 30.0,
+              pauseAfterRound: const Duration(seconds: 1),
+              startPadding: 10.0,
+            ),
+          );
+        } else {
+          return Text(
+            text,
+            style: const TextStyle(fontSize: 13),
+            overflow: TextOverflow.ellipsis,
+          );
+        }
+      },
     );
   }
 }

--- a/lib/modules/manga/detail/widgets/migrate_screen.dart
+++ b/lib/modules/manga/detail/widgets/migrate_screen.dart
@@ -93,8 +93,8 @@ class _MigrationSourceSearchScreenState
     extends State<MigrationSourceSearchScreen> {
   @override
   void initState() {
-    _init();
     super.initState();
+    _init();
   }
 
   String _errorMessage = "";

--- a/lib/modules/manga/detail/widgets/tracker_search_widget.dart
+++ b/lib/modules/manga/detail/widgets/tracker_search_widget.dart
@@ -29,8 +29,8 @@ class TrackerWidgetSearch extends ConsumerStatefulWidget {
 class _TrackerWidgetSearchState extends ConsumerState<TrackerWidgetSearch> {
   @override
   initState() {
-    _init();
     super.initState();
+    _init();
   }
 
   late String query = widget.track.title!.trim();

--- a/lib/modules/manga/detail/widgets/tracker_widget.dart
+++ b/lib/modules/manga/detail/widgets/tracker_widget.dart
@@ -35,8 +35,8 @@ class TrackerWidget extends ConsumerStatefulWidget {
 class _TrackerWidgetState extends ConsumerState<TrackerWidget> {
   @override
   initState() {
-    _init();
     super.initState();
+    _init();
   }
 
   _init() async {

--- a/lib/modules/manga/detail/widgets/tracker_widget.dart
+++ b/lib/modules/manga/detail/widgets/tracker_widget.dart
@@ -491,7 +491,7 @@ class _TrackerWidgetState extends ConsumerState<TrackerWidget> {
                   text:
                       widget.trackRes.startedReadingDate != null &&
                               widget.trackRes.startedReadingDate! >
-                                  DateTime(1970).millisecondsSinceEpoch
+                                  DateTime.utc(1970).millisecondsSinceEpoch
                           ? dateFormat(
                             widget.trackRes.startedReadingDate.toString(),
                             ref: ref,
@@ -532,7 +532,7 @@ class _TrackerWidgetState extends ConsumerState<TrackerWidget> {
                   text:
                       widget.trackRes.finishedReadingDate != null &&
                               widget.trackRes.finishedReadingDate! >
-                                  DateTime(1970).millisecondsSinceEpoch
+                                  DateTime.utc(1970).millisecondsSinceEpoch
                           ? dateFormat(
                             widget.trackRes.finishedReadingDate.toString(),
                             ref: ref,

--- a/lib/modules/manga/reader/double_columm_view_center.dart
+++ b/lib/modules/manga/reader/double_columm_view_center.dart
@@ -68,6 +68,7 @@ class _DoubleColummViewState extends State<DoubleColummView>
 
   @override
   void initState() {
+    super.initState();
     _scaleAnimationController = AnimationController(
       duration: _doubleTapAnimationDuration(),
       vsync: this,
@@ -78,8 +79,6 @@ class _DoubleColummViewState extends State<DoubleColummView>
     _animation.addListener(() {
       _photoViewController.scale = _animation.value;
     });
-
-    super.initState();
   }
 
   void _toggleScale(Offset tapPosition) {

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -189,6 +189,7 @@ class _MangaChapterPageGalleryState
       StreamController<double>.broadcast();
   @override
   void initState() {
+    super.initState();
     _doubleClickAnimationController = AnimationController(
       duration: _doubleTapAnimationDuration(),
       vsync: this,
@@ -203,8 +204,6 @@ class _MangaChapterPageGalleryState
     _animation.addListener(() => _photoViewController.scale = _animation.value);
     _itemPositionsListener.itemPositions.addListener(_readProgressListener);
     _initCurrentIndex();
-
-    super.initState();
   }
 
   final double _horizontalScaleValue = 1.0;
@@ -960,53 +959,55 @@ class _MangaChapterPageGalleryState
   }
 
   void _readProgressListener() {
-    _currentIndex = _itemPositionsListener.itemPositions.value.first.index;
+    final itemPositions = _itemPositionsListener.itemPositions.value;
 
-    int pagesLength =
-        (_pageMode == PageMode.doublePage &&
-                !(ref.watch(_currentReaderMode) ==
-                    ReaderMode.horizontalContinuous))
-            ? (_uChapDataPreload.length / 2).ceil() + 1
-            : _uChapDataPreload.length;
+    if (itemPositions.isNotEmpty) {
+      _currentIndex = itemPositions.first.index;
+      int pagesLength =
+          (_pageMode == PageMode.doublePage &&
+                  !(ref.watch(_currentReaderMode) ==
+                      ReaderMode.horizontalContinuous))
+              ? (_uChapDataPreload.length / 2).ceil() + 1
+              : _uChapDataPreload.length;
 
-    if (_currentIndex! >= 0 && _currentIndex! < pagesLength) {
-      if (_readerController.chapter.id !=
-          _uChapDataPreload[_currentIndex!].chapter!.id) {
-        _readerController.setPageIndex(
-          _geCurrentIndex(_uChapDataPreload[_currentIndex! - 1].index!),
-          false,
-        );
-        if (mounted) {
-          setState(() {
-            _readerController = ref.read(
-              readerControllerProvider(
-                chapter: _uChapDataPreload[_currentIndex!].chapter!,
-              ).notifier,
-            );
+      if (_currentIndex! >= 0 && _currentIndex! < pagesLength) {
+        if (_readerController.chapter.id !=
+            _uChapDataPreload[_currentIndex!].chapter!.id) {
+          _readerController.setPageIndex(
+            _geCurrentIndex(_uChapDataPreload[_currentIndex! - 1].index!),
+            false,
+          );
+          if (mounted) {
+            setState(() {
+              _readerController = ref.read(
+                readerControllerProvider(
+                  chapter: _uChapDataPreload[_currentIndex!].chapter!,
+                ).notifier,
+              );
 
-            chapter = _uChapDataPreload[_currentIndex!].chapter!;
-            _chapterUrlModel =
-                _uChapDataPreload[_currentIndex!].chapterUrlModel!;
-            _isBookmarked = _readerController.getChapterBookmarked();
-          });
+              chapter = _uChapDataPreload[_currentIndex!].chapter!;
+              _chapterUrlModel =
+                  _uChapDataPreload[_currentIndex!].chapterUrlModel!;
+              _isBookmarked = _readerController.getChapterBookmarked();
+            });
+          }
         }
-      }
-      if (_itemPositionsListener.itemPositions.value.last.index ==
-          pagesLength - 1) {
-        try {
-          ref
-              .watch(
-                getChapterPagesProvider(
-                  chapter: _readerController.getNextChapter(),
-                ).future,
-              )
-              .then((value) => _preloadNextChapter(value, chapter));
-        } catch (_) {}
-      }
+        if (itemPositions.last.index == pagesLength - 1) {
+          try {
+            ref
+                .watch(
+                  getChapterPagesProvider(
+                    chapter: _readerController.getNextChapter(),
+                  ).future,
+                )
+                .then((value) => _preloadNextChapter(value, chapter));
+          } catch (_) {}
+        }
 
-      ref
-          .read(currentIndexProvider(chapter).notifier)
-          .setCurrentIndex(_uChapDataPreload[_currentIndex!].index!);
+        ref
+            .read(currentIndexProvider(chapter).notifier)
+            .setCurrentIndex(_uChapDataPreload[_currentIndex!].index!);
+      }
     }
   }
 

--- a/lib/modules/manga/reader/widgets/btn_chapter_list_dialog.dart
+++ b/lib/modules/manga/reader/widgets/btn_chapter_list_dialog.dart
@@ -57,8 +57,8 @@ class _ChapterListWidgetState extends State<ChapterListWidget> {
   );
   @override
   void initState() {
-    _jumpTo();
     super.initState();
+    _jumpTo();
   }
 
   Future<void> _jumpTo() async {

--- a/lib/modules/manga/reader/widgets/circular_progress_indicator_animate_rotate.dart
+++ b/lib/modules/manga/reader/widgets/circular_progress_indicator_animate_rotate.dart
@@ -51,9 +51,13 @@ class _CircularProgressIndicatorAnimateRotateState
                   duration: const Duration(milliseconds: 500),
                   curve: Curves.easeInOut,
                   tween: Tween<double>(begin: 0, end: widget.progress),
-                  builder:
-                      (context, value, _) =>
-                          CircularProgressIndicator(value: value),
+                  builder: (context, value, _) {
+                    final safeValue =
+                        value.isNaN || value.isInfinite
+                            ? null
+                            : value.clamp(0.0, 1.0);
+                    return CircularProgressIndicator(value: safeValue);
+                  },
                 ),
               ),
     );

--- a/lib/modules/more/categories/categories_screen.dart
+++ b/lib/modules/more/categories/categories_screen.dart
@@ -27,10 +27,9 @@ class _CategoriesScreenState extends ConsumerState<CategoriesScreen>
   int tabs = 3;
   @override
   void initState() {
+    super.initState();
     _tabBarController = TabController(length: tabs, vsync: this);
     _tabBarController.animateTo(widget.data.$2);
-
-    super.initState();
   }
 
   @override

--- a/lib/modules/more/settings/appearance/providers/theme_provider.dart
+++ b/lib/modules/more/settings/appearance/providers/theme_provider.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'blend_level_state_provider.dart';
+import 'flex_scheme_color_state_provider.dart';
+import 'pure_black_dark_mode_state_provider.dart';
+import 'app_font_family.dart';
+
+/// Provides the light theme for the app, recomputed only when
+/// flex scheme colors, blend level, or font family change.
+final lightThemeProvider = Provider<ThemeData>((ref) {
+  final colors = ref.watch(flexSchemeColorStateProvider);
+  final blendLevel = ref.watch(blendLevelStateProvider).toInt();
+  final fontFamily = ref.watch(appFontFamilyProvider);
+
+  return FlexThemeData.light(
+    colors: colors,
+    surfaceMode: FlexSurfaceMode.highScaffoldLevelSurface,
+    blendLevel: blendLevel,
+    appBarOpacity: 0.00,
+    subThemesData: const FlexSubThemesData(
+      blendOnLevel: 10,
+      thinBorderWidth: 2.0,
+      unselectedToggleIsColored: true,
+      inputDecoratorRadius: 24.0,
+      chipRadius: 24.0,
+    ),
+    useMaterial3ErrorColors: true,
+    visualDensity: FlexColorScheme.comfortablePlatformDensity,
+    useMaterial3: true,
+    fontFamily: fontFamily,
+  );
+});
+
+/// Provides the dark theme for the app, recomputed only when
+/// flex scheme colors, blend level, font family, or pure-black toggle change.
+final darkThemeProvider = Provider<ThemeData>((ref) {
+  final colors = ref.watch(flexSchemeColorStateProvider);
+  final blendLevel = ref.watch(blendLevelStateProvider).toInt();
+  final fontFamily = ref.watch(appFontFamilyProvider);
+  final pureBlack = ref.watch(pureBlackDarkModeStateProvider);
+
+  return FlexThemeData.dark(
+    colors: colors,
+    surfaceMode: FlexSurfaceMode.level,
+    blendLevel: blendLevel,
+    appBarOpacity: 0.00,
+    scaffoldBackground: pureBlack ? Colors.black : null,
+    subThemesData: const FlexSubThemesData(
+      blendOnLevel: 10,
+      thinBorderWidth: 2.0,
+      unselectedToggleIsColored: true,
+      inputDecoratorRadius: 24.0,
+      chipRadius: 24.0,
+    ),
+    useMaterial3ErrorColors: true,
+    visualDensity: FlexColorScheme.comfortablePlatformDensity,
+    useMaterial3: true,
+    fontFamily: fontFamily,
+  );
+});

--- a/lib/modules/more/settings/track/manage_trackers/manage_trackers.dart
+++ b/lib/modules/more/settings/track/manage_trackers/manage_trackers.dart
@@ -19,10 +19,10 @@ class _ManageTrackersScreenState extends State<ManageTrackersScreen> {
   late List<TrackPreference> trackPreferences = [];
   @override
   void initState() {
+    super.initState();
     trackPreferences =
         isar.trackPreferences.filter().syncIdIsNotNull().findAllSync();
     // trackPreferences.insert(0, TrackPreference(syncId: -1));
-    super.initState();
   }
 
   @override

--- a/lib/modules/more/settings/track/manage_trackers/tracking_detail.dart
+++ b/lib/modules/more/settings/track/manage_trackers/tracking_detail.dart
@@ -22,10 +22,9 @@ class _TrackingDetailState extends State<TrackingDetail>
   late TabController _tabBarController;
   @override
   void initState() {
+    super.initState();
     _tabBarController = TabController(length: 2, vsync: this);
     _tabBarController.animateTo(0);
-
-    super.initState();
   }
 
   @override

--- a/lib/modules/updates/updates_screen.dart
+++ b/lib/modules/updates/updates_screen.dart
@@ -91,10 +91,10 @@ class _UpdatesScreenState extends ConsumerState<UpdatesScreen>
 
   @override
   void initState() {
+    super.initState();
     _tabBarController = TabController(length: tabs, vsync: this);
     _tabBarController.animateTo(0);
     _tabBarController.addListener(tabListener);
-    super.initState();
   }
 
   final _textEditingController = TextEditingController();

--- a/lib/modules/webview/webview.dart
+++ b/lib/modules/webview/webview.dart
@@ -28,6 +28,7 @@ class _MangaWebViewState extends ConsumerState<MangaWebView> {
   bool isNotWebviewWindow = false;
   @override
   void initState() {
+    super.initState();
     if (Platform.isLinux || Platform.isWindows) {
       _runWebViewDesktop();
     } else {
@@ -35,7 +36,6 @@ class _MangaWebViewState extends ConsumerState<MangaWebView> {
         isNotWebviewWindow = true;
       });
     }
-    super.initState();
   }
 
   Webview? _desktopWebview;

--- a/lib/modules/widgets/custom_draggable_tabbar.dart
+++ b/lib/modules/widgets/custom_draggable_tabbar.dart
@@ -25,10 +25,10 @@ class _MeasureWidgetSizeState extends State<MeasureWidgetSize> {
 
   @override
   initState() {
+    super.initState();
     WidgetsBinding.instance.addPostFrameCallback(
       (_) => widget.onCalculateSize(_key.currentContext?.size),
     );
-    super.initState();
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -479,6 +479,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.6"
+  fading_edge_scrollview:
+    dependency: transitive
+    description:
+      name: fading_edge_scrollview
+      sha256: "1f84fe3ea8e251d00d5735e27502a6a250e4aa3d3b330d3fdcb475af741464ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
   fake_async:
     dependency: transitive
     description:
@@ -1117,6 +1125,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.3-main.0"
+  marquee:
+    dependency: "direct main"
+    description:
+      name: marquee
+      sha256: a87e7e80c5d21434f90ad92add9f820cf68be374b226404fe881d2bba7be0862
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,6 +81,7 @@ dependencies:
   protobuf: ^3.1.0
   device_info_plus: ^11.3.3
   flutter_app_installer: ^1.0.0
+  marquee: ^2.2.3
 
 dependency_overrides:
   ffi: ^2.1.3


### PR DESCRIPTION
- Kitsu tracker now displays the ì character correctly.
- Kitsu detail now shows "Start date" and "Finish date" like MAL tracker, instead of "01 Jan 1970"

![image](https://github.com/user-attachments/assets/875d3399-eabc-4825-a02e-fcd15d16c63d)

- Marquee effect for episode/chapter names when they are too long to fit in the line.
Before:
![image](https://github.com/user-attachments/assets/afce4b4b-a32f-4f7b-ad59-441241d02539)


After:
https://github.com/user-attachments/assets/32fc90d0-61a1-4d5b-94f6-91bb8e675d8f

