### PR TITLE
Reduce file size of AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,7 +280,7 @@ jobs:
         run: flutter build linux --release --verbose
 
       - name: Zip
-        uses: thedoctor0/zip-release@master
+        uses: thedoctor0/zip-release@main
         with:
           type: "zip"
           filename: Mangayomi-${{ github.ref_name }}-linux.zip
@@ -288,6 +288,8 @@ jobs:
 
       - name: Create AppImage
         run: |
+          # Move Zip-file outside the bundle dir to avoid including it in the AppImage
+          mv build/linux/x64/release/bundle/Mangayomi-*.zip build/linux/x64/release/
           # Create fresh AppDir structure
           rm -rf AppDir
           mkdir -p AppDir/usr/bin
@@ -375,14 +377,14 @@ jobs:
         with:
           name: Mangayomi-${{ github.ref_name }}-linux-zip
           path: |
-            build/linux/x64/release/bundle/Mangayomi-*.zip
+            build/linux/x64/release/Mangayomi-*.zip
             build/linux/x64/release/Mangayomi-*.AppImage
             build/linux/x64/release/Mangayomi-*.rpm
       - name: release packages linux zip
         uses: ncipollo/release-action@v1
         with:
           artifacts: |
-            build/linux/x64/release/bundle/Mangayomi-*.zip
+            build/linux/x64/release/Mangayomi-*.zip
             build/linux/x64/release/Mangayomi-*.AppImage
             build/linux/x64/release/Mangayomi-*.rpm
           allowUpdates: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,13 @@ jobs:
           # Copy built files
           cp -r build/linux/x64/release/bundle/* AppDir/usr/bin/
           cp -rL linux/packaging/icons/* AppDir/usr/share/icons
-          # Create desktop file in AppDir root
+          # Scan AppDir/usr/bin/lib for existing libraries to exclude them from linuxdeploy packaging
+          EXCLUDE_LIBS=$(find AppDir/usr/bin/lib -type f -name "*.so*" -exec basename {} \; | sort -u)
+          # Add --exclude-library flag to each found library
+          for lib in $EXCLUDE_LIBS; do
+            EXCLUDE_ARGS+=" --exclude-library $lib"
+          done
+          # Copy desktop file to AppDir root
           cp linux/mangayomi.desktop AppDir/mangayomi.desktop
           # Create AppRun file
           cat <<EOF > AppDir/AppRun
@@ -303,7 +309,7 @@ jobs:
           SELF=\$(readlink -f "\$0")
           HERE=\${SELF%/*}
           export PATH="\${HERE}/usr/bin/:\${PATH}"
-          export LD_LIBRARY_PATH="\${HERE}/usr/lib/:\${HERE}/usr/bin/lib/:\${LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="\${HERE}/usr/bin/lib/:\${HERE}/usr/lib/:\${LD_LIBRARY_PATH}"
           exec "\${HERE}/usr/bin/mangayomi" "\$@"
           EOF
           chmod +x AppDir/AppRun
@@ -313,6 +319,7 @@ jobs:
             --desktop-file AppDir/mangayomi.desktop \
             --icon-file AppDir/usr/share/icons/hicolor/512x512/apps/mangayomi.png \
             --executable AppDir/usr/bin/mangayomi \
+            $EXCLUDE_ARGS \
             --output appimage
           mv $(find . -type f -name "*.AppImage") build/linux/x64/release/Mangayomi-${{ github.ref_name }}-linux.AppImage
 


### PR DESCRIPTION
Before, the created zip-package was packaged inside the AppImage.
Now the zip is not inside the `bundle/` directory, but in the `release/` directory, so when copying the contents of `bundle/`, the zip does not get involved.

Also, now the main branch of thedoctor0/zip-release is being used instead of master, as it is the default branch.

Before, `linuxdeploy` was bundling all libraries required by the app, leading to duplicate files, because flutter already provides some essential libraries.
Now the `/usr/bin/lib` directory is being searched for libraries and those are being passed to the `linuxdeploy` command with the `--exclude-library` flag.