### PR TITLE
No discordRPC for iOS and Android

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,7 +36,7 @@ import 'package:window_manager/window_manager.dart';
 import 'package:path/path.dart' as p;
 
 late Isar isar;
-late DiscordRPC discordRpc;
+DiscordRPC? discordRpc;
 WebViewEnvironment? webViewEnvironment;
 void main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -63,8 +63,10 @@ void main(List<String> args) async {
   isar = await StorageProvider().initDB(null, inspector: kDebugMode);
   await Hive.initFlutter();
   Hive.registerAdapter(TrackSearchAdapter());
-  discordRpc = DiscordRPC(applicationId: "1395040506677039157");
-  await discordRpc.initialize();
+  if (Platform.isMacOS || Platform.isLinux || Platform.isWindows) {
+    discordRpc = DiscordRPC(applicationId: "1395040506677039157");
+    await discordRpc?.initialize();
+  }
 
   runApp(const ProviderScope(child: MyApp()));
   unawaited(_postLaunchInit()); // Defer non-essential async operations
@@ -133,7 +135,7 @@ class _MyAppState extends ConsumerState<MyApp> {
   @override
   void dispose() {
     _linkSubscription?.cancel();
-    discordRpc.destroy();
+    discordRpc?.destroy();
     super.dispose();
   }
 

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -222,7 +222,7 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
       .duration
       .listen((duration) {
         _currentTotalDuration.value = duration;
-        discordRpc.startChapterTimestamp(
+        discordRpc?.startChapterTimestamp(
           _currentPosition.value.inMilliseconds,
           duration.inMilliseconds,
         );
@@ -313,7 +313,7 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
   void _updateRpcTimestamp() {
     final now = DateTime.now().millisecondsSinceEpoch;
     if (lastRpcTimestampUpdate + 10000 < now) {
-      discordRpc.updateChapterTimestamp(_currentPosition.value.inMilliseconds);
+      discordRpc?.updateChapterTimestamp(_currentPosition.value.inMilliseconds);
       lastRpcTimestampUpdate = now;
     }
   }
@@ -351,7 +351,7 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
       _setPlaybackSpeed(ref.read(defaultPlayBackSpeedStateProvider));
       if (ref.read(enableAniSkipStateProvider)) _initAniSkip();
     });
-    discordRpc.showChapterDetails(ref, widget.episode);
+    discordRpc?.showChapterDetails(ref, widget.episode);
     _currentPosition.addListener(_updateRpcTimestamp);
     WidgetsBinding.instance.addObserver(this);
   }
@@ -438,8 +438,8 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
       _setLandscapeMode(false);
     }
     _skipPhase.dispose();
-    discordRpc.showIdleText();
-    discordRpc.showOriginalTimestamp();
+    discordRpc?.showIdleText();
+    discordRpc?.showOriginalTimestamp();
     _currentPosition.dispose();
     super.dispose();
   }

--- a/lib/modules/main_view/main_screen.dart
+++ b/lib/modules/main_view/main_screen.dart
@@ -97,7 +97,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
       }
     });
 
-    discordRpc.connect(ref);
+    discordRpc?.connect(ref);
   }
 
   void _initializeTimers() {
@@ -160,7 +160,7 @@ class _MainScreenState extends ConsumerState<MainScreen> {
   void dispose() {
     _backupTimer?.cancel();
     _syncTimer?.cancel();
-    discordRpc.disconnect();
+    discordRpc?.disconnect();
     super.dispose();
   }
 

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -163,7 +163,7 @@ class _MangaChapterPageGalleryState
         overlays: SystemUiOverlay.values,
       );
     }
-    discordRpc.showIdleText();
+    discordRpc?.showIdleText();
     super.dispose();
   }
 
@@ -222,7 +222,7 @@ class _MangaChapterPageGalleryState
     _animation.addListener(() => _photoViewController.scale = _animation.value);
     _itemPositionsListener.itemPositions.addListener(_readProgressListener);
     _initCurrentIndex();
-    discordRpc.showChapterDetails(ref, chapter);
+    discordRpc?.showChapterDetails(ref, chapter);
     WidgetsBinding.instance.addObserver(this);
   }
 

--- a/lib/modules/more/settings/general/general_screen.dart
+++ b/lib/modules/more/settings/general/general_screen.dart
@@ -30,9 +30,9 @@ class GeneralScreen extends ConsumerWidget {
               onChanged: (value) {
                 ref.read(enableDiscordRpcStateProvider.notifier).set(value);
                 if (value) {
-                  discordRpc.connect(ref);
+                  discordRpc?.connect(ref);
                 } else {
-                  discordRpc.disconnect();
+                  discordRpc?.disconnect();
                 }
               },
             ),

--- a/lib/modules/more/widgets/incognito_mode_widget.dart
+++ b/lib/modules/more/widgets/incognito_mode_widget.dart
@@ -21,10 +21,10 @@ class IncognitoModeWidget extends ConsumerWidget {
       onTap: () {
         if (incognitoMode == true) {
           ref.read(incognitoModeStateProvider.notifier).setIncognitoMode(false);
-          if (hideDiscordRpcInIncognito) discordRpc.connect(ref);
+          if (hideDiscordRpcInIncognito) discordRpc?.connect(ref);
         } else {
           ref.read(incognitoModeStateProvider.notifier).setIncognitoMode(true);
-          if (hideDiscordRpcInIncognito) discordRpc.disconnect();
+          if (hideDiscordRpcInIncognito) discordRpc?.disconnect();
         }
       },
       icon: CupertinoIcons.eyeglasses,
@@ -36,9 +36,9 @@ class IncognitoModeWidget extends ConsumerWidget {
           ref.read(incognitoModeStateProvider.notifier).setIncognitoMode(value);
           if (hideDiscordRpcInIncognito) {
             if (value) {
-              discordRpc.disconnect();
+              discordRpc?.disconnect();
             } else {
-              discordRpc.connect(ref);
+              discordRpc?.connect(ref);
             }
           }
         },

--- a/lib/modules/novel/novel_reader_view.dart
+++ b/lib/modules/novel/novel_reader_view.dart
@@ -95,7 +95,7 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
         overlays: SystemUiOverlay.values,
       );
     }
-    discordRpc.showIdleText();
+    discordRpc?.showIdleText();
     super.dispose();
   }
 
@@ -114,7 +114,7 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
         fontSize = initFontSize;
       });
     });
-    discordRpc.showChapterDetails(ref, chapter);
+    discordRpc?.showChapterDetails(ref, chapter);
   }
 
   late bool _isBookmarked = _readerController.getChapterBookmarked();


### PR DESCRIPTION
The initialization of discordRPC on iOS and Android was leading to a grey screen (UnimplementedError), preventing the app to paint the Flutter UI. 
The flutter_discord_rpc is only available on macOS, Linux and Windows.