### PR TITLE
Fix shouldUpdate button in categories view

### DIFF
--- a/lib/modules/more/categories/categories_screen.dart
+++ b/lib/modules/more/categories/categories_screen.dart
@@ -418,7 +418,7 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab>
                       onPressed: () async {
                         await isar.writeTxn(() async {
                           category.shouldUpdate =
-                              !(category.shouldUpdate ?? false);
+                              !(category.shouldUpdate ?? true);
                           category.updatedAt =
                               DateTime.now().millisecondsSinceEpoch;
                           isar.categorys.put(category);


### PR DESCRIPTION
This reverts commit 3c2bc096a9b584df633ba3c385ab005cb4646546.

Fixes the bug where the button sets the value to true when first pressed, which makes it appear like nothing happened.
Now the value is correctly being set to false.


https://github.com/user-attachments/assets/ab8da5e2-37eb-4f62-abb9-9771467da688

