### PR TITLE
Make buttons white for consistency in light mode

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -1133,6 +1133,7 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
                         _player.pause();
                       }
                     },
+                    iconColor: Colors.white,
                   ),
                   btnToShowShareScreenshot(
                     widget.episode,
@@ -1539,7 +1540,7 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
         );
         onChanged?.call(true);
       },
-      icon: Icon(Icons.adaptive.share),
+      icon: Icon(Icons.adaptive.share, color: Colors.white),
     );
   }
 

--- a/lib/modules/manga/reader/widgets/btn_chapter_list_dialog.dart
+++ b/lib/modules/manga/reader/widgets/btn_chapter_list_dialog.dart
@@ -15,6 +15,7 @@ Widget btnToShowChapterListDialog(
   String title,
   Chapter chapter, {
   void Function(bool)? onChanged,
+  Color? iconColor,
 }) {
   return IconButton(
     onPressed: () async {
@@ -33,7 +34,7 @@ Widget btnToShowChapterListDialog(
       );
       onChanged?.call(true);
     },
-    icon: const Icon(Icons.format_list_numbered_outlined),
+    icon: Icon(Icons.format_list_numbered_outlined, color: iconColor),
   );
 }
 

--- a/lib/modules/more/data_and_storage/providers/restore.dart
+++ b/lib/modules/more/data_and_storage/providers/restore.dart
@@ -385,7 +385,10 @@ void restoreTachiBkBackup(Ref ref, String path, BackupType bkType) {
   final inputStream = InputFileStream(path);
   final content = GZipDecoder().decodeBytes(inputStream.toUint8List());
   inputStream.close();
-  final backup = BackupMihon.fromBuffer(content);
+  final backup = BackupMihon.create();
+  backup.mergeFromCodedBufferReader(
+    CodedBufferReader(content, sizeLimit: 250 << 20),
+  );
   List<Category> cats = [];
   isar.writeTxnSync(() {
     isar.categorys.clearSync();


### PR DESCRIPTION
The share-button on the top right and the show-episode-list-button next to it were dark when the app was in light mode.

Before:
![image](https://github.com/user-attachments/assets/9e415a14-8b79-4090-9dc1-030edaa395c9)


After:
![image](https://github.com/user-attachments/assets/d0ebf465-69ae-4698-8f67-a14ae087e5ce)

&nbsp;

And partially revert changes in 181c3b5 to increase the protobuf limit to 250 MB again (#494)