### PR TITLE
Fix AnyhowException (DiscordRPC) when restoring a backup

### DIFF
--- a/lib/utils/discord_rpc.dart
+++ b/lib/utils/discord_rpc.dart
@@ -203,6 +203,7 @@ class DiscordRPC {
   }
 
   Future<void> disconnect() async {
+    if (!FlutterDiscordRPC.instance.isConnected) return;
     await FlutterDiscordRPC.instance.disconnect();
   }
 


### PR DESCRIPTION
When restoring a backup, the app tries to disconnect DiscordRPC but that gives an exception, when there is no live IPC socket to close.

`AnyhowException (AnyhowException(Failed to close to Discord IPC: Custom { kind: ConnectionRefused, error: "Couldn't retrieve the Discord IPC socket" }`