### PR TITLE
Add new feature: Always On Top on the anime player view.

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -195,7 +195,7 @@ bool _firstTime = true;
 
 class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
     with
-        AlwaysOnTopStateMixin,
+        _AlwaysOnTopStateMixin,
         TickerProviderStateMixin,
         WidgetsBindingObserver {
   late final GlobalKey<VideoState> _key = GlobalKey<VideoState>();
@@ -2390,7 +2390,7 @@ class VideoPrefs {
   });
 }
 
-mixin AlwaysOnTopStateMixin<T extends StatefulWidget> on State<T> {
+mixin _AlwaysOnTopStateMixin<T extends StatefulWidget> on State<T> {
   // The original alwaysOnTop state.
   // This will be used to restore the original state when the widget disposed.
   bool? _savedAlwaysOnTop;


### PR DESCRIPTION
New Feature:
User could make the player always shown in desktop.

Its not a bug, its a new feature.
I don't know whether its gonna be accepted to the main repo.
Its up to you guys.

I usually playing video while doing something else 😁.
So in my cases, i need this feature.