### PR TITLE
Fix manga library section (WIP #590)

### DIFF
--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -83,16 +83,16 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
         _fullDataLength = _fullDataLength + 50;
       } else {
         if (_selectedIndex == 0 && !_isSearch && _query.isEmpty) {
-          mangaRes = await ref.watch(
+          mangaRes = await ref.read(
             getPopularProvider(source: source, page: _page + 1).future,
           );
         } else if (_selectedIndex == 1 && !_isSearch && _query.isEmpty) {
-          mangaRes = await ref.watch(
+          mangaRes = await ref.read(
             getLatestUpdatesProvider(source: source, page: _page + 1).future,
           );
         } else if (_selectedIndex == 2 && (_isSearch && _query.isNotEmpty) ||
             _isFiltering) {
-          mangaRes = await ref.watch(
+          mangaRes = await ref.read(
             searchProvider(
               source: source,
               query: _query,

--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -712,12 +712,9 @@ class MangaHomeImageCard extends ConsumerStatefulWidget {
   ConsumerState<MangaHomeImageCard> createState() => _MangaHomeImageCardState();
 }
 
-class _MangaHomeImageCardState extends ConsumerState<MangaHomeImageCard>
-    with AutomaticKeepAliveClientMixin<MangaHomeImageCard> {
+class _MangaHomeImageCardState extends ConsumerState<MangaHomeImageCard> {
   @override
   Widget build(BuildContext context) {
-    super.build(context);
-
     return MangaImageCardWidget(
       getMangaDetail: widget.manga,
       source: widget.source,
@@ -725,9 +722,6 @@ class _MangaHomeImageCardState extends ConsumerState<MangaHomeImageCard>
       isComfortableGrid: widget.isComfortableGrid,
     );
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }
 
 class MangaHomeImageCardListTile extends ConsumerStatefulWidget {
@@ -747,19 +741,13 @@ class MangaHomeImageCardListTile extends ConsumerStatefulWidget {
 }
 
 class _MangaHomeImageCardListTileState
-    extends ConsumerState<MangaHomeImageCardListTile>
-    with AutomaticKeepAliveClientMixin<MangaHomeImageCardListTile> {
+    extends ConsumerState<MangaHomeImageCardListTile> {
   @override
   Widget build(BuildContext context) {
-    super.build(context);
-
     return MangaImageCardListTileWidget(
       getMangaDetail: widget.manga,
       source: widget.source,
       itemType: widget.itemType,
     );
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }


### PR DESCRIPTION
For issue #590 
Altered the way manga grid for home library is handled. Widgets were forced to stay active artificially via the mixin for keeping widgets alive when they are offscreen.

The current fix I've written gets rid of that, which may introduce a slight load delay, as widgets have to be recreated when they are scrolled back into. Need to have some more testing done, before I can guarantee no regression in features. 
⚠️ It is a work in progress ⚠️ 