### PR TITLE
Fix regression: restore fullscreen exit logic on desktop

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -54,6 +54,9 @@ class _AnimePlayerViewState extends riv.ConsumerState<AnimePlayerView> {
   bool desktopFullScreenPlayer = false;
   @override
   void dispose() {
+    if (_isDesktop) {
+      setFullScreen(value: desktopFullScreenPlayer);
+    }
     for (var infoHash in _infoHashList) {
       MTorrentServer().removeTorrent(infoHash);
     }


### PR DESCRIPTION
This PR reverts a mistake from commit d21dbbbc where the fullscreen reset logic was accidentally removed from `AnimePlayerView.dispose()`.
As a result, the app remained stuck in fullscreen mode when exiting the anime player view before a video had loaded.
The call to setFullScreen(...) has been re-added to restore the original behavior.