### PR TITLE
Fix MyAnimeList Token Refresh

### DIFF
--- a/lib/modules/more/settings/track/myanimelist/model.dart
+++ b/lib/modules/more/settings/track/myanimelist/model.dart
@@ -3,14 +3,22 @@ class OAuth {
   int? expiresIn;
   String? accessToken;
   String? refreshToken;
+  String? clientId;
 
-  OAuth({this.tokenType, this.expiresIn, this.accessToken, this.refreshToken});
+  OAuth({
+    this.tokenType,
+    this.expiresIn,
+    this.accessToken,
+    this.refreshToken,
+    this.clientId,
+  });
 
   OAuth.fromJson(Map<String, dynamic> json) {
     tokenType = json['token_type'];
     expiresIn = json['expires_in'] as int;
     accessToken = json['access_token'];
     refreshToken = json['refresh_token'];
+    clientId = json['client_id'];
   }
 
   Map<String, dynamic> toJson() {
@@ -19,6 +27,7 @@ class OAuth {
     data['expires_in'] = expiresIn;
     data['access_token'] = accessToken;
     data['refresh_token'] = refreshToken;
+    data['client_id'] = clientId;
     return data;
   }
 }

--- a/lib/services/trackers/myanimelist.dart
+++ b/lib/services/trackers/myanimelist.dart
@@ -46,7 +46,8 @@ class MyAnimeList extends _$MyAnimeList {
       final mALOAuth = OAuth.fromJson(oAuth as Map<String, dynamic>)
         ..expiresIn = DateTime.now()
             .add(Duration(seconds: oAuth['expires_in']))
-            .millisecondsSinceEpoch;
+            .millisecondsSinceEpoch
+        ..clientId = clientId;
       final username = await _getUserName(mALOAuth.accessToken!);
       ref
           .read(tracksProvider(syncId: syncId).notifier)


### PR DESCRIPTION
This PR fixes the following issue:
When the user logged in with mobile, the mobile clientId was being used to login. When the token expires and the user is now on desktop, the desktop clientId will be used to get the new token, leading to a `{"error":"invalid_request","message":"The refresh token is invalid.","hint":"Token is not linked to client"}` response from MAL.

Now the used clientId is being saved on login in the OAuth model and is being used when refreshing the token.
If the user logged in before this change, and therefore `OAuth.clientId` is null, the clientId for the current platform will be tried to get the refresh token. If it fails, it will fallback to the other clientId.
If that also fails, it will log the user out of MAL with the botToast message "MyAnimeList Token expired".

Also refactored the code a little to reduce some duplication and enhance readability.