### PR TITLE
Fix Async Transaction Bug and Category Management Issues

### DIFF
--- a/lib/modules/library/library_screen.dart
+++ b/lib/modules/library/library_screen.dart
@@ -128,18 +128,45 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         final withoutCategories = ref.watch(
           getAllMangaWithoutCategoriesStreamProvider(itemType: widget.itemType),
         );
-        final showCategoryTabs = ref.watch(
-          libraryShowCategoryTabsStateProvider(
-            itemType: widget.itemType,
-            settings: settings,
-          ),
-        );
         final mangaAll = ref.watch(
           getAllMangaStreamProvider(
             categoryId: null,
             itemType: widget.itemType,
           ),
         );
+        T watchWithSettings<T>(
+          ProviderListenable<T> Function({
+            required ItemType itemType,
+            required Settings settings,
+          })
+          providerFn,
+        ) {
+          return ref.watch(
+            providerFn(itemType: widget.itemType, settings: settings),
+          );
+        }
+
+        T watchWithSettingsAndManga<T>(
+          ProviderListenable<T> Function({
+            required ItemType itemType,
+            required List<Manga> mangaList,
+            required Settings settings,
+          })
+          providerFn,
+        ) {
+          return ref.watch(
+            providerFn(
+              itemType: widget.itemType,
+              mangaList: _entries,
+              settings: settings,
+            ),
+          );
+        }
+
+        final showCategoryTabs = watchWithSettings(
+          libraryShowCategoryTabsStateProvider.call,
+        );
+
         final l10n = l10nLocalizations(context)!;
         return Scaffold(
           body: mangaAll.when(
@@ -148,6 +175,48 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
                 data: (withoutCategory) {
                   return categories.when(
                     data: (data) {
+                      bool reverse = watchWithSettings(
+                        sortLibraryMangaStateProvider.call,
+                      ).reverse!;
+                      final continueReaderBtn = watchWithSettings(
+                        libraryShowContinueReadingButtonStateProvider.call,
+                      );
+                      final showNumbersOfItems = watchWithSettings(
+                        libraryShowNumbersOfItemsStateProvider.call,
+                      );
+                      final localSource = watchWithSettings(
+                        libraryLocalSourceStateProvider.call,
+                      );
+                      final downloadedChapter = watchWithSettings(
+                        libraryDownloadedChaptersStateProvider.call,
+                      );
+                      final language = watchWithSettings(
+                        libraryLanguageStateProvider.call,
+                      );
+                      final displayType = watchWithSettings(
+                        libraryDisplayTypeStateProvider.call,
+                      );
+                      final isNotFiltering = watchWithSettingsAndManga(
+                        mangasFilterResultStateProvider.call,
+                      );
+                      final downloadFilterType = watchWithSettingsAndManga(
+                        mangaFilterDownloadedStateProvider.call,
+                      );
+                      final unreadFilterType = watchWithSettingsAndManga(
+                        mangaFilterUnreadStateProvider.call,
+                      );
+                      final startedFilterType = watchWithSettingsAndManga(
+                        mangaFilterStartedStateProvider.call,
+                      );
+                      final bookmarkedFilterType = watchWithSettingsAndManga(
+                        mangaFilterBookmarkedStateProvider.call,
+                      );
+                      final sortType =
+                          watchWithSettings(
+                                sortLibraryMangaStateProvider.call,
+                              ).index
+                              as int;
+
                       if (data.isNotEmpty && showCategoryTabs) {
                         data.sort((a, b) => (a.pos ?? 0).compareTo(b.pos ?? 0));
 
@@ -157,8 +226,26 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
                         int tabCount = withoutCategory.isNotEmpty
                             ? entr.length + 1
                             : entr.length;
-                        if (tabBarController == null ||
-                            tabBarController!.length != tabCount) {
+                        if (tabCount <= 0) {
+                          return _bodyWithoutCategories(
+                            withoutCategories: true,
+                            downloadFilterType: downloadFilterType,
+                            unreadFilterType: unreadFilterType,
+                            startedFilterType: startedFilterType,
+                            bookmarkedFilterType: bookmarkedFilterType,
+                            reverse: reverse,
+                            downloadedChapter: downloadedChapter,
+                            continueReaderBtn: continueReaderBtn,
+                            language: language,
+                            displayType: displayType,
+                            ref: ref,
+                            localSource: localSource,
+                            settings: settings,
+                          );
+                        }
+                        if (tabCount > 0 &&
+                            (tabBarController == null ||
+                                tabBarController!.length != tabCount)) {
                           int newTabIndex = _tabIndex;
                           if (newTabIndex >= tabCount) {
                             newTabIndex = tabCount - 1;
@@ -179,96 +266,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
 
                         return Consumer(
                           builder: (context, ref, child) {
-                            bool reverse = ref
-                                .watch(
-                                  sortLibraryMangaStateProvider(
-                                    itemType: widget.itemType,
-                                    settings: settings,
-                                  ),
-                                )
-                                .reverse!;
-
-                            final continueReaderBtn = ref.watch(
-                              libraryShowContinueReadingButtonStateProvider(
-                                itemType: widget.itemType,
-                                settings: settings,
-                              ),
-                            );
-                            final showNumbersOfItems = ref.watch(
-                              libraryShowNumbersOfItemsStateProvider(
-                                itemType: widget.itemType,
-                                settings: settings,
-                              ),
-                            );
-                            final localSource = ref.watch(
-                              libraryLocalSourceStateProvider(
-                                itemType: widget.itemType,
-                                settings: settings,
-                              ),
-                            );
-                            final downloadedChapter = ref.watch(
-                              libraryDownloadedChaptersStateProvider(
-                                itemType: widget.itemType,
-                                settings: settings,
-                              ),
-                            );
-                            final language = ref.watch(
-                              libraryLanguageStateProvider(
-                                itemType: widget.itemType,
-                                settings: settings,
-                              ),
-                            );
-                            final displayType = ref.watch(
-                              libraryDisplayTypeStateProvider(
-                                itemType: widget.itemType,
-                                settings: settings,
-                              ),
-                            );
-                            final isNotFiltering = ref.watch(
-                              mangasFilterResultStateProvider(
-                                itemType: widget.itemType,
-                                mangaList: _entries,
-                                settings: settings,
-                              ),
-                            );
-                            final downloadFilterType = ref.watch(
-                              mangaFilterDownloadedStateProvider(
-                                itemType: widget.itemType,
-                                mangaList: _entries,
-                                settings: settings,
-                              ),
-                            );
-                            final unreadFilterType = ref.watch(
-                              mangaFilterUnreadStateProvider(
-                                itemType: widget.itemType,
-                                mangaList: _entries,
-                                settings: settings,
-                              ),
-                            );
-                            final startedFilterType = ref.watch(
-                              mangaFilterStartedStateProvider(
-                                itemType: widget.itemType,
-                                mangaList: _entries,
-                                settings: settings,
-                              ),
-                            );
-                            final bookmarkedFilterType = ref.watch(
-                              mangaFilterBookmarkedStateProvider(
-                                itemType: widget.itemType,
-                                mangaList: _entries,
-                                settings: settings,
-                              ),
-                            );
-                            final sortType =
-                                ref
-                                        .watch(
-                                          sortLibraryMangaStateProvider(
-                                            itemType: widget.itemType,
-                                            settings: settings,
-                                          ),
-                                        )
-                                        .index
-                                    as int;
                             final numberOfItemsList = _filterAndSortManga(
                               data: man,
                               downloadFilterType: downloadFilterType,
@@ -410,7 +407,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
                                             )
                                               i == 0
                                                   ? _bodyWithoutCategories(
-                                                      withouCategories: true,
+                                                      withoutCategories: true,
                                                       downloadFilterType:
                                                           downloadFilterType,
                                                       unreadFilterType:
@@ -491,102 +488,13 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
                       }
                       return Consumer(
                         builder: (context, ref, child) {
-                          bool reverse =
-                              ref
-                                  .watch(
-                                    sortLibraryMangaStateProvider(
-                                      itemType: widget.itemType,
-                                      settings: settings,
-                                    ),
-                                  )
-                                  .reverse ??
-                              false;
-                          final continueReaderBtn = ref.watch(
-                            libraryShowContinueReadingButtonStateProvider(
-                              itemType: widget.itemType,
-                              settings: settings,
-                            ),
-                          );
-                          final showNumbersOfItems = ref.watch(
-                            libraryShowNumbersOfItemsStateProvider(
-                              itemType: widget.itemType,
-                              settings: settings,
-                            ),
-                          );
-                          final localSource = ref.watch(
-                            libraryLocalSourceStateProvider(
-                              itemType: widget.itemType,
-                              settings: settings,
-                            ),
-                          );
-                          final downloadedChapter = ref.watch(
-                            libraryDownloadedChaptersStateProvider(
-                              itemType: widget.itemType,
-                              settings: settings,
-                            ),
-                          );
-                          final language = ref.watch(
-                            libraryLanguageStateProvider(
-                              itemType: widget.itemType,
-                              settings: settings,
-                            ),
-                          );
-                          final displayType = ref.watch(
-                            libraryDisplayTypeStateProvider(
-                              itemType: widget.itemType,
-                              settings: settings,
-                            ),
-                          );
-                          final isNotFiltering = ref.watch(
-                            mangasFilterResultStateProvider(
-                              itemType: widget.itemType,
-                              mangaList: _entries,
-                              settings: settings,
-                            ),
-                          );
-                          final downloadFilterType = ref.watch(
-                            mangaFilterDownloadedStateProvider(
-                              itemType: widget.itemType,
-                              mangaList: _entries,
-                              settings: settings,
-                            ),
-                          );
-                          final unreadFilterType = ref.watch(
-                            mangaFilterUnreadStateProvider(
-                              itemType: widget.itemType,
-                              mangaList: _entries,
-                              settings: settings,
-                            ),
-                          );
-                          final startedFilterType = ref.watch(
-                            mangaFilterStartedStateProvider(
-                              itemType: widget.itemType,
-                              mangaList: _entries,
-                              settings: settings,
-                            ),
-                          );
-                          final bookmarkedFilterType = ref.watch(
-                            mangaFilterBookmarkedStateProvider(
-                              itemType: widget.itemType,
-                              mangaList: _entries,
-                              settings: settings,
-                            ),
-                          );
-                          final sortType = ref
-                              .watch(
-                                sortLibraryMangaStateProvider(
-                                  itemType: widget.itemType,
-                                  settings: settings,
-                                ),
-                              )
-                              .index;
                           final numberOfItemsList = _filterAndSortManga(
                             data: man,
                             downloadFilterType: downloadFilterType,
                             unreadFilterType: unreadFilterType,
                             startedFilterType: startedFilterType,
                             bookmarkedFilterType: bookmarkedFilterType,
-                            sortType: sortType ?? 0,
+                            sortType: sortType,
                           );
                           return Scaffold(
                             appBar: _appBar(
@@ -948,7 +856,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     required bool language,
     required DisplayType displayType,
     required WidgetRef ref,
-    bool withouCategories = false,
+    bool withoutCategories = false,
     required Settings settings,
   }) {
     final sortType = ref
@@ -959,7 +867,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
           ),
         )
         .index;
-    final manga = withouCategories
+    final manga = withoutCategories
         ? ref.watch(
             getAllMangaWithoutCategoriesStreamProvider(
               itemType: widget.itemType,

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -1135,7 +1135,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
 
   void _openCategory(Manga manga) {
     final l10n = l10nLocalizations(context)!;
-    List<int> categoryIds = [];
+    List<int> categoryIds = List<int>.from(manga.categories ?? []);
     showDialog(
       context: context,
       builder: (context) => StatefulBuilder(
@@ -1215,12 +1215,6 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                           isar.mangas.putSync(manga);
                           final sync = ref.read(
                             synchingProvider(syncId: 1).notifier,
-                          );
-                          sync.addChangedPart(
-                            ActionType.addItem,
-                            manga.id,
-                            manga.toJson(),
-                            false,
                           );
                           sync.addChangedPart(
                             ActionType.updateItem,


### PR DESCRIPTION
### 📝 Summary

This PR consolidates four related fixes to improve stability and correctness in transaction handling and category management across the app:

**1. Async Write Transaction Bug
2. Category Selection in Manga Detail View
3. Category Removal Reference Cleanup
4. Tab‐Controller Edge Case & Code Cleanup**
&nbsp;

### 🔍 Details

**1. Fix async write transaction bug**
    - Issue: Switching the write transaction to fully async led to a nested‑transaction error:
    ```
IsarError: Cannot perform this operation from within an active transaction. Isar does not support nesting transactions.
    ```
    - Resolution: Ensure that the write transaction is fully awaited and not re‑entered before completion.

**2. Fix "Set categories" in `manga_detail_view`**
    - Issue: The category selection dialog did not reflect the current categories for a library item.
    - Resolution: Updated the dialog data source so it correctly marks which categories the item already belongs to.

**3. Fix category removal bug**
    - Issue: Removing a category did not update the linked manga items, causing them to disappear from the library view.
    - Resolution: On category deletion, remove the reference from each affected item. Items without any category now fall back into the “Default” category.

**4. Fix tab‐controller edge case & remove redundant code**
    - Issue A: If the user hid the only remaining category, `tabCount` became <= 0, triggering an assertion in `TabController`:
    ```
    _AssertionError ('package:flutter/src/material/tab_controller.dart': Failed assertion: line 116 pos 15: 'initialIndex >= 0 && (length == 0 || initialIndex < length)': is not true.)
    ```
    - Issue B: Duplicate variables and multiple `ref.watch` calls created unnecessary code churn.
    - Resolutions:
        - Added a guard so that when `tabCount <= 0`, the UI shows `_bodyWithoutCategories` instead of instantiating a `TabController`.
        - Consolidated redundant variables and grouped all `ref.watch` calls into a single, DRY implementation.
&nbsp;

### ✅ Testing & Validation

- Verified that the async transaction no longer triggers nesting errors under heavy load.
- Manually tested category selection and saw correct pre‐selected state in the dialog.
- Confirmed that deleting a category reassigns orphaned items to “Default” and they reappear in the library.
- Hid the last category and ensured the fallback view renders without exceptions.