### PR TITLE
fix(downloads): unstall anime downloads on URLs with query strings + 206 responses

### DIFF
--- a/lib/services/download_manager/download_isolate_pool.dart
+++ b/lib/services/download_manager/download_isolate_pool.dart
@@ -509,9 +509,14 @@ Future<void> _downloadFile(
         var request = Request('GET', Uri.parse(pageUrl.url));
         request.headers.addAll(pageUrl.headers ?? {});
         StreamedResponse response = await client.send(request);
-        if (response.statusCode != 200) {
+        // Accept any 2xx — including 206 Partial Content, which the server
+        // returns when the source extension sends `Range: bytes=0-` on the
+        // streaming request (e.g. AnimeGG). Rejecting 206 here caused 3
+        // retries → silent stall.
+        if (response.statusCode < 200 || response.statusCode >= 300) {
           throw DownloadPoolException(
-            'Failed to download file: ${pageUrl.fileName!}',
+            'Failed to download file: ${pageUrl.fileName!} '
+            '(status ${response.statusCode})',
           );
         }
         int total = response.contentLength ?? 0;
@@ -617,8 +622,12 @@ Future<void> _downloadSegment(
     }
     StreamedResponse response = await _withRetry(() => client.send(request), 3);
 
-    if (response.statusCode != 200) {
-      throw DownloadPoolException('Failed to download segment: ${ts.name}');
+    // Accept any 2xx (including 206 Partial Content) — see comment in
+    // _downloadFile.
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw DownloadPoolException(
+        'Failed to download segment: ${ts.name} (status ${response.statusCode})',
+      );
     }
 
     final sink = file.openWrite();

--- a/lib/utils/extensions/string_extensions.dart
+++ b/lib/utils/extensions/string_extensions.dart
@@ -59,7 +59,11 @@ extension StringExtensions on String {
   }
 
   bool isMediaVideo() {
-    return [
+    // Match against the URL path only — query strings (e.g. AnimeGG's
+    // `?for=...`) and fragments must not defeat the suffix check. Use a
+    // leading `.` so e.g. `flashmp4` doesn't accidentally match.
+    final lower = (Uri.tryParse(this)?.path ?? this).toLowerCase();
+    return const [
       "3gp",
       "avi",
       "mpg",
@@ -73,7 +77,7 @@ extension StringExtensions on String {
       "wmv",
       "mkv",
       "mov",
-    ].any((extension) => toLowerCase().endsWith(extension));
+    ].any((extension) => lower.endsWith(".$extension"));
   }
 }
 


### PR DESCRIPTION
## Summary

Two related bugs left **anime downloads stuck at 0%** with **no error visible to the user**. The download row spawned, an empty episode-named folder appeared on disk, and the spinner ran forever. Manga downloads from sources with clean MP4/JPG URLs (Asura Scans, MangaDex, etc.) were unaffected, which is why this slipped through.

Fixed by two surgical changes in two files. Both bugs reproduce end-to-end on AnimeGG; both are general (not source-specific).

## The two bugs

### 1. `isMediaVideo()` rejects URLs with query strings

`lib/utils/extensions/string_extensions.dart` — `isMediaVideo()` did a plain `endsWith` against the **full URL string**:

```dart
return [...].any((extension) => toLowerCase().endsWith(extension));
```

Many sources return stream URLs shaped like:

```
https://www.animegg.org/play/75460/video.mp4?for=101778365476299
```

The trailing `?for=…` query string defeats the suffix match — `isMediaVideo()` returns `false` for a URL that genuinely is an MP4. In `downloadChapter` (`lib/modules/manga/download/providers/download_provider.dart`), this means **both** filters return empty:

```dart
final m3u8Urls = value.$1.where(... .endsWith(".m3u8") ...).toList();
final nonM3u8Urls = value.$1.where((e) => e.originalUrl.isMediaVideo()).toList();
...
if (videosUrls.isNotEmpty) { ... isOk = true; }
```

`isOk` stays `false`, and the surrounding loop:

```dart
await Future.doWhile(() async {
  await Future.delayed(const Duration(seconds: 1));
  if (isOk == true) return false;
  return true;
});
```

waits forever. `MDownloader` is **never constructed**. No error is raised because there's no error path for "extension returned 0 playable URLs" — the function just polls. The outer `} catch (_) { keepAlive.close(); }` would have hidden it anyway.

**Fix** (this PR):

```dart
final lower = (Uri.tryParse(this)?.path ?? this).toLowerCase();
return const [...].any((ext) => lower.endsWith(".$ext"));
```

Two adjustments:
- Match against the URL **path only** (`Uri.tryParse(this)?.path`), so `?…` and `#…` cannot defeat the check.
- Require a leading dot in the suffix (`.mp4` not `mp4`), so a URL ending in e.g. `flashmp4` cannot accidentally pass — a latent bug in the original code.

### 2. `_downloadFile` rejects HTTP 206 Partial Content

`lib/services/download_manager/download_isolate_pool.dart` — once a URL passes the filter, the anime branch of `_downloadFile` opens a streaming request:

```dart
StreamedResponse response = await client.send(request);
if (response.statusCode != 200) {
  throw DownloadPoolException('Failed to download file: …');
}
```

When the source extension sets `Range: bytes=0-` on the request (AnimeGG's extension does this; many others do too), the server **correctly** responds with **HTTP 206 Partial Content** — that's the literal definition of an honored range request. The check rejects it as non-200, throws, retries 3×, and ultimately surfaces the throw — but the throw is masked by the outer `} catch (_) { keepAlive.close(); }` in `downloadChapter` (`lib/modules/manga/download/providers/download_provider.dart`), so the user only sees a forever-spinner.

**Fix** (this PR):

```dart
if (response.statusCode < 200 || response.statusCode >= 300) {
  throw DownloadPoolException(
    'Failed to download file: ${pageUrl.fileName!} '
    '(status ${response.statusCode})',
  );
}
```

Same fix applied to `_downloadSegment` for HLS segment fetches (HLS hosts also commonly return 206 to a ranged segment GET).

## Files

```
lib/utils/extensions/string_extensions.dart             |  8 ++++++--
lib/services/download_manager/download_isolate_pool.dart| 17 +++++++++++++----
2 files changed, 19 insertions(+), 6 deletions(-)
```

No platform-specific code. No new dependencies. No behavior change for any URL that already passed both predicates.

## Reproduction

- **Source:** AnimeGG (en) — install via Mangayomi extensions
- **Episode:** any. Examples used in testing:
  - Toriko Episode 147 — 65,026,283 bytes
  - Gintama Episode 39 — 40,499,317 bytes
  - Grand Blue Episode 12 — 180,478,812 bytes
  - One Piece, etc.
- **Action:** tap the download icon

**Before this PR:** an empty `…/AnimeGG (EN)/<series>/<episode>.mp4`-named folder is created (this is the per-episode subdir from earlier in `downloadChapter`). The download icon stays in the spinner state. No error toast, no log entry, the queue row sits at 0% indefinitely.

**After this PR:** the `.mp4` file is written to disk at exactly the size declared in `Content-Length`, plays in QuickTime/VLC.

## Trial-and-error trail (chain of evidence)

We instrumented the download path with `print` statements to find the bug. Each step ruled out a hypothesis or revealed the next layer.

| # | Test | Observation | Conclusion |
|---|------|-------------|------------|
| 1 | `curl -L -o "<download path>" "<animegg URL>"` | 241 MB written in 25 s | URL + filesystem fine, not a network issue |
| 2 | Trigger manga download (Asura Scans) on the same build | `.cbz` written end-to-end, "MDownloader completed" log | Downloader pipeline works for manga |
| 3 | Trigger anime download on the same build | Empty episode folder created, **zero** logs from `_downloadFile` | `MDownloader` is never reached for anime |
| 4 | Add log inside the anime branch of `downloadChapter` | `got 1 videos` → `originalUrl=…video.mp4?for=… isMedia=`**`false`** → `m3u8=0 nonM3u8=0` | `isMediaVideo()` rejects URLs with `?…` query strings |
| 5 | Patch `isMediaVideo()` (this PR) | `isMedia=true` → `nonM3u8=1` → "picked video url=…" → `_downloadFile` reached | First bug confirmed and fixed; second bug now visible |
| 6 | `_downloadFile` finally fires | `response status=206 contentLength=65026283` followed by `Failed to download file: … (status 206)` thrown 3× | Status check rejects 206 Partial Content |
| 7 | Patch the status check to accept any 2xx (this PR) | `first chunk received (7571 bytes)` → `stream done, received=65026283 bytes` → `MDownloader completed` | File written, plays |

### Sample log output

**Before any fix** — empty filter result, infinite poll:

```
[DL] anime: got 1 videos for Episode 147 - Toriko and Komatsu Embark on a New Voyage!
[DL]   video quality=360p - Sub url=https://www.animegg.org/play/75460/video.mp4?for=… originalUrl=…?for=… isMedia=false
[DL] anime: m3u8=0 nonM3u8=0
[DL] anime: NO playable URLs after filtering — download will hang in doWhile loop
```

**With `isMediaVideo()` fixed but status check still 200-only** — second bug visible:

```
[DL] anime: m3u8=0 nonM3u8=1
[DL] anime: picked video url=https://www.animegg.org/play/75460/video.mp4?for=…
[DL] anime fetch: https://www.animegg.org/play/75460/video.mp4?for=…
[DL] anime response status=206 contentLength=65026283
[DL] downloadChapter: MDownloader threw: MDownloaderException: Download failed (… status 206)
```

**With both fixes** — file completes:

```
[DL] anime first chunk received (7571 bytes) for https://www.animegg.org/play/75460/video.mp4?for=…
[DL] anime stream done, received=65026283 bytes
[DL] downloadChapter: MDownloader completed for Episode 147 …
```

Concurrent downloads (Toriko 147, Toriko 146, Gintama 39, Grand Blue 12) all reached "first chunk received" together; the Toriko 147 one completed end-to-end before we stopped watching.

The instrumentation `print`s are **not** included in this PR — they were dev-only. The PR carries only the two minimal source changes that proved load-bearing.

## Notes

- **Manga path unchanged.** The non-anime branch of `_downloadFile` still uses `if (statusCode != 200)`. Manga image servers don't honor `Range` requests (the manga branch doesn't send one), so 206 is irrelevant there. Left as-is to keep the diff minimal and avoid touching code the bug doesn't reach.
- **No source-specific code.** The fix isn't "make AnimeGG work"; it's "stop corner-casing URLs that legitimately end with `.mp4` after a query string, and stop rejecting compliant 206 responses to Range requests." Any future source returning either pattern is unblocked too.
- **Two real cleanup opportunities surfaced during investigation but are not part of this PR** to keep it minimal:
  - The bare `} catch (_) { keepAlive.close(); }` at the end of `downloadChapter` discards every exception silently. Both bugs above were initially invisible because of this.
  - The `Future.doWhile(() => isOk == true)` poll has no timeout and no error path — if the extension returns nothing playable or throws, the spinner hangs forever.

  Happy to send those as a separate cleanup PR if you want.

