### PR TITLE
Improve Kitsu login dialog with autofill, input validation

### DIFF
--- a/lib/modules/more/settings/track/track.dart
+++ b/lib/modules/more/settings/track/track.dart
@@ -168,6 +168,8 @@ class TrackScreen extends ConsumerWidget {
 Future<void> _showDialogLogin(BuildContext context, WidgetRef ref) async {
   final passwordController = TextEditingController();
   final emailController = TextEditingController();
+  final emailFocusNode = FocusNode();
+  final passwordFocusNode = FocusNode();
   bool canLogin = false;
   String errorMessage = "";
   bool isLoading = false;
@@ -228,6 +230,7 @@ Future<void> _showDialogLogin(BuildContext context, WidgetRef ref) async {
                     padding: const EdgeInsets.symmetric(vertical: 10),
                     child: TextFormField(
                       controller: emailController,
+                      focusNode: emailFocusNode,
                       keyboardType: TextInputType.emailAddress,
                       textInputAction: TextInputAction.next,
                       autofillHints: const [
@@ -236,8 +239,7 @@ Future<void> _showDialogLogin(BuildContext context, WidgetRef ref) async {
                       ],
                       autofocus: true,
                       onChanged: (_) => setState(updateCanLogin),
-                      onFieldSubmitted: (_) =>
-                          FocusScope.of(context).nextFocus(),
+                      onFieldSubmitted: (_) => passwordFocusNode.requestFocus(),
                       decoration: InputDecoration(
                         hintText: l10n.email_adress,
                         filled: false,
@@ -262,6 +264,7 @@ Future<void> _showDialogLogin(BuildContext context, WidgetRef ref) async {
                     padding: const EdgeInsets.symmetric(vertical: 10),
                     child: TextFormField(
                       controller: passwordController,
+                      focusNode: passwordFocusNode,
                       obscureText: obscureText,
                       onChanged: (_) => setState(updateCanLogin),
                       keyboardType: TextInputType.visiblePassword,
@@ -327,4 +330,6 @@ Future<void> _showDialogLogin(BuildContext context, WidgetRef ref) async {
   );
   emailController.dispose();
   passwordController.dispose();
+  emailFocusNode.dispose();
+  passwordFocusNode.dispose();
 }


### PR DESCRIPTION
This PR refactors and improves the Kitsu login dialog to provide a more user‑friendly login experience.
It introduces proper autofill support, input validation, cleaner async handling, and several UX refinements.

- Converted `_showDialogLogin` to `Future<void>` to correctly support async dialog flow.
- Added AutofillGroup and platform autofill hints for email and password.
- Introduced input validation to enable the login button only when both fields contain valid input.
- Added `TextInput.finishAutofillContext()` to properly close autofill sessions after successful login.
- Enhanced keyboard navigation with `TextInputAction.next` and `TextInputAction.done`.
- removed redundant `email` and `password` variables, as `TextEditingController()` already has the value.


Tested, working: https://github.com/NBA2K1/mangayomi/releases/tag/v0.7.2