### PR TITLE
Fix: Reverse icon for toggling the Extension.

### DIFF
--- a/lib/modules/more/settings/browse/source_repositories.dart
+++ b/lib/modules/more/settings/browse/source_repositories.dart
@@ -200,7 +200,7 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
                               icon: Stack(
                                 children: [
                                   const Icon(Icons.remove_red_eye_outlined),
-                                  if (!isHidden)
+                                  if (isHidden)
                                     Positioned(
                                       right: 8,
                                       child: Transform.scale(


### PR DESCRIPTION
The icon for toggling the Extension (manga, anime and novel) seems reversed.
When its shows,  the icon is Slashed Eye.
When its hidden, the icon is Eye.

https://github.com/user-attachments/assets/749002bc-fc28-4780-8c01-804685ce0288

