### PR TITLE
Don't allow zooming

### DIFF
--- a/lib/utils/cached_network.dart
+++ b/lib/utils/cached_network.dart
@@ -20,7 +20,7 @@ Widget cachedNetworkImage({
     height: height,
     fit: fit,
     filterQuality: FilterQuality.medium,
-    mode: ExtendedImageMode.gesture,
+    mode: ExtendedImageMode.none,
     handleLoadingProgress: true,
     loadStateChanged: (state) {
       if (state.extendedImageLoadState == LoadState.failed) {
@@ -53,7 +53,7 @@ Widget cachedCompressedNetworkImage({
     height: height,
     fit: fit,
     filterQuality: FilterQuality.medium,
-    mode: ExtendedImageMode.gesture,
+    mode: ExtendedImageMode.none,
     handleLoadingProgress: true,
     clearMemoryCacheWhenDispose: true,
     loadStateChanged: (state) {


### PR DESCRIPTION
When these methods were used to display images (migration screen, history screen, etc) the images (anime/manga covers and extension icons) were zoomable. You could (on a touch device) pinch to zoom. And with the mouse you could get your cursor an on image and scroll up to zoom out and scroll down to zoom in. This was not necessary confusing for the user.

How it was before:


https://github.com/user-attachments/assets/c4e2e117-640c-42ab-9220-2f6f63a8c066

