### PR TITLE
Fix downloadedChapterIdsProvider

### DIFF
--- a/lib/modules/anime/providers/anime_player_controller_provider.g.dart
+++ b/lib/modules/anime/providers/anime_player_controller_provider.g.dart
@@ -59,7 +59,7 @@ final class AnimeStreamControllerProvider
 }
 
 String _$animeStreamControllerHash() =>
-    r'fd3e6030dccc06be7ccd4b9564476a3587de401f';
+    r'8bb6a7346f0b51b1d7807cf56728bbbaba05c4bc';
 
 final class AnimeStreamControllerFamily extends $Family
     with

--- a/lib/modules/library/providers/library_filter_provider.dart
+++ b/lib/modules/library/providers/library_filter_provider.dart
@@ -9,17 +9,12 @@ part 'library_filter_provider.g.dart';
 /// Pre-fetches all downloaded chapter IDs in a single Isar query.
 /// Returns a [Set<int>] for O(1) lookup instead of per-chapter queries.
 @riverpod
-Set<int> downloadedChapterIds(Ref ref) {
-  final downloaded = isar.downloads.filter().isDownloadEqualTo(true);
-  // Subscribe to changes — when anything in downloads mutates,
-  final subscription = downloaded
-      .watchLazy(fireImmediately: false)
-      .listen((_) => ref.invalidateSelf());
-
-  // invalidate this provider so it rebuilds with fresh data.
-  ref.onDispose(subscription.cancel);
-
-  return downloaded.idProperty().findAllSync().whereType<int>().toSet();
+Stream<Set<int>> downloadedChapterIds(Ref ref) {
+  return isar.downloads
+      .filter()
+      .isDownloadEqualTo(true)
+      .watch(fireImmediately: true)
+      .map((list) => list.map((d) => d.id).whereType<int>().toSet());
 }
 
 /// Pre-fetches all manga IDs that have at least one tracking entry.
@@ -45,7 +40,8 @@ List<Manga> filteredLibraryManga(
   required String searchQuery,
   required bool ignoreFiltersOnSearch,
 }) {
-  final downloadedIds = ref.watch(downloadedChapterIdsProvider);
+  final downloadedIds =
+      ref.watch(downloadedChapterIdsProvider).asData?.value ?? const <int>{};
   final trackedIds = ref.watch(trackedMangaIdsProvider);
 
   return _filterAndSortManga(

--- a/lib/modules/library/providers/library_filter_provider.dart
+++ b/lib/modules/library/providers/library_filter_provider.dart
@@ -10,12 +10,16 @@ part 'library_filter_provider.g.dart';
 /// Returns a [Set<int>] for O(1) lookup instead of per-chapter queries.
 @riverpod
 Set<int> downloadedChapterIds(Ref ref) {
-  final downloads = isar.downloads
-      .filter()
-      .isDownloadEqualTo(true)
-      .idProperty()
-      .findAllSync();
-  return downloads.whereType<int>().toSet();
+  final downloaded = isar.downloads.filter().isDownloadEqualTo(true);
+  // Subscribe to changes — when anything in downloads mutates,
+  final subscription = downloaded
+      .watchLazy(fireImmediately: false)
+      .listen((_) => ref.invalidateSelf());
+
+  // invalidate this provider so it rebuilds with fresh data.
+  ref.onDispose(subscription.cancel);
+
+  return downloaded.idProperty().findAllSync().whereType<int>().toSet();
 }
 
 /// Pre-fetches all manga IDs that have at least one tracking entry.

--- a/lib/modules/library/providers/library_filter_provider.g.dart
+++ b/lib/modules/library/providers/library_filter_provider.g.dart
@@ -18,8 +18,9 @@ final downloadedChapterIdsProvider = DownloadedChapterIdsProvider._();
 /// Returns a [Set<int>] for O(1) lookup instead of per-chapter queries.
 
 final class DownloadedChapterIdsProvider
-    extends $FunctionalProvider<Set<int>, Set<int>, Set<int>>
-    with $Provider<Set<int>> {
+    extends
+        $FunctionalProvider<AsyncValue<Set<int>>, Set<int>, Stream<Set<int>>>
+    with $FutureModifier<Set<int>>, $StreamProvider<Set<int>> {
   /// Pre-fetches all downloaded chapter IDs in a single Isar query.
   /// Returns a [Set<int>] for O(1) lookup instead of per-chapter queries.
   DownloadedChapterIdsProvider._()
@@ -38,25 +39,17 @@ final class DownloadedChapterIdsProvider
 
   @$internal
   @override
-  $ProviderElement<Set<int>> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
+  $StreamProviderElement<Set<int>> $createElement($ProviderPointer pointer) =>
+      $StreamProviderElement(pointer);
 
   @override
-  Set<int> create(Ref ref) {
+  Stream<Set<int>> create(Ref ref) {
     return downloadedChapterIds(ref);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(Set<int> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<Set<int>>(value),
-    );
   }
 }
 
 String _$downloadedChapterIdsHash() =>
-    r'a51ff78fb0ad2548c719d1ca400ae474fc01e683';
+    r'ff409df987e776e8c150e541c5aa48b1d5f9e9b9';
 
 /// Pre-fetches all manga IDs that have at least one tracking entry.
 
@@ -207,7 +200,7 @@ final class FilteredLibraryMangaProvider
 }
 
 String _$filteredLibraryMangaHash() =>
-    r'afecb3de71f1f8c1682a0bfd9949f8a372c7d1b6';
+    r'17c6f370c3120277379c3bbb22c31a19ff028682';
 
 /// Filters and sorts a list of [Manga] based on library filter/sort settings.
 

--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -173,9 +173,14 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                                         builder: (context, ref, child) {
                                           int downloadCount = 0;
                                           if (widget.downloadedChapter) {
-                                            final downloadedIds = ref.watch(
-                                              downloadedChapterIdsProvider,
-                                            );
+                                            final downloadedIds =
+                                                ref
+                                                    .watch(
+                                                      downloadedChapterIdsProvider,
+                                                    )
+                                                    .asData
+                                                    ?.value ??
+                                                const <int>{};
                                             downloadCount = entry.chapters
                                                 .where(
                                                   (c) =>

--- a/lib/modules/library/widgets/library_listview_widget.dart
+++ b/lib/modules/library/widgets/library_listview_widget.dart
@@ -1,9 +1,7 @@
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:isar_community/isar.dart';
-import 'package:mangayomi/main.dart';
-import 'package:mangayomi/models/download.dart';
+import 'package:mangayomi/modules/library/providers/library_filter_provider.dart';
 import 'package:mangayomi/modules/library/providers/isar_providers.dart';
 import 'package:mangayomi/modules/library/providers/library_state_provider.dart';
 import 'package:mangayomi/models/manga.dart';
@@ -205,23 +203,24 @@ class LibraryListViewWidget extends StatelessWidget {
                                         ),
                                         child: Consumer(
                                           builder: (context, ref, child) {
-                                            final chapterIds = entry.chapters
-                                                .toList()
-                                                .map((c) => c.id)
-                                                .whereType<int>()
-                                                .toList();
-                                            List nbrDown = chapterIds.isNotEmpty
-                                                ? isar.downloads
-                                                      .filter()
-                                                      .anyOf(
-                                                        chapterIds,
-                                                        (q, id) =>
-                                                            q.idEqualTo(id),
-                                                      )
-                                                      .isDownloadEqualTo(true)
-                                                      .findAllSync()
-                                                : [];
-                                            if (nbrDown.isNotEmpty) {
+                                            final downloadedIds =
+                                                ref
+                                                    .watch(
+                                                      downloadedChapterIdsProvider,
+                                                    )
+                                                    .asData
+                                                    ?.value ??
+                                                const <int>{};
+                                            final nbrDown = entry.chapters
+                                                .where(
+                                                  (c) =>
+                                                      c.id != null &&
+                                                      downloadedIds.contains(
+                                                        c.id,
+                                                      ),
+                                                )
+                                                .length;
+                                            if (nbrDown > 0) {
                                               return Container(
                                                 decoration: BoxDecoration(
                                                   borderRadius:
@@ -242,7 +241,7 @@ class LibraryListViewWidget extends StatelessWidget {
                                                         right: 3,
                                                       ),
                                                   child: Text(
-                                                    nbrDown.length.toString(),
+                                                    nbrDown.toString(),
                                                     style: const TextStyle(
                                                       color: Colors.white,
                                                     ),

--- a/lib/modules/manga/reader/providers/reader_controller_provider.g.dart
+++ b/lib/modules/manga/reader/providers/reader_controller_provider.g.dart
@@ -147,7 +147,7 @@ final class ReaderControllerProvider
   }
 }
 
-String _$readerControllerHash() => r'f129a22656f06082d217f2364697f3fc68668b64';
+String _$readerControllerHash() => r'43c6e1583c52c8fae01d606a51308b0e96a74a6b';
 
 final class ReaderControllerFamily extends $Family
     with


### PR DESCRIPTION
Before the "Downloaded" filter in the library AND the "Downloaded chapters" badge would not update, unless you restart the app.

Now the "Downloaded chapters" badge is increasing and the "Downloaded" filter is showing new downloaded manga chapters and hiding deleted manga chapters.

## Before:

https://github.com/user-attachments/assets/40e70bee-2f97-474f-8a2b-961e7c7cde16

## After:

https://github.com/user-attachments/assets/83404a0a-f8a7-4818-9e29-43487598ff0b



