### PR TITLE
Fix Kitsu

### DIFF
--- a/lib/services/trackers/kitsu.dart
+++ b/lib/services/trackers/kitsu.dart
@@ -179,7 +179,7 @@ class Kitsu extends _$Kitsu {
     final accessToken = _getAccessToken();
 
     final url = Uri.parse(
-      '${_baseUrl}library-entries?filter[${type}_id]=${track.libraryId}&filter[user_id]=$userId&include=$type',
+      '${_baseUrl}library-entries?filter[${type}_id]=${track.mediaId}&filter[user_id]=$userId&include=$type',
     );
     Response response = await _makeGetRequest(url, accessToken);
     if (response.statusCode == 200) {


### PR DESCRIPTION
Resolved an issue where items could not be added to the tracker due to the use of an incorrect ID. This caused `parseTrackResponse()` to fail in locating the 'included' key within `jsonResponse`, leading to a null return. As a result, an exception was thrown in `tracker_widget.dart` at line 134 when accessing `widget.trackRes.title!,` triggering a _TypeError (Null check operator used on a null value)_.