### PR TITLE
Improve performance of library, manga home, and tracker screens

### DIFF
--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -1,9 +1,7 @@
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:isar_community/isar.dart';
-import 'package:mangayomi/main.dart';
-import 'package:mangayomi/models/download.dart';
+import 'package:mangayomi/modules/library/providers/library_filter_provider.dart';
 import 'package:mangayomi/modules/library/providers/isar_providers.dart';
 import 'package:mangayomi/modules/library/providers/library_state_provider.dart';
 import 'package:mangayomi/models/manga.dart';
@@ -173,27 +171,24 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                                       padding: const EdgeInsets.only(right: 5),
                                       child: Consumer(
                                         builder: (context, ref, child) {
-                                          List nbrDown = [];
+                                          int downloadCount = 0;
                                           if (widget.downloadedChapter) {
-                                            final chapterIds = entry.chapters
-                                                .toList()
-                                                .map((c) => c.id)
-                                                .whereType<int>()
-                                                .toList();
-                                            if (chapterIds.isNotEmpty) {
-                                              nbrDown = isar.downloads
-                                                  .filter()
-                                                  .anyOf(
-                                                    chapterIds,
-                                                    (q, id) => q.idEqualTo(id),
-                                                  )
-                                                  .isDownloadEqualTo(true)
-                                                  .findAllSync();
-                                            }
+                                            final downloadedIds = ref.watch(
+                                              downloadedChapterIdsProvider,
+                                            );
+                                            downloadCount = entry.chapters
+                                                .where(
+                                                  (c) =>
+                                                      c.id != null &&
+                                                      downloadedIds.contains(
+                                                        c.id,
+                                                      ),
+                                                )
+                                                .length;
                                           }
                                           return Row(
                                             children: [
-                                              if (nbrDown.isNotEmpty &&
+                                              if (downloadCount > 0 &&
                                                   widget.downloadedChapter)
                                                 Container(
                                                   decoration: BoxDecoration(
@@ -219,7 +214,7 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                                                           right: 3,
                                                         ),
                                                     child: Text(
-                                                      nbrDown.length.toString(),
+                                                      downloadCount.toString(),
                                                     ),
                                                   ),
                                                 ),
@@ -229,10 +224,7 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                                                 ),
                                                 child: Text(
                                                   entry.chapters
-                                                      .where(
-                                                        (element) =>
-                                                            !element.isRead!,
-                                                      )
+                                                      .where((e) => !e.isRead!)
                                                       .length
                                                       .toString(),
                                                   style: TextStyle(

--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -117,10 +117,37 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
   void dispose() {
+    _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     _textEditingController.dispose();
     super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels ==
+        _scrollController.position.maxScrollExtent) {
+      if (_mangaList.isNotEmpty &&
+          _hasNextPage &&
+          !_isLoading &&
+          !(_getManga?.isLoading ?? false)) {
+        setState(() => _isLoading = true);
+        _loadMore().then((value) {
+          if (mounted && value != null) {
+            setState(() {
+              _mangaList.addAll(value.list);
+              _isLoading = false;
+            });
+          }
+        });
+      }
+    }
   }
 
   late final _textEditingController = TextEditingController(text: widget.query);
@@ -519,30 +546,6 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                 if (data!.list.isEmpty) {
                   return Center(child: Text(l10n.no_result));
                 }
-                _scrollController.addListener(() {
-                  if (_scrollController.position.pixels ==
-                      _scrollController.position.maxScrollExtent) {
-                    if (_mangaList.isNotEmpty &&
-                        (_hasNextPage) &&
-                        !_isLoading &&
-                        !_getManga!.isLoading) {
-                      if (mounted) {
-                        setState(() {
-                          _isLoading = true;
-                        });
-                      }
-                      _loadMore().then((value) {
-                        if (mounted && value != null) {
-                          setState(() {
-                            _mangaList.addAll(value.list);
-                            _isLoading = false;
-                          });
-                        }
-                      });
-                    }
-                  }
-                });
-
                 _length = source.isFullData!
                     ? _fullDataLength
                     : _mangaList.length;

--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -84,16 +84,16 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
         _fullDataLength = _fullDataLength + 50;
       } else {
         if (_selectedIndex == 0 && !_isSearch && _query.isEmpty) {
-          mangaRes = await ref.watch(
+          mangaRes = await ref.read(
             getPopularProvider(source: source, page: _page + 1).future,
           );
         } else if (_selectedIndex == 1 && !_isSearch && _query.isEmpty) {
-          mangaRes = await ref.watch(
+          mangaRes = await ref.read(
             getLatestUpdatesProvider(source: source, page: _page + 1).future,
           );
         } else if (_selectedIndex == 2 && (_isSearch && _query.isNotEmpty) ||
             _isFiltering) {
-          mangaRes = await ref.watch(
+          mangaRes = await ref.read(
             searchProvider(
               source: source,
               query: _query,

--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:isar_community/isar.dart';
 import 'package:mangayomi/eval/model/m_manga.dart';
 import 'package:mangayomi/eval/model/m_pages.dart';
+import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/source.dart';
@@ -67,6 +69,8 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
   late bool isLocal = source.name == "local" && source.lang == "";
   late List<dynamic> filters = isLocal ? [] : getFilterList(source: source);
   final List<MManga> _mangaList = [];
+  late StreamSubscription<List<Manga>> _mangaStreamSub;
+  Map<String, Manga> _libraryIndex = {};
   List<TypeMangaSelector> _types(BuildContext context) {
     final l10n = l10nLocalizations(context)!;
     return [
@@ -120,10 +124,28 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
   void initState() {
     super.initState();
     _scrollController.addListener(_onScroll);
+    _mangaStreamSub = isar.mangas
+        .filter()
+        .sourceEqualTo(source.name)
+        .langEqualTo(source.lang)
+        .watch(fireImmediately: true)
+        .listen((mangas) {
+          if (mounted) {
+            setState(() {
+              _libraryIndex = {
+                for (final m in mangas.where(
+                  (e) => e.sourceId == null || e.sourceId == source.id,
+                ))
+                  if (m.name != null) m.name!: m,
+              };
+            });
+          }
+        });
   }
 
   @override
   void dispose() {
+    _mangaStreamSub.cancel();
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     _textEditingController.dispose();
@@ -571,6 +593,8 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                                     itemType: source.itemType,
                                     manga: _mangaList[index],
                                     source: source,
+                                    libraryManga:
+                                        _libraryIndex[_mangaList[index].name],
                                   );
                                 },
                               )
@@ -598,6 +622,9 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                                         manga: _mangaList[index],
                                         source: source,
                                         isComfortableGrid: isComfortableGrid,
+                                        libraryManga:
+                                            _libraryIndex[_mangaList[index]
+                                                .name],
                                       );
                                     },
                                   );
@@ -700,12 +727,14 @@ class MangaHomeImageCard extends ConsumerStatefulWidget {
   final ItemType itemType;
   final Source source;
   final bool isComfortableGrid;
+  final Manga? libraryManga;
   const MangaHomeImageCard({
     super.key,
     required this.manga,
     required this.source,
     required this.itemType,
     required this.isComfortableGrid,
+    this.libraryManga,
   });
 
   @override
@@ -720,6 +749,7 @@ class _MangaHomeImageCardState extends ConsumerState<MangaHomeImageCard> {
       source: widget.source,
       itemType: widget.itemType,
       isComfortableGrid: widget.isComfortableGrid,
+      libraryManga: widget.libraryManga,
     );
   }
 }
@@ -728,11 +758,13 @@ class MangaHomeImageCardListTile extends ConsumerStatefulWidget {
   final MManga manga;
   final ItemType itemType;
   final Source source;
+  final Manga? libraryManga;
   const MangaHomeImageCardListTile({
     super.key,
     required this.manga,
     required this.source,
     required this.itemType,
+    this.libraryManga,
   });
 
   @override
@@ -748,6 +780,7 @@ class _MangaHomeImageCardListTileState
       getMangaDetail: widget.manga,
       source: widget.source,
       itemType: widget.itemType,
+      libraryManga: widget.libraryManga,
     );
   }
 }

--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -132,12 +132,18 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
         .listen((mangas) {
           if (mounted) {
             setState(() {
-              _libraryIndex = {
-                for (final m in mangas.where(
-                  (e) => e.sourceId == null || e.sourceId == source.id,
-                ))
-                  if (m.name != null) m.name!: m,
-              };
+              _libraryIndex = {};
+              for (final m in mangas.where(
+                (e) => e.sourceId == null || e.sourceId == source.id,
+              )) {
+                if (m.name == null) continue;
+                final existing = _libraryIndex[m.name!];
+                // Prefer the record with the lower id (first inserted = real entry).
+                // Guards against pre-existing duplicate records in the DB.
+                if (existing == null || m.id! < existing.id!) {
+                  _libraryIndex[m.name!] = m;
+                }
+              }
             });
           }
         });

--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -709,12 +709,9 @@ class MangaHomeImageCard extends ConsumerStatefulWidget {
   ConsumerState<MangaHomeImageCard> createState() => _MangaHomeImageCardState();
 }
 
-class _MangaHomeImageCardState extends ConsumerState<MangaHomeImageCard>
-    with AutomaticKeepAliveClientMixin<MangaHomeImageCard> {
+class _MangaHomeImageCardState extends ConsumerState<MangaHomeImageCard> {
   @override
   Widget build(BuildContext context) {
-    super.build(context);
-
     return MangaImageCardWidget(
       getMangaDetail: widget.manga,
       source: widget.source,
@@ -722,9 +719,6 @@ class _MangaHomeImageCardState extends ConsumerState<MangaHomeImageCard>
       isComfortableGrid: widget.isComfortableGrid,
     );
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }
 
 class MangaHomeImageCardListTile extends ConsumerStatefulWidget {
@@ -744,19 +738,13 @@ class MangaHomeImageCardListTile extends ConsumerStatefulWidget {
 }
 
 class _MangaHomeImageCardListTileState
-    extends ConsumerState<MangaHomeImageCardListTile>
-    with AutomaticKeepAliveClientMixin<MangaHomeImageCardListTile> {
+    extends ConsumerState<MangaHomeImageCardListTile> {
   @override
   Widget build(BuildContext context) {
-    super.build(context);
-
     return MangaImageCardListTileWidget(
       getMangaDetail: widget.manga,
       source: widget.source,
       itemType: widget.itemType,
     );
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }

--- a/lib/modules/tracker_library/tracker_library_card.dart
+++ b/lib/modules/tracker_library/tracker_library_card.dart
@@ -1,7 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:isar_community/isar.dart';
-import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/track.dart';
 import 'package:mangayomi/models/track_search.dart';
@@ -11,141 +8,113 @@ import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/constant.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 
-class TrackerLibraryImageCard extends ConsumerStatefulWidget {
+class TrackerLibraryImageCard extends StatelessWidget {
   final TrackSearch track;
   final ItemType itemType;
+  final Track? libraryTrack;
 
   const TrackerLibraryImageCard({
     super.key,
     required this.track,
     required this.itemType,
+    this.libraryTrack,
   });
 
   @override
-  ConsumerState<TrackerLibraryImageCard> createState() =>
-      _TrackerLibraryImageCardState();
-}
-
-class _TrackerLibraryImageCardState
-    extends ConsumerState<TrackerLibraryImageCard>
-    with AutomaticKeepAliveClientMixin<TrackerLibraryImageCard> {
-  @override
   Widget build(BuildContext context) {
-    super.build(context);
-    final trackData = widget.track;
-    return StreamBuilder(
-      stream: isar.tracks
-          .filter()
-          .mangaIdIsNotNull()
-          .mediaIdEqualTo(trackData.mediaId)
-          .itemTypeEqualTo(widget.itemType)
-          .watch(fireImmediately: true),
-      builder: (context, snapshot) {
-        final hasData = snapshot.hasData && snapshot.data!.isNotEmpty;
-        return GestureDetector(
-          onTap: () => _showCard(context, snapshot.data?.firstOrNull?.mangaId),
-          child: Padding(
-            padding: const EdgeInsets.only(left: 10),
-            child: Stack(
-              children: [
-                SizedBox(
-                  width: 110,
-                  child: Column(
-                    children: [
-                      Builder(
-                        builder: (context) {
-                          return ClipRRect(
-                            borderRadius: BorderRadius.circular(5),
-                            child: Stack(
+    final hasData = libraryTrack != null;
+    return GestureDetector(
+      onTap: () => _showCard(context, libraryTrack?.mangaId),
+      child: Padding(
+        padding: const EdgeInsets.only(left: 10),
+        child: Stack(
+          children: [
+            SizedBox(
+              width: 110,
+              child: Column(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(5),
+                    child: Stack(
+                      children: [
+                        cachedNetworkImage(
+                          imageUrl: toImgUrl(track.coverUrl ?? ""),
+                          width: 110,
+                          height: 150,
+                          fit: BoxFit.cover,
+                        ),
+                        Positioned(
+                          top: 0,
+                          right: 0,
+                          child: Text.rich(
+                            TextSpan(
+                              style: TextStyle(
+                                background: Paint()
+                                  ..color = Theme.of(context)
+                                      .scaffoldBackgroundColor
+                                      .withValues(alpha: 0.75)
+                                  ..strokeWidth = 20.0
+                                  ..strokeJoin = StrokeJoin.round
+                                  ..style = PaintingStyle.stroke,
+                              ),
                               children: [
-                                cachedNetworkImage(
-                                  imageUrl: toImgUrl(trackData.coverUrl ?? ""),
-                                  width: 110,
-                                  height: 150,
-                                  fit: BoxFit.cover,
+                                WidgetSpan(
+                                  child: Icon(
+                                    Icons.star,
+                                    color: context.primaryColor,
+                                  ),
                                 ),
-                                Positioned(
-                                  top: 0,
-                                  right: 0,
-                                  child: Text.rich(
-                                    TextSpan(
-                                      style: TextStyle(
-                                        background: Paint()
-                                          ..color = Theme.of(context)
-                                              .scaffoldBackgroundColor
-                                              .withValues(alpha: 0.75)
-                                          ..strokeWidth = 20.0
-                                          ..strokeJoin = StrokeJoin.round
-                                          ..style = PaintingStyle.stroke,
-                                      ),
-                                      children: [
-                                        WidgetSpan(
-                                          child: Icon(
-                                            Icons.star,
-                                            color: context.primaryColor,
-                                          ),
-                                        ),
-                                        TextSpan(
-                                          text: " ${trackData.score ?? "?"}",
-                                          style: const TextStyle(
-                                            fontWeight: FontWeight.bold,
-                                          ),
-                                        ),
-                                      ],
-                                    ),
+                                TextSpan(
+                                  text: " ${track.score ?? "?"}",
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.bold,
                                   ),
                                 ),
                               ],
                             ),
-                          );
-                        },
-                      ),
-                      BottomTextWidget(
-                        fontSize: 12.0,
-                        text: trackData.title!,
-                        isLoading: true,
-                        textColor: Theme.of(context).textTheme.bodyLarge!.color,
-                        isComfortableGrid: true,
-                      ),
-                    ],
-                  ),
-                ),
-                Container(
-                  width: 110,
-                  height: 150,
-                  color: hasData ? Colors.black.withValues(alpha: 0.7) : null,
-                ),
-                if (hasData)
-                  Positioned(
-                    top: 0,
-                    left: 0,
-                    child: Padding(
-                      padding: const EdgeInsets.all(4),
-                      child: Icon(
-                        Icons.collections_bookmark,
-                        color: context.primaryColor,
-                      ),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-              ],
+                  BottomTextWidget(
+                    fontSize: 12.0,
+                    text: track.title!,
+                    isLoading: true,
+                    textColor: Theme.of(context).textTheme.bodyLarge!.color,
+                    isComfortableGrid: true,
+                  ),
+                ],
+              ),
             ),
-          ),
-        );
-      },
+            Container(
+              width: 110,
+              height: 150,
+              color: hasData ? Colors.black.withValues(alpha: 0.7) : null,
+            ),
+            if (hasData)
+              Positioned(
+                top: 0,
+                left: 0,
+                child: Padding(
+                  padding: const EdgeInsets.all(4),
+                  child: Icon(
+                    Icons.collections_bookmark,
+                    color: context.primaryColor,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
     );
   }
 
   void _showCard(BuildContext context, int? mangaId) {
     showDialog(
       context: context,
-      builder: (context) => TrackerItemCard(
-        track: widget.track,
-        itemType: widget.itemType,
-        mangaId: mangaId,
-      ),
+      builder: (context) =>
+          TrackerItemCard(track: track, itemType: itemType, mangaId: mangaId),
     );
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }

--- a/lib/modules/tracker_library/tracker_library_card.dart
+++ b/lib/modules/tracker_library/tracker_library_card.dart
@@ -22,7 +22,7 @@ class TrackerLibraryImageCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hasData = libraryTrack != null;
+    final hasData = libraryTrack?.mangaId != null;
     return GestureDetector(
       onTap: () => _showCard(context, libraryTrack?.mangaId),
       child: Padding(

--- a/lib/modules/tracker_library/tracker_section_screen.dart
+++ b/lib/modules/tracker_library/tracker_section_screen.dart
@@ -37,6 +37,7 @@ class _TrackerSectionScreenState extends State<TrackerSectionScreen> {
     _trackStreamSub = isar.tracks
         .filter()
         .itemTypeEqualTo(widget.section.itemType)
+        .mangaIdIsNotNull()
         .watch(fireImmediately: true)
         .listen((tracks) {
           if (mounted) {

--- a/lib/modules/tracker_library/tracker_section_screen.dart
+++ b/lib/modules/tracker_library/tracker_section_screen.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/adapters.dart';
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/track.dart';
 import 'package:mangayomi/models/track_search.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_card.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_section.dart';
@@ -19,23 +23,52 @@ class _TrackerSectionScreenState extends State<TrackerSectionScreen> {
   String _errorMessage = "";
   bool _isLoading = true;
   List<TrackSearch> _tracks = [];
+  late StreamSubscription<List<Track>> _trackStreamSub;
+  Map<int, Track> _trackIndex = {};
 
   @override
   void initState() {
     super.initState();
     _fetchData();
+    _subscribeToTracks();
+  }
+
+  void _subscribeToTracks() {
+    _trackStreamSub = isar.tracks
+        .filter()
+        .itemTypeEqualTo(widget.section.itemType)
+        .watch(fireImmediately: true)
+        .listen((tracks) {
+          if (mounted) {
+            setState(() {
+              _trackIndex = {
+                for (final t in tracks)
+                  if (t.mediaId != null) t.mediaId!: t,
+              };
+            });
+          }
+        });
   }
 
   @override
   void didUpdateWidget(covariant TrackerSectionScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.section.itemType != widget.section.itemType) {
+      _trackStreamSub.cancel();
+      _subscribeToTracks();
+    }
     _fetchData();
+  }
+
+  @override
+  void dispose() {
+    _trackStreamSub.cancel();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final l10n = l10nLocalizations(context)!;
-
     return Scaffold(
       body: SizedBox(
         height: 260,
@@ -57,9 +90,11 @@ class _TrackerSectionScreenState extends State<TrackerSectionScreen> {
                             scrollDirection: Axis.horizontal,
                             itemCount: _tracks.length,
                             itemBuilder: (context, index) {
+                              final track = _tracks[index];
                               return TrackerLibraryImageCard(
-                                track: _tracks[index],
+                                track: track,
                                 itemType: widget.section.itemType,
+                                libraryTrack: _trackIndex[track.mediaId],
                               );
                             },
                           );
@@ -78,17 +113,13 @@ class _TrackerSectionScreenState extends State<TrackerSectionScreen> {
     final box = await Hive.openBox("tracker_library");
     final key =
         "${widget.section.syncId}-${widget.section.itemType.name}-${widget.section.name}";
-    if (_checkCache(box, key)) {
-      return;
-    }
+    if (_checkCache(box, key)) return;
     try {
       _errorMessage = "";
       _tracks = await widget.section.func() ?? [];
       box.put(key, _tracks);
       if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
+        setState(() => _isLoading = false);
       }
     } catch (e) {
       if (mounted) {
@@ -106,11 +137,7 @@ class _TrackerSectionScreenState extends State<TrackerSectionScreen> {
       if (temp is List<TrackSearch>) {
         _errorMessage = "";
         _tracks = temp;
-        if (mounted) {
-          setState(() {
-            _isLoading = false;
-          });
-        }
+        if (mounted) setState(() => _isLoading = false);
         return true;
       }
     }

--- a/lib/modules/widgets/manga_image_card_widget.dart
+++ b/lib/modules/widgets/manga_image_card_widget.dart
@@ -174,41 +174,35 @@ class MangaImageCardListTileWidget extends ConsumerWidget {
         color: Colors.transparent,
         clipBehavior: Clip.antiAlias,
         child: InkWell(
-          onTap: () {
-            pushToMangaReaderDetail(
-              ref: ref,
-              context: context,
-              getManga: getMangaDetail!,
-              lang: source.lang!,
-              source: source.name!,
-              itemType: itemType,
-              sourceId: source.id,
-            );
-          },
-          onLongPress: () {
-            pushToMangaReaderDetail(
-              ref: ref,
-              context: context,
-              getManga: getMangaDetail!,
-              lang: source.lang!,
-              source: source.name!,
-              itemType: itemType,
-              addToFavourite: true,
-              sourceId: source.id,
-            );
-          },
-          onSecondaryTap: () {
-            pushToMangaReaderDetail(
-              ref: ref,
-              context: context,
-              getManga: getMangaDetail!,
-              lang: source.lang!,
-              source: source.name!,
-              itemType: itemType,
-              addToFavourite: true,
-              sourceId: source.id,
-            );
-          },
+          onTap: () => pushToMangaReaderDetail(
+            ref: ref,
+            context: context,
+            getManga: getMangaDetail!,
+            lang: source.lang!,
+            source: source.name!,
+            itemType: itemType,
+            sourceId: source.id,
+          ),
+          onLongPress: () => pushToMangaReaderDetail(
+            ref: ref,
+            context: context,
+            getManga: getMangaDetail!,
+            lang: source.lang!,
+            source: source.name!,
+            itemType: itemType,
+            addToFavourite: true,
+            sourceId: source.id,
+          ),
+          onSecondaryTap: () => pushToMangaReaderDetail(
+            ref: ref,
+            context: context,
+            getManga: getMangaDetail!,
+            lang: source.lang!,
+            source: source.name!,
+            itemType: itemType,
+            addToFavourite: true,
+            sourceId: source.id,
+          ),
           child: Row(
             children: [
               Padding(
@@ -285,14 +279,14 @@ Future<void> pushToMangaReaderDetail({
   bool useMaterialRoute = false,
   bool addToFavourite = false,
 }) async {
-  int? mangaId;
-  mangaId = isar.mangas
-      .filter()
-      .isLocalArchiveEqualTo(true)
-      .sourceEqualTo("local")
-      .nameEqualTo(getManga?.name)
-      .findFirstSync()
-      ?.id;
+  int? mangaId =
+      (await isar.mangas
+              .filter()
+              .isLocalArchiveEqualTo(true)
+              .sourceEqualTo("local")
+              .nameEqualTo(getManga?.name)
+              .findFirst())
+          ?.id;
 
   if (mangaId == null) {
     if (archiveId == null) {
@@ -313,85 +307,65 @@ Future<void> pushToMangaReaderDetail({
             artist: getManga.artist ?? '',
             sourceId: sourceId,
           );
-      final empty = isar.mangas
+      final empty = await isar.mangas
           .filter()
           .langEqualTo(lang)
           .nameEqualTo(manga.name)
           .sourceEqualTo(manga.source)
-          .isEmptySync();
+          .isEmpty();
       if (empty) {
         await isar.writeTxn(() async {
           await isar.mangas.put(
             manga..updatedAt = DateTime.now().millisecondsSinceEpoch,
           );
         });
-      } else {
-        await isar.writeTxn(() async {
-          await isar.mangas.put(manga);
-        });
       }
 
-      mangaId = isar.mangas
+      final foundMangas = await isar.mangas
           .filter()
           .langEqualTo(lang)
           .nameEqualTo(manga.name)
           .sourceEqualTo(manga.source)
-          .findAllSync()
-          .firstWhere(
-            (element) =>
-                element.sourceId == null ? true : element.sourceId == sourceId,
-          )
+          .findAll();
+      mangaId = foundMangas
+          .firstWhere((e) => e.sourceId == null || e.sourceId == sourceId)
           .id!;
     } else {
       mangaId = archiveId;
     }
   }
 
-  final mang = isar.mangas.getSync(mangaId);
+  final mang = await isar.mangas.get(mangaId);
   if (mang!.sourceId == null && !(mang.isLocalArchive ?? false)) {
     await isar.writeTxn(() async {
       await isar.mangas.put(mang..sourceId = sourceId);
     });
   }
-  final settings = isar.settings.getSync(227)!;
-  final sortList = settings.sortChapterList ?? [];
-  final checkIfExist = sortList
-      .where((element) => element.mangaId == mangaId)
-      .toList();
-  if (checkIfExist.isEmpty) {
+  final settings = await isar.settings.get(227);
+  final exists =
+      settings!.sortChapterList?.any((e) => e.mangaId == mangaId) ?? false;
+  if (!exists) {
     await isar.writeTxn(() async {
-      List<SortChapter>? sortChapterList = [];
-      for (var sortChapter in settings.sortChapterList ?? []) {
-        sortChapterList.add(sortChapter);
-      }
-      List<ChapterFilterBookmarked>? chapterFilterBookmarkedList = [];
-      for (var sortChapter in settings.chapterFilterBookmarkedList ?? []) {
-        chapterFilterBookmarkedList.add(sortChapter);
-      }
-      List<ChapterFilterDownloaded>? chapterFilterDownloadedList = [];
-      for (var sortChapter in settings.chapterFilterDownloadedList ?? []) {
-        chapterFilterDownloadedList.add(sortChapter);
-      }
-      List<ChapterFilterUnread>? chapterFilterUnreadList = [];
-      for (var sortChapter in settings.chapterFilterUnreadList ?? []) {
-        chapterFilterUnreadList.add(sortChapter);
-      }
-      sortChapterList.add(SortChapter()..mangaId = mangaId);
-      chapterFilterBookmarkedList.add(
-        ChapterFilterBookmarked()..mangaId = mangaId,
-      );
-      chapterFilterDownloadedList.add(
-        ChapterFilterDownloaded()..mangaId = mangaId,
-      );
-      chapterFilterUnreadList.add(ChapterFilterUnread()..mangaId = mangaId);
-      await isar.settings.put(
-        settings
-          ..sortChapterList = sortChapterList
-          ..chapterFilterBookmarkedList = chapterFilterBookmarkedList
-          ..chapterFilterDownloadedList = chapterFilterDownloadedList
-          ..chapterFilterUnreadList = chapterFilterUnreadList
-          ..updatedAt = DateTime.now().millisecondsSinceEpoch,
-      );
+      settings
+        ..sortChapterList = [
+          ...(settings.sortChapterList ?? []),
+          SortChapter()..mangaId = mangaId,
+        ]
+        ..chapterFilterBookmarkedList = [
+          ...(settings.chapterFilterBookmarkedList ?? []),
+          ChapterFilterBookmarked()..mangaId = mangaId,
+        ]
+        ..chapterFilterDownloadedList = [
+          ...(settings.chapterFilterDownloadedList ?? []),
+          ChapterFilterDownloaded()..mangaId = mangaId,
+        ]
+        ..chapterFilterUnreadList = [
+          ...(settings.chapterFilterUnreadList ?? []),
+          ChapterFilterUnread()..mangaId = mangaId,
+        ]
+        ..updatedAt = DateTime.now().millisecondsSinceEpoch;
+
+      await isar.settings.put(settings);
     });
   }
   if (!addToFavourite) {
@@ -404,15 +378,15 @@ Future<void> pushToMangaReaderDetail({
       } else {
         await context.push('/manga-reader/detail', extra: mangaId);
       }
-    } else {
-      final getManga = isar.mangas.filter().idEqualTo(mangaId).findFirstSync()!;
-      await isar.writeTxn(() async {
-        await isar.mangas.put(
-          getManga
-            ..favorite = !getManga.favorite!
-            ..updatedAt = DateTime.now().millisecondsSinceEpoch,
-        );
-      });
     }
+  } else {
+    final getManga = await isar.mangas.get(mangaId);
+    await isar.writeTxn(() async {
+      await isar.mangas.put(
+        getManga!
+          ..favorite = !getManga.favorite!
+          ..updatedAt = DateTime.now().millisecondsSinceEpoch,
+      );
+    });
   }
 }

--- a/lib/modules/widgets/manga_image_card_widget.dart
+++ b/lib/modules/widgets/manga_image_card_widget.dart
@@ -327,9 +327,22 @@ Future<void> pushToMangaReaderDetail({
           .nameEqualTo(manga.name)
           .sourceEqualTo(manga.source)
           .findAll();
-      mangaId = foundMangas
-          .firstWhere((e) => e.sourceId == null || e.sourceId == sourceId)
-          .id!;
+      Manga? matchedManga;
+      for (final foundManga in foundMangas) {
+        if (foundManga.sourceId == null || foundManga.sourceId == sourceId) {
+          matchedManga = foundManga;
+          break;
+        }
+      }
+      if (matchedManga == null) {
+        await isar.writeTxn(() async {
+          await isar.mangas.put(
+            manga..updatedAt = DateTime.now().millisecondsSinceEpoch,
+          );
+        });
+        matchedManga = manga;
+      }
+      mangaId = matchedManga.id!;
     } else {
       mangaId = archiveId;
     }

--- a/lib/modules/widgets/manga_image_card_widget.dart
+++ b/lib/modules/widgets/manga_image_card_widget.dart
@@ -22,6 +22,7 @@ class MangaImageCardWidget extends ConsumerWidget {
   final ItemType itemType;
   final bool isComfortableGrid;
   final MManga? getMangaDetail;
+  final Manga? libraryManga;
 
   const MangaImageCardWidget({
     required this.source,
@@ -29,57 +30,150 @@ class MangaImageCardWidget extends ConsumerWidget {
     required this.getMangaDetail,
     required this.isComfortableGrid,
     required this.itemType,
+    this.libraryManga,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return StreamBuilder(
-      stream: isar.mangas
-          .filter()
-          .langEqualTo(source.lang)
-          .nameEqualTo(getMangaDetail!.name)
-          .sourceEqualTo(source.name)
-          .watch(fireImmediately: true),
-      builder: (context, snapshot) {
-        bool hasData = snapshot.hasData;
-        final mangaList = hasData
-            ? snapshot.data!
-                  .where(
-                    (element) => element.sourceId == null
-                        ? true
-                        : element.sourceId == source.id,
-                  )
-                  .toList()
-            : [];
-        hasData = hasData && mangaList.isNotEmpty;
-        return CoverViewWidget(
-          bottomTextWidget: BottomTextWidget(
-            maxLines: 1,
-            text: getMangaDetail!.name!,
-            isComfortableGrid: isComfortableGrid,
-          ),
-          isComfortableGrid: isComfortableGrid,
-          image: hasData && mangaList.first.customCoverImage != null
-              ? MemoryImage(mangaList.first.customCoverImage as Uint8List)
-                    as ImageProvider
-              : CustomExtendedNetworkImageProvider(
-                  toImgUrl(
-                    hasData
-                        ? mangaList.first.customCoverFromTracker ??
-                              mangaList.first.imageUrl ??
-                              ""
-                        : getMangaDetail!.imageUrl ?? "",
-                  ),
-                  headers: ref.watch(
-                    headersProvider(
-                      source: source.name!,
-                      lang: source.lang!,
-                      sourceId: source.id,
-                    ),
-                  ),
-                  cache: true,
-                  cacheMaxAge: const Duration(days: 7),
+    final hasData = libraryManga != null;
+    return CoverViewWidget(
+      bottomTextWidget: BottomTextWidget(
+        maxLines: 1,
+        text: getMangaDetail!.name!,
+        isComfortableGrid: isComfortableGrid,
+      ),
+      isComfortableGrid: isComfortableGrid,
+      image: hasData && libraryManga!.customCoverImage != null
+          ? MemoryImage(libraryManga!.customCoverImage as Uint8List)
+                as ImageProvider
+          : CustomExtendedNetworkImageProvider(
+              toImgUrl(
+                hasData
+                    ? libraryManga!.customCoverFromTracker ??
+                          libraryManga!.imageUrl ??
+                          ""
+                    : getMangaDetail!.imageUrl ?? "",
+              ),
+              headers: ref.watch(
+                headersProvider(
+                  source: source.name!,
+                  lang: source.lang!,
+                  sourceId: source.id,
                 ),
+              ),
+              cache: true,
+              cacheMaxAge: const Duration(days: 7),
+            ),
+      onTap: () => pushToMangaReaderDetail(
+        ref: ref,
+        context: context,
+        getManga: getMangaDetail!,
+        lang: source.lang!,
+        source: source.name!,
+        itemType: itemType,
+        sourceId: source.id,
+      ),
+      onLongPress: () => pushToMangaReaderDetail(
+        ref: ref,
+        context: context,
+        getManga: getMangaDetail!,
+        lang: source.lang!,
+        source: source.name!,
+        itemType: itemType,
+        addToFavourite: true,
+        sourceId: source.id,
+      ),
+      onSecondaryTap: () => pushToMangaReaderDetail(
+        ref: ref,
+        context: context,
+        getManga: getMangaDetail!,
+        lang: source.lang!,
+        source: source.name!,
+        itemType: itemType,
+        addToFavourite: true,
+        sourceId: source.id,
+      ),
+      children: [
+        Container(
+          color: hasData && libraryManga!.favorite!
+              ? Colors.black.withValues(alpha: 0.5)
+              : null,
+        ),
+        if (hasData && libraryManga!.favorite!)
+          Positioned(
+            top: 0,
+            left: 0,
+            child: Padding(
+              padding: const EdgeInsets.all(4),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: context.primaryColor,
+                  borderRadius: BorderRadius.circular(5),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(4),
+                  child: Icon(
+                    Icons.collections_bookmark_outlined,
+                    size: 16,
+                    color: context.dynamicWhiteBlackColor,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        if (!isComfortableGrid)
+          BottomTextWidget(
+            isTorrent: source.isTorrent,
+            text: getMangaDetail!.name!,
+          ),
+      ],
+    );
+  }
+}
+
+class MangaImageCardListTileWidget extends ConsumerWidget {
+  final Source source;
+  final ItemType itemType;
+  final MManga? getMangaDetail;
+  final Manga? libraryManga;
+
+  const MangaImageCardListTileWidget({
+    required this.source,
+    super.key,
+    required this.itemType,
+    required this.getMangaDetail,
+    this.libraryManga,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final hasData = libraryManga != null;
+    final image = hasData && libraryManga!.customCoverImage != null
+        ? MemoryImage(libraryManga!.customCoverImage as Uint8List)
+              as ImageProvider
+        : CustomExtendedNetworkImageProvider(
+            toImgUrl(
+              hasData
+                  ? libraryManga!.customCoverFromTracker ??
+                        libraryManga!.imageUrl ??
+                        ""
+                  : getMangaDetail!.imageUrl ?? "",
+            ),
+            headers: ref.watch(
+              headersProvider(
+                source: source.name!,
+                lang: source.lang!,
+                sourceId: source.id,
+              ),
+            ),
+          );
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Material(
+        borderRadius: BorderRadius.circular(5),
+        color: Colors.transparent,
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
           onTap: () {
             pushToMangaReaderDetail(
               ref: ref,
@@ -115,18 +209,46 @@ class MangaImageCardWidget extends ConsumerWidget {
               sourceId: source.id,
             );
           },
-          children: [
-            Container(
-              color: hasData && mangaList.first.favorite!
-                  ? Colors.black.withValues(alpha: 0.5)
-                  : null,
-            ),
-            if (hasData && mangaList.first.favorite!)
-              Positioned(
-                top: 0,
-                left: 0,
-                child: Padding(
-                  padding: const EdgeInsets.all(4),
+          child: Row(
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 10),
+                child: Stack(
+                  children: [
+                    Material(
+                      borderRadius: BorderRadius.circular(5),
+                      color: Colors.transparent,
+                      clipBehavior: Clip.antiAlias,
+                      child: Image(
+                        height: 55,
+                        width: 40,
+                        fit: BoxFit.cover,
+                        image: image,
+                      ),
+                    ),
+                    Container(
+                      height: 55,
+                      width: 40,
+                      color: hasData && libraryManga!.favorite!
+                          ? Colors.black.withValues(alpha: 0.5)
+                          : null,
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  getMangaDetail!.name!,
+                  maxLines: 2,
+                  style: TextStyle(
+                    overflow: TextOverflow.ellipsis,
+                    color: context.textColor,
+                  ),
+                ),
+              ),
+              if (hasData && libraryManga!.favorite!)
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
                   child: Container(
                     decoration: BoxDecoration(
                       color: context.primaryColor,
@@ -142,174 +264,10 @@ class MangaImageCardWidget extends ConsumerWidget {
                     ),
                   ),
                 ),
-              ),
-            if (!isComfortableGrid)
-              BottomTextWidget(
-                isTorrent: source.isTorrent,
-                text: getMangaDetail!.name!,
-              ),
-          ],
-        );
-      },
-    );
-  }
-}
-
-class MangaImageCardListTileWidget extends ConsumerWidget {
-  final Source source;
-  final ItemType itemType;
-  final MManga? getMangaDetail;
-
-  const MangaImageCardListTileWidget({
-    required this.source,
-    super.key,
-    required this.itemType,
-    required this.getMangaDetail,
-  });
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return StreamBuilder(
-      stream: isar.mangas
-          .filter()
-          .langEqualTo(source.lang)
-          .nameEqualTo(getMangaDetail!.name)
-          .sourceEqualTo(source.name)
-          .watch(fireImmediately: true),
-      builder: (context, snapshot) {
-        bool hasData = snapshot.hasData;
-        final mangaList = hasData
-            ? snapshot.data!
-                  .where(
-                    (element) => element.sourceId == null
-                        ? true
-                        : element.sourceId == source.id,
-                  )
-                  .toList()
-            : [];
-        hasData = hasData && mangaList.isNotEmpty;
-        final image = hasData && mangaList.first.customCoverImage != null
-            ? MemoryImage(mangaList.first.customCoverImage as Uint8List)
-                  as ImageProvider
-            : CustomExtendedNetworkImageProvider(
-                toImgUrl(
-                  hasData
-                      ? mangaList.first.customCoverFromTracker ??
-                            mangaList.first.imageUrl ??
-                            ""
-                      : getMangaDetail!.imageUrl ?? "",
-                ),
-                headers: ref.watch(
-                  headersProvider(
-                    source: source.name!,
-                    lang: source.lang!,
-                    sourceId: source.id,
-                  ),
-                ),
-              );
-        return Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Material(
-            borderRadius: BorderRadius.circular(5),
-            color: Colors.transparent,
-            clipBehavior: Clip.antiAlias,
-            child: InkWell(
-              onTap: () {
-                pushToMangaReaderDetail(
-                  ref: ref,
-                  context: context,
-                  getManga: getMangaDetail!,
-                  lang: source.lang!,
-                  source: source.name!,
-                  itemType: itemType,
-                  sourceId: source.id,
-                );
-              },
-              onLongPress: () {
-                pushToMangaReaderDetail(
-                  ref: ref,
-                  context: context,
-                  getManga: getMangaDetail!,
-                  lang: source.lang!,
-                  source: source.name!,
-                  itemType: itemType,
-                  addToFavourite: true,
-                  sourceId: source.id,
-                );
-              },
-              onSecondaryTap: () {
-                pushToMangaReaderDetail(
-                  ref: ref,
-                  context: context,
-                  getManga: getMangaDetail!,
-                  lang: source.lang!,
-                  source: source.name!,
-                  itemType: itemType,
-                  addToFavourite: true,
-                  sourceId: source.id,
-                );
-              },
-              child: Row(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 10),
-                    child: Stack(
-                      children: [
-                        Material(
-                          borderRadius: BorderRadius.circular(5),
-                          color: Colors.transparent,
-                          clipBehavior: Clip.antiAlias,
-                          child: Image(
-                            height: 55,
-                            width: 40,
-                            fit: BoxFit.cover,
-                            image: image,
-                          ),
-                        ),
-                        Container(
-                          height: 55,
-                          width: 40,
-                          color: hasData && mangaList.first.favorite!
-                              ? Colors.black.withValues(alpha: 0.5)
-                              : null,
-                        ),
-                      ],
-                    ),
-                  ),
-                  Expanded(
-                    child: Text(
-                      getMangaDetail!.name!,
-                      maxLines: 2,
-                      style: TextStyle(
-                        overflow: TextOverflow.ellipsis,
-                        color: context.textColor,
-                      ),
-                    ),
-                  ),
-                  if (hasData && mangaList.first.favorite!)
-                    Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: context.primaryColor,
-                          borderRadius: BorderRadius.circular(5),
-                        ),
-                        child: Padding(
-                          padding: const EdgeInsets.all(4),
-                          child: Icon(
-                            Icons.collections_bookmark_outlined,
-                            size: 16,
-                            color: context.dynamicWhiteBlackColor,
-                          ),
-                        ),
-                      ),
-                    ),
-                ],
-              ),
-            ),
+            ],
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }

--- a/lib/modules/widgets/manga_image_card_widget.dart
+++ b/lib/modules/widgets/manga_image_card_widget.dart
@@ -320,14 +320,14 @@ Future<void> pushToMangaReaderDetail({
           .sourceEqualTo(manga.source)
           .isEmptySync();
       if (empty) {
-        isar.writeTxnSync(() {
-          isar.mangas.putSync(
+        await isar.writeTxn(() async {
+          await isar.mangas.put(
             manga..updatedAt = DateTime.now().millisecondsSinceEpoch,
           );
         });
       } else {
-        isar.writeTxnSync(() {
-          isar.mangas.putSync(manga);
+        await isar.writeTxn(() async {
+          await isar.mangas.put(manga);
         });
       }
 
@@ -349,8 +349,8 @@ Future<void> pushToMangaReaderDetail({
 
   final mang = isar.mangas.getSync(mangaId);
   if (mang!.sourceId == null && !(mang.isLocalArchive ?? false)) {
-    isar.writeTxnSync(() {
-      isar.mangas.putSync(mang..sourceId = sourceId);
+    await isar.writeTxn(() async {
+      await isar.mangas.put(mang..sourceId = sourceId);
     });
   }
   final settings = isar.settings.getSync(227)!;
@@ -359,7 +359,7 @@ Future<void> pushToMangaReaderDetail({
       .where((element) => element.mangaId == mangaId)
       .toList();
   if (checkIfExist.isEmpty) {
-    isar.writeTxnSync(() {
+    await isar.writeTxn(() async {
       List<SortChapter>? sortChapterList = [];
       for (var sortChapter in settings.sortChapterList ?? []) {
         sortChapterList.add(sortChapter);
@@ -384,7 +384,7 @@ Future<void> pushToMangaReaderDetail({
         ChapterFilterDownloaded()..mangaId = mangaId,
       );
       chapterFilterUnreadList.add(ChapterFilterUnread()..mangaId = mangaId);
-      isar.settings.putSync(
+      await isar.settings.put(
         settings
           ..sortChapterList = sortChapterList
           ..chapterFilterBookmarkedList = chapterFilterBookmarkedList
@@ -395,22 +395,24 @@ Future<void> pushToMangaReaderDetail({
     });
   }
   if (!addToFavourite) {
-    if (useMaterialRoute) {
-      await Navigator.push(
-        context,
-        createRoute(page: MangaReaderDetail(mangaId: mangaId)),
-      );
+    if (context.mounted) {
+      if (useMaterialRoute) {
+        await Navigator.push(
+          context,
+          createRoute(page: MangaReaderDetail(mangaId: mangaId)),
+        );
+      } else {
+        await context.push('/manga-reader/detail', extra: mangaId);
+      }
     } else {
-      await context.push('/manga-reader/detail', extra: mangaId);
+      final getManga = isar.mangas.filter().idEqualTo(mangaId).findFirstSync()!;
+      await isar.writeTxn(() async {
+        await isar.mangas.put(
+          getManga
+            ..favorite = !getManga.favorite!
+            ..updatedAt = DateTime.now().millisecondsSinceEpoch,
+        );
+      });
     }
-  } else {
-    final getManga = isar.mangas.filter().idEqualTo(mangaId).findFirstSync()!;
-    isar.writeTxnSync(() {
-      isar.mangas.putSync(
-        getManga
-          ..favorite = !getManga.favorite!
-          ..updatedAt = DateTime.now().millisecondsSinceEpoch,
-      );
-    });
   }
 }


### PR DESCRIPTION
This PR refactors multiple UI components to remove per-item Isar queries
and replace them with shared, parent-level state and cached lookups.

### Key changes

#### 1. Manga Home
- Add a single Isar stream subscription in MangaHomeScreen
- Build a `Map<String, Manga>` index for quick lookups
- Pass `libraryManga` down to card widgets
- Remove StreamBuilder usage from MangaImageCardWidget
- Remove unnecessary AutomaticKeepAliveClientMixin usage
- Move scroll listener into initState (fixes repeated listener attachment)

#### 2. Library Grid
- Replace per-card synchronous download queries with
  `downloadedChapterIdsProvider`
- Compute download counts via in-memory lookup
- Avoid repeated sync DB calls on rebuilds and tab switches

#### 3. Tracker Library
- Add a single Isar stream in TrackerSectionScreen
- Build a `Map<mediaId, Track>` index
- Pass `libraryTrack` into each card
- Convert TrackerLibraryImageCard to StatelessWidget
- Remove StreamBuilder and ConsumerStatefulWidget boilerplate

### Benefits

- Eliminates dozens of database queries per frame in large lists
- Reduces rebuild cost and improves scroll performance
- Simplifies widget structure and removes unnecessary state/keep-alive usage
- Aligns patterns across manga home, library, and tracker features

Overall, this introduces a consistent “parent index + dumb child widget”
pattern that significantly improves performance and maintainability.

Closes #590 