### PR TITLE
fix(macos): use Application Support directory for persistent storage to avoid MDBX iCloud issues,  So no-more black screen for mac users

### DIFF
--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -52,7 +52,7 @@ class StorageProvider {
     if (Platform.isAndroid) {
       directory = Directory("/storage/emulated/0/Mangayomi/");
     } else {
-      final dir = await getApplicationDocumentsDirectory();
+      final dir = await getApplicationSupportDirectory();
       // The documents dir in iOS is already named "Mangayomi".
       // Appending "Mangayomi" to the documents dir would create
       // unnecessarily nested Mangayomi/Mangayomi/ folder.
@@ -133,7 +133,7 @@ class StorageProvider {
         dPath.isEmpty ? "/storage/emulated/0/Mangayomi/" : "$dPath/",
       );
     } else {
-      final dir = await getApplicationDocumentsDirectory();
+      final dir = await getApplicationSupportDirectory();
       final p = dPath.isEmpty ? dir.path : dPath;
       // The documents dir in iOS is already named "Mangayomi".
       // Appending "Mangayomi" to the documents dir would create
@@ -181,7 +181,7 @@ class StorageProvider {
   }
 
   Future<Directory?> getDatabaseDirectory() async {
-    final dir = await getApplicationDocumentsDirectory();
+    final dir = await getApplicationSupportDirectory();
     String dbDir;
     if (Platform.isAndroid) return dir;
     if (Platform.isIOS) {


### PR DESCRIPTION
## Problem

On macOS, the app uses `getApplicationDocumentsDirectory()` for persistent storage.

This directory is often iCloud-backed (Documents folder), which can cause issues with libmdbx.

This leads to:

MdbxError (15): Block device required

Resulting in:
- Black screen on launch
- Database initialization failure
- Potential data reset or loss of previously stored data in some cases

---

## Root cause

libmdbx requires a real block-device-backed filesystem.

macOS Documents folder may be:
- iCloud-synced
- virtualized
- not suitable for mmap-based databases

In some cases, this can cause the database to fail opening properly and trigger reinitialization, which may result in users losing access to their existing data.

---

## Fix

This PR replaces:

getApplicationDocumentsDirectory()

with:

getApplicationSupportDirectory()

for persistent storage in:

- lib/providers/storage_provider.dart

---

## Why this works

Application Support directory is:
- local APFS storage
- not iCloud-backed
- recommended by Apple for app data
- safe for database engines like libmdbx

---

## Impact

- Fixes macOS black screen on launch
- Prevents libmdbx initialization failure
- Reduces risk of silent database resets or data loss
- Improves reliability for macOS users (especially Apple Silicon / iCloud-enabled systems)

---

## Notes

No version bump is included. Versioning will be handled by maintainers during release.

<img width="1434" height="898" alt="Screenshot 2026-05-02 at 10 29 27 PM" src="https://github.com/user-attachments/assets/c18be270-1a10-4100-b373-6315d2627432" />
