### PR TITLE
Refactor: Consolidate _openCategory() Methods into Unified Dialog

### DIFF
--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -26,6 +26,7 @@ import 'package:mangayomi/modules/manga/reader/providers/reader_controller_provi
 import 'package:mangayomi/modules/more/settings/appearance/providers/pure_black_dark_mode_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/sync/providers/sync_providers.dart';
 import 'package:mangayomi/modules/more/settings/track/widgets/track_listile.dart';
+import 'package:mangayomi/modules/widgets/category_selection_dialog.dart';
 import 'package:mangayomi/modules/widgets/custom_draggable_tabbar.dart';
 import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -637,7 +638,12 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                   widget.checkForUpdate(true);
                                   break;
                                 case 1:
-                                  _openCategory(widget.manga!);
+                                  showCategorySelectionDialog(
+                                    context: context,
+                                    ref: ref,
+                                    itemType: widget.manga!.itemType,
+                                    singleManga: widget.manga!,
+                                  );
                                   break;
                                 case 2:
                                   final source = getSource(
@@ -1130,107 +1136,6 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
           ),
         ),
       ],
-    );
-  }
-
-  void _openCategory(Manga manga) {
-    final l10n = l10nLocalizations(context)!;
-    List<int> categoryIds = List<int>.from(manga.categories ?? []);
-    showDialog(
-      context: context,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setState) => AlertDialog(
-          title: Text(l10n.set_categories),
-          content: SizedBox(
-            width: context.width(0.8),
-            child: StreamBuilder(
-              stream: isar.categorys
-                  .filter()
-                  .idIsNotNull()
-                  .and()
-                  .forItemTypeEqualTo(manga.itemType)
-                  .watch(fireImmediately: true),
-              builder: (context, snapshot) {
-                if (!snapshot.hasData || snapshot.data!.isEmpty) {
-                  return Container();
-                }
-                final entries = snapshot.data!;
-                return SuperListView.builder(
-                  shrinkWrap: true,
-                  itemCount: entries.length,
-                  itemBuilder: (context, index) {
-                    final category = entries[index];
-                    final selected = categoryIds.contains(category.id);
-                    return ListTileChapterFilter(
-                      label: category.name!,
-                      onTap: () {
-                        setState(() {
-                          selected
-                              ? categoryIds.remove(category.id)
-                              : categoryIds.add(category.id!);
-                        });
-                      },
-                      type: selected ? 1 : 0,
-                    );
-                  },
-                );
-              },
-            ),
-          ),
-          actions: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                TextButton(
-                  onPressed: () {
-                    context.push(
-                      "/categories",
-                      extra: (
-                        true,
-                        manga.itemType == ItemType.manga
-                            ? 0
-                            : manga.itemType == ItemType.anime
-                            ? 1
-                            : 2,
-                      ),
-                    );
-                    Navigator.pop(context);
-                  },
-                  child: Text(l10n.edit),
-                ),
-                Row(
-                  children: [
-                    TextButton(
-                      onPressed: () => Navigator.pop(context),
-                      child: Text(l10n.cancel),
-                    ),
-                    const SizedBox(width: 15),
-                    TextButton(
-                      onPressed: () {
-                        isar.writeTxnSync(() {
-                          manga.categories = categoryIds;
-                          isar.mangas.putSync(manga);
-                          final sync = ref.read(
-                            synchingProvider(syncId: 1).notifier,
-                          );
-                          sync.addChangedPart(
-                            ActionType.updateItem,
-                            manga.id,
-                            manga.toJson(),
-                            false,
-                          );
-                        });
-                        if (mounted) Navigator.pop(context);
-                      },
-                      child: Text(l10n.ok),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
     );
   }
 

--- a/lib/modules/widgets/category_selection_dialog.dart
+++ b/lib/modules/widgets/category_selection_dialog.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:isar/isar.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/category.dart';
+import 'package:mangayomi/models/changed.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/modules/library/providers/library_state_provider.dart';
+import 'package:mangayomi/modules/library/widgets/list_tile_manga_category.dart';
+import 'package:mangayomi/modules/manga/detail/widgets/chapter_filter_list_tile_widget.dart';
+import 'package:mangayomi/modules/more/settings/sync/providers/sync_providers.dart';
+import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:super_sliver_list/super_sliver_list.dart';
+
+void showCategorySelectionDialog({
+  required BuildContext context,
+  required WidgetRef ref,
+  required ItemType itemType,
+  Manga? singleManga,
+  List<Manga>? bulkMangas,
+}) {
+  assert(
+    (singleManga != null) ^ (bulkMangas != null),
+    "Provide either singleManga or bulkMangas, not both.",
+  );
+  final l10n = l10nLocalizations(context)!;
+  final bool isBulk = bulkMangas != null;
+  final bool isFavorite = !isBulk && (singleManga!.favorite ?? false);
+  List<int> categoryIds = [];
+  if (!isBulk && isFavorite) {
+    categoryIds = List<int>.from(singleManga.categories ?? []);
+  }
+  showDialog(
+    context: context,
+    builder: (context) => StatefulBuilder(
+      builder: (context, setState) => AlertDialog(
+        title: Text(l10n.set_categories),
+        content: SizedBox(
+          width: context.width(0.8),
+          child: StreamBuilder(
+            stream: isar.categorys
+                .filter()
+                .idIsNotNull()
+                .and()
+                .forItemTypeEqualTo(itemType)
+                .watch(fireImmediately: true),
+            builder: (context, snapshot) {
+              if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                return Text(l10n.library_no_category_exist);
+              }
+              var entries = (snapshot.data!
+                ..sort((a, b) => (a.pos ?? 0).compareTo(b.pos ?? 0)));
+              if (isFavorite || isBulk) {
+                // When item is in library, hide hidden categories in list
+                entries = entries.where((e) => !(e.hide ?? false)).toList();
+              }
+              if (entries.isEmpty) return Text(l10n.library_no_category_exist);
+              return SuperListView.builder(
+                shrinkWrap: true,
+                itemCount: entries.length,
+                itemBuilder: (context, index) {
+                  final category = entries[index];
+                  final isSelected = categoryIds.contains(category.id);
+                  if (!isBulk) {
+                    return ListTileChapterFilter(
+                      label: category.name!,
+                      onTap: () {
+                        setState(() {
+                          isSelected
+                              ? categoryIds.remove(category.id)
+                              : categoryIds.add(category.id!);
+                        });
+                      },
+                      type: isSelected ? 1 : 0,
+                    );
+                  }
+                  return ListTileMangaCategory(
+                    category: category,
+                    categoryIds: categoryIds,
+                    mangasList: bulkMangas,
+                    onTap: () {
+                      setState(() {
+                        if (isSelected) {
+                          categoryIds.remove(category.id);
+                        } else {
+                          categoryIds.add(category.id!);
+                        }
+                      });
+                    },
+                    res: (res) {
+                      if (res.isNotEmpty && !isSelected) {
+                        categoryIds.add(category.id!);
+                      }
+                    },
+                  );
+                },
+              );
+            },
+          ),
+        ),
+        actions: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              TextButton(
+                child: Text(l10n.edit),
+                onPressed: () {
+                  context.push(
+                    "/categories",
+                    extra: (
+                      true,
+                      itemType == ItemType.manga
+                          ? 0
+                          : itemType == ItemType.anime
+                          ? 1
+                          : 2,
+                    ),
+                  );
+                  Navigator.pop(context);
+                },
+              ),
+              Row(
+                children: [
+                  TextButton(
+                    child: Text(l10n.cancel),
+                    onPressed: () => Navigator.pop(context),
+                  ),
+                  const SizedBox(width: 15),
+                  TextButton(
+                    child: Text(l10n.ok),
+                    onPressed: () {
+                      isar.writeTxnSync(() {
+                        if (isBulk) {
+                          for (var manga in bulkMangas) {
+                            manga.categories = categoryIds;
+                            isar.mangas.putSync(manga);
+                            _syncManga(manga, isFavorite, ref);
+                          }
+                        } else {
+                          if (!isFavorite) {
+                            singleManga!.favorite = true;
+                            singleManga.dateAdded =
+                                DateTime.now().millisecondsSinceEpoch;
+                          }
+                          singleManga.categories = categoryIds;
+                          isar.mangas.putSync(singleManga);
+                          _syncManga(singleManga, isFavorite, ref);
+                        }
+                        if (isBulk) {
+                          ref.read(mangasListStateProvider.notifier).clear();
+                          ref
+                              .read(isLongPressedMangaStateProvider.notifier)
+                              .update(false);
+                        }
+                      });
+                      if (context.mounted) Navigator.pop(context);
+                    },
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+void _syncManga(Manga manga, bool isFavorite, WidgetRef ref) {
+  final sync = ref.read(synchingProvider(syncId: 1).notifier);
+  if (isFavorite) {
+    sync.addChangedPart(ActionType.updateItem, manga.id, manga.toJson(), false);
+  } else {
+    sync.addChangedPart(ActionType.addItem, manga.id, manga.toJson(), false);
+  }
+}


### PR DESCRIPTION
**Summary**:
Replaced three separate `_openCategory()` implementations with a single, flexible `showCategorySelectionDialog()` function.

**Details**:
Previously, there were three distinct `_openCategory()` methods used in different contexts (bulk manga selection, single manga update, and library addition). All three shared nearly identical UI logic and structure, leading to duplicated code and maintenance complexity.

This PR introduces `showCategorySelectionDialog()`, a unified, parameterized function that:

- Supports both single manga and bulk manga inputs via assertion logic
- Conditionally shows/hides hidden categories (just like before, shows hidden categories, when adding to library)
- Replaces all redundant methods with a reusable, streamlined implementation

**Benefits**:

- Simplifies codebase by removing duplication
- Improves maintainability and readability
- Reduces future bugs due to logic divergence

**Testing**:

- Verified behavior with both single manga updates and bulk selection
- Ensured sync operations are preserved for both update and add scenarios
- Confirmed categories render and update as expected in all entry points