### PR TITLE
fix(macos): host libmdbx DB under Application Support to avoid TCC EACCES on launch

### DIFF
--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -181,7 +181,17 @@ class StorageProvider {
   }
 
   Future<Directory?> getDatabaseDirectory() async {
-    final dir = await getApplicationDocumentsDirectory();
+    // On macOS, host the libmdbx / Isar database under Application Support
+    // (app-private, not TCC-gated) instead of Documents. macOS denies
+    // unsigned/sideloaded/dev builds access to ~/Documents when iCloud
+    // "Desktop & Documents Folders" sync is enabled, surfacing as
+    // `IsarError: Cannot open Environment: MdbxError (13): Permission denied`
+    // and a black screen on launch. iOS keeps Documents so the DB remains
+    // visible alongside backups via the Files app. Windows / Linux are
+    // untouched — Documents is the conventional location there.
+    final dir = Platform.isMacOS
+        ? await getApplicationSupportDirectory()
+        : await getApplicationDocumentsDirectory();
     String dbDir;
     if (Platform.isAndroid) return dir;
     if (Platform.isIOS) {
@@ -191,8 +201,45 @@ class StorageProvider {
     } else {
       dbDir = path.join(dir.path, 'Mangayomi', 'databases');
     }
+    if (Platform.isMacOS) {
+      await _migrateLegacyMacosDatabase(dbDir);
+    }
     await createDirectorySafely(dbDir);
     return Directory(dbDir);
+  }
+
+  /// One-shot migration: if a pre-existing macOS user has their database
+  /// under the legacy Documents path and the new Application Support path
+  /// is empty, rename it across so library / history / progress are not
+  /// silently reset. Subsequent launches skip this branch because the new
+  /// path already exists.
+  Future<void> _migrateLegacyMacosDatabase(String newDbDir) async {
+    try {
+      final docs = await getApplicationDocumentsDirectory();
+      final legacyDir = Directory(
+        path.join(docs.path, 'Mangayomi', 'databases'),
+      );
+      if (!await legacyDir.exists()) return;
+      final newDir = Directory(newDbDir);
+      if (await newDir.exists()) {
+        // Only migrate when the new location is empty — never overwrite.
+        final entries = await newDir
+            .list(followLinks: false)
+            .take(1)
+            .toList();
+        if (entries.isNotEmpty) return;
+      }
+      await Directory(path.dirname(newDbDir)).create(recursive: true);
+      await legacyDir.rename(newDbDir);
+      debugPrint(
+        '[storage] Migrated macOS DB from ${legacyDir.path} to $newDbDir',
+      );
+    } catch (e) {
+      // Migration is best-effort. Falling back to a fresh DB is preferable
+      // to crashing on launch — the user can manually move the legacy
+      // ~/Documents/Mangayomi/databases/ contents if needed.
+      debugPrint('[storage] macOS DB migration skipped: $e');
+    }
   }
 
   Future<Directory?> getGalleryDirectory() async {


### PR DESCRIPTION
## Summary

Black screen on launch on macOS for unsigned / sideloaded / dev / not-yet-permission-granted builds when iCloud Drive's **"Desktop & Documents Folders"** sync is enabled (a default many users have on). The Isar / libmdbx database fails to open with:

```
[ERROR:flutter/runtime/dart_isolate.cc(1402)] Unhandled exception:
IsarError: Cannot open Environment: MdbxError (13): Permission denied
```

Fixed by storing the database under `getApplicationSupportDirectory()` on **macOS only**. Other platforms (iOS, Windows, Linux) are unchanged. Existing macOS users have their database migrated automatically on first launch.

## Root cause (what's actually happening)

POSIX errno **13 is `EACCES`** — access denied. It is **not** errno 15 (`ENOTBLK` / "Block device required"), and it is **not** iCloud Drive's "Optimise Mac Storage" evicting files (which would only matter once a file existed; here the file never gets created).

When iCloud "Desktop & Documents Folders" sync is on, macOS treats `~/Documents` as a TCC-protected location ("Files and Folders > Documents" privacy gate). Behavior:

| Caller | Result |
|---|---|
| Signed Mac App Store / properly notarized app, after the user grants the TCC prompt | Allowed |
| Signed app, before the user grants (or if they decline) | EACCES |
| **Unsigned / dev / sideloaded build** | EACCES, no prompt |
| Terminal as the same user | Allowed (Terminal inherits a full grant) |

That last row is how I verified the cause: from Terminal `mkdir ~/Documents/com.kodjodevf.mangayomi/ && echo x > .../probe.txt` succeeds; the unsigned dev build of the same code on the same machine fails on the first DB open.

iCloud Drive doesn't directly cause `EACCES` — it correlates with it because **enabling Desktop & Documents Folders is one of the conditions under which macOS enforces TCC strictly on `~/Documents`**. Same machine, same code, no iCloud sync → no error.

## Fix

`lib/providers/storage_provider.dart` — `getDatabaseDirectory()` only:

```dart
final dir = Platform.isMacOS
    ? await getApplicationSupportDirectory()
    : await getApplicationDocumentsDirectory();
```

`~/Library/Application Support/<bundle id>/` is **app-private**, **not TCC-gated**, and Apple's recommended location for app data files (per [File System Programming Guide](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html)).

Plus a one-shot best-effort migration so existing users keep their library:

```dart
Future<void> _migrateLegacyMacosDatabase(String newDbDir) async {
  final docs = await getApplicationDocumentsDirectory();
  final legacyDir = Directory(path.join(docs.path, 'Mangayomi', 'databases'));
  if (!await legacyDir.exists()) return;
  // Skip if the new location is non-empty — never overwrite user data
  ...
  await legacyDir.rename(newDbDir);
}
```

Migration runs only on macOS, only when the legacy directory exists and the new one is empty. Failures fall through to a fresh DB rather than crashing on launch — the user can then move the legacy `~/Documents/Mangayomi/databases/` contents manually if they want.

## Files

```
lib/providers/storage_provider.dart | 49 ++++++++++++++++++++++++++++++++++++-
1 file changed, 48 insertions(+), 1 deletion(-)
```

No platform-specific code added beyond `Platform.isMacOS` guards.

## What this PR explicitly does NOT do (addressing prior review feedback)

A previous attempt at this fix was correctly rejected for being too broad. Each concern is addressed here:

| Prior concern | This PR |
|---|---|
| **Affects iOS / Windows / Linux too** | All three platforms remain on `getApplicationDocumentsDirectory()`. Only macOS branches to Application Support. |
| **iOS Files-app visibility lost** (backups via `getIosBackupDirectory()` become unreachable) | iOS is untouched. `getApplicationDocumentsDirectory()` is still used; backups are still in the user-visible Documents folder. |
| **Windows / Linux convention is Documents, no iCloud concern** | Windows and Linux are untouched. |
| **No migration — silent fresh start for existing users** | One-shot migration on macOS first launch. Skipped if the new path is non-empty so user data is never overwritten. |
| **Claimed root cause may be inaccurate ("Block device required")** | Captured the actual `MdbxError (13): Permission denied` and rewrote the explanation around POSIX EACCES + macOS TCC. The "Block device required" claim is dropped entirely. |
| **No actual error in repro screenshot** | Real error captured this time (see Verification section). |

## Reproduction

- macOS host with iCloud Drive's **"Desktop & Documents Folders"** sync enabled
  - System Settings → Apple ID → iCloud → iCloud Drive → "Desktop & Documents Folders" → ON
- Unsigned / sideloaded / dev / not-yet-TCC-granted Mangayomi build
- Launch the app

**Before this PR:** black screen, app exits within seconds. Launch log:

```
2026-05-09 21:59:29.782 mangayomi[29165:3494720] Running with merged UI and platform thread. Experimental.
flutter: IsarCore using libmdbx: v0.13.8-temp-upstream-fix
[ERROR:flutter/runtime/dart_isolate.cc(1402)] Unhandled exception:
IsarError: Cannot open Environment: MdbxError (13): Permission denied
Terminated: 15
```

**After this PR:** clean launch, no error. Database opens at `~/Library/Application Support/<bundle id>/Mangayomi/databases/mangayomiDb.isar`.

## Verification

- macOS 26.3, Apple Silicon (M1)
- iCloud Drive `Desktop & Documents Folders` sync confirmed active via `MobileMeAccounts` + `brctl status` (CLOUDDESKTOP dataclass active)
- Reproduced the exact error on `upstream/main` (`25c1d72c`):

  ```
  flutter: IsarCore using libmdbx: v0.13.8-temp-upstream-fix
  [ERROR:flutter/runtime/dart_isolate.cc(1402)] Unhandled exception:
  IsarError: Cannot open Environment: MdbxError (13): Permission denied
  ```

- Cross-checked from Terminal: `mkdir`+`write` to the same `~/Documents/com.kodjodevf.mangayomi/` path succeeded, ruling out a filesystem-level failure.
- Built this branch (single 1-file change), launched: app comes up cleanly, Isar opens at the new path:

  ```
  $ ls -la ~/Library/Application\ Support/com.kodjodevf.mangayomi/Mangayomi/databases/
  -rw-------@ 1 mehak  staff  15728640 ... mangayomiDb.isar
  -rw-------@ 1 mehak  staff     16384 ... mangayomiDb.isar-lck
  ```

- Pre-existing 15 MB Isar database from prior test runs preserved through rebuild — no data loss.

## Notes

- **Hive** (`Hive.initFlutter` in `main.dart`) still uses Documents on macOS. It is initialized after Isar inside `_postLaunchInit`, which is `unawaited`, so a Hive failure will not reproduce the black-screen symptom this PR fixes. If Hive is observed to fail with the same EACCES on TCC-restricted setups, a follow-up PR can move it the same way. Out of scope here to keep the diff minimal.
- **No test coverage in the existing project for storage paths**, so verification is manual launch-and-inspect on macOS.
- **No source-specific or platform-coupled side effects.** The non-macOS branches return the same value as before.

