### PR TITLE
Refactor page navigation handling in reader view

### DIFF
--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -353,9 +353,6 @@ class _MangaChapterPageGalleryState
 
   @override
   Widget build(BuildContext context) {
-    final animatePageTransitions = ref.watch(
-      animatePageTransitionsStateProvider,
-    );
     final backgroundColor = ref.watch(backgroundColorStateProvider);
     final fullScreenReader = ref.watch(fullScreenReaderStateProvider);
     final readerMode = ref.watch(_currentReaderMode);
@@ -365,17 +362,8 @@ class _MangaChapterPageGalleryState
 
     final l10n = l10nLocalizations(context)!;
     return ReaderKeyboardHandler(
-      onPreviousPage: () => navigationService.previousPage(
-        readerMode: readerMode!,
-        currentIndex: _currentIndex!,
-        animate: animatePageTransitions,
-      ),
-      onNextPage: () => navigationService.nextPage(
-        readerMode: readerMode!,
-        currentIndex: _currentIndex!,
-        maxPages: _pageViewPageCount,
-        animate: animatePageTransitions,
-      ),
+      onPreviousPage: () => _handlePageNavigation(forward: false),
+      onNextPage: () => _handlePageNavigation(forward: true),
       onEscape: () => _goBack(context),
       onFullScreen: () => _setFullScreen(),
       onNextChapter: () {
@@ -766,17 +754,10 @@ class _MangaChapterPageGalleryState
                           hasImageError: failedToLoadImage,
                           isContinuousMode: _isContinuousMode(),
                           onToggleUI: _isViewFunction,
-                          onPreviousPage: () => navigationService.previousPage(
-                            readerMode: readerMode!,
-                            currentIndex: _currentIndex!,
-                            animate: animatePageTransitions,
-                          ),
-                          onNextPage: () => navigationService.nextPage(
-                            readerMode: readerMode!,
-                            currentIndex: _currentIndex!,
-                            maxPages: _pageViewPageCount,
-                            animate: animatePageTransitions,
-                          ),
+                          onPreviousPage: () =>
+                              _handlePageNavigation(forward: false),
+                          onNextPage: () =>
+                              _handlePageNavigation(forward: true),
                           onDoubleTapDown: (position) => _toggleScale(position),
                           onDoubleTap: () {},
                           onSecondaryTapDown: (position) =>
@@ -954,6 +935,43 @@ class _MangaChapterPageGalleryState
         ),
       ),
     );
+  }
+
+  void _handlePageNavigation({required bool forward}) {
+    final readerMode = ref.read(_currentReaderMode);
+    final animatePageTransitions = ref.read(
+      animatePageTransitionsStateProvider,
+    );
+    if (readerMode == null || _currentIndex == null) return;
+
+    if (readerMode == ReaderMode.webtoon) {
+      final viewportHeight = MediaQuery.sizeOf(context).height;
+      final offset = viewportHeight * 0.60 * (forward ? 1 : -1);
+      final duration = animatePageTransitions
+          ? const Duration(milliseconds: 160)
+          : const Duration(milliseconds: 10);
+      _pageOffsetController.animateScroll(
+        offset: offset,
+        duration: duration,
+        curve: Curves.easeInOut,
+      );
+      return;
+    }
+
+    if (forward) {
+      navigationService.nextPage(
+        readerMode: readerMode,
+        currentIndex: _currentIndex!,
+        maxPages: _pageViewPageCount,
+        animate: animatePageTransitions,
+      );
+    } else {
+      navigationService.previousPage(
+        readerMode: readerMode,
+        currentIndex: _currentIndex!,
+        animate: animatePageTransitions,
+      );
+    }
   }
 
   Duration? _doubleTapAnimationDuration() {


### PR DESCRIPTION
This pull request refactors the page navigation logic in the manga reader view to centralize and simplify how navigation is handled, especially for different reader modes. The main change is the introduction of a new private method, `_handlePageNavigation`, which unifies the logic for handling next/previous page actions and accounts for both standard and webtoon reader modes.

Refactoring and code simplification:

* Introduced the `_handlePageNavigation` method to centralize logic for navigating between pages, including special handling for webtoon mode with smooth scrolling and custom animation durations.
* Updated all references to page navigation in the widget tree to use `_handlePageNavigation` instead of directly calling `navigationService.nextPage` or `previousPage`, reducing code duplication and improving maintainability. [[1]](diffhunk://#diff-599921b17d2ac305a8791adc40a34a65d47a48010f162928000048ee90cdf5f5L368-R366) [[2]](diffhunk://#diff-599921b17d2ac305a8791adc40a34a65d47a48010f162928000048ee90cdf5f5L769-R760)
* Removed the now-unnecessary direct usage of `animatePageTransitionsStateProvider` in the widget build method, as animation state is now handled within `_handlePageNavigation`.