### PR TITLE
fix/reader-single-pages

### DIFF
--- a/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
+++ b/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
@@ -26,7 +26,12 @@ Future<dynamic> updateMangaDetail(
         (manga.chapters.isNotEmpty && isInit)) {
       return;
     }
-    final source = getSource(manga.lang!, manga.source!, manga.sourceId);
+    final source = getSource(
+      manga.lang!,
+      manga.source!,
+      manga.sourceId,
+      installedOnly: true,
+    );
     MManga getManga;
 
     getManga = await ref.read(

--- a/lib/modules/manga/reader/providers/reader_controller_provider.dart
+++ b/lib/modules/manga/reader/providers/reader_controller_provider.dart
@@ -352,10 +352,10 @@ class ReaderController extends _$ReaderController {
     final isRead =
         (getReaderMode() == ReaderMode.verticalContinuous ||
             getReaderMode() == ReaderMode.webtoon)
-        ? ((newIndex + 2) == getPageLength([]) - 1)
-              ? ((newIndex + 2) == getPageLength([]) - 1)
-              : (newIndex + 2) == getPageLength([])
-        : (newIndex + 2) == getPageLength([]);
+        ? ((newIndex + 2) >= getPageLength([]) - 1)
+              ? ((newIndex + 2) >= getPageLength([]) - 1)
+              : (newIndex + 2) >= getPageLength([])
+        : (newIndex + 2) >= getPageLength([]);
     if (isRead || save) {
       List<ChapterPageIndex>? chapterPageIndexs = [];
       for (var chapterPageIndex

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -1051,10 +1051,10 @@ class _MangaChapterPageGalleryState
         setState(() {
           _readerController = ref.read(
             readerControllerProvider(
-              chapter: pages[_currentIndex!].chapter!,
+              chapter: pages[index].chapter!,
             ).notifier,
           );
-          chapter = pages[_currentIndex!].chapter!;
+          chapter = pages[index].chapter!;
           final chapterUrlModel = pages[index].chapterUrlModel;
           if (chapterUrlModel != null) {
             _chapterUrlModel = chapterUrlModel;

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -2,9 +2,18 @@ import 'package:isar_community/isar.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/source.dart';
 
-Source? getSource(String lang, String name, int? sourceId) {
+Source? getSource(
+  String lang,
+  String name,
+  int? sourceId, {
+  bool installedOnly = false,
+}) {
   try {
-    final sourcesList = isar.sources.filter().idIsNotNull().findAllSync();
+    var sourcesFilter = isar.sources.filter().idIsNotNull();
+    if (installedOnly) {
+      sourcesFilter = sourcesFilter.isActiveEqualTo(true).isAddedEqualTo(true);
+    }
+    final sourcesList = sourcesFilter.findAllSync();
     return sourcesList.firstWhere(
       (element) => sourceId != null
           ? element.id == sourceId && element.sourceCode != null


### PR DESCRIPTION
- small adjustments for a better reading experience of many single pages in a row

- prevent old entries (before sourceId was introduced) from accidentally using conflicting sources with the same name even if they are not installed