### PR TITLE
perf(statistics): aggregate inside Isar to fix #543 crash on large libraries

### DIFF
--- a/lib/modules/more/statistics/statistics_provider.dart
+++ b/lib/modules/more/statistics/statistics_provider.dart
@@ -30,50 +30,77 @@ Future<StatisticsData> getStatistics(
   Ref ref, {
   required ItemType itemType,
 }) async {
-  final items = await isar.mangas
+  // Aggregate inside Isar instead of materialising every favourite manga
+  // and every one of their chapters in Dart. Loading all chapters of a
+  // 75+ manga library exhausts heap on Android and reliably crashes the
+  // statistics screen — see issue #543.
+
+  final totalItems = await isar.mangas
       .filter()
-      .idIsNotNull()
       .favoriteEqualTo(true)
       .itemTypeEqualTo(itemType)
-      .findAll();
+      .count();
 
-  final chapters = await isar.chapters
+  final totalChapters = await isar.chapters
       .filter()
-      .idIsNotNull()
       .manga((q) => q.favoriteEqualTo(true).itemTypeEqualTo(itemType))
-      .findAll();
+      .count();
+
+  final readChapters = await isar.chapters
+      .filter()
+      .manga((q) => q.favoriteEqualTo(true).itemTypeEqualTo(itemType))
+      .isReadEqualTo(true)
+      .count();
 
   final downloadedCount = await isar.downloads
       .filter()
-      .idIsNotNull()
-      .chapter((q) => q.manga((m) => m.itemTypeEqualTo(itemType)))
-      .chapter((q) => q.manga((m) => m.favoriteEqualTo(true)))
+      .chapter(
+        (q) => q.manga(
+          (m) => m.favoriteEqualTo(true).itemTypeEqualTo(itemType),
+        ),
+      )
       .isDownloadEqualTo(true)
       .count();
 
-  final totalItems = items.length;
-  final totalChapters = chapters.length;
-  final readChapters = chapters.where((c) => c.isRead ?? false).length;
+  // Completed items: a favourite manga whose source-reported status is
+  // Completed AND every chapter is read AND there is at least one chapter.
+  // Pull only the IDs of completed favourites, then run two cheap count()
+  // queries per item — never materialise the chapter rows.
+  final completedFavouriteIds = await isar.mangas
+      .filter()
+      .favoriteEqualTo(true)
+      .itemTypeEqualTo(itemType)
+      .statusEqualTo(Status.completed)
+      .idProperty()
+      .findAll();
 
   int completedItems = 0;
-  for (var item in items) {
-    if (item.status == Status.completed) {
-      final itemChapters = item.chapters.toList();
-      if (itemChapters.isNotEmpty &&
-          itemChapters.every((element) => element.isRead ?? false)) {
-        completedItems++;
-      }
-    }
+  for (final id in completedFavouriteIds) {
+    final total = await isar.chapters
+        .filter()
+        .mangaIdEqualTo(id)
+        .count();
+    if (total == 0) continue;
+    final unread = await isar.chapters
+        .filter()
+        .mangaIdEqualTo(id)
+        .isReadEqualTo(false)
+        .count();
+    if (unread == 0) completedItems++;
   }
 
-  final histories = await isar.historys
+  // Sum reading time without loading full History rows. Project just the
+  // int field — Isar returns a List<int?> of plain ints, far cheaper than
+  // hydrating every history record.
+  final readingTimes = await isar.historys
       .filter()
       .itemTypeEqualTo(itemType)
+      .readingTimeSecondsProperty()
       .findAll();
-  int totalReadingTimeSeconds = 0;
-  for (final h in histories) {
-    totalReadingTimeSeconds += h.readingTimeSeconds ?? 0;
-  }
+  final totalReadingTimeSeconds = readingTimes.fold<int>(
+    0,
+    (sum, v) => sum + (v ?? 0),
+  );
 
   return StatisticsData(
     totalItems: totalItems,


### PR DESCRIPTION
## Summary

Fixes #543. Opening More → Statistics on a populated library (~75+ favourites) hangs and crashes the app on Android. Cause is the statistics provider materialising every favourite manga *and* every chapter of every favourite into a Dart list — for a typical library that is 7,500+ heavy Isar objects in memory at once just to compute six counters.

Rewrite the aggregation to live inside Isar (`count()` + property projection) so no object is hydrated. Same numbers, same semantics, dramatically lower memory.

## The bug

`lib/modules/more/statistics/statistics_provider.dart`:

```dart
final items = await isar.mangas
    .filter()
    .idIsNotNull()
    .favoriteEqualTo(true)
    .itemTypeEqualTo(itemType)
    .findAll();                         // every favourite manga, full row

final chapters = await isar.chapters
    .filter()
    .idIsNotNull()
    .manga((q) => q.favoriteEqualTo(true).itemTypeEqualTo(itemType))
    .findAll();                         // every chapter of every favourite

// nested loop that re-fetches chapters per completed manga
for (var item in items) {
  if (item.status == Status.completed) {
    final itemChapters = item.chapters.toList();   // link traversal
    if (itemChapters.isNotEmpty &&
        itemChapters.every((e) => e.isRead ?? false)) {
      completedItems++;
    }
  }
}

final histories = await isar.historys.filter().itemTypeEqualTo(itemType).findAll();
int totalReadingTimeSeconds = 0;
for (final h in histories) {                       // every History row to sum one int
  totalReadingTimeSeconds += h.readingTimeSeconds ?? 0;
}
```

For a library with 75 favourites at ~100 chapters each = 7,500+ fully-hydrated `Chapter` records (with URLs, names, scanlator strings, etc.) materialised in `List<Chapter>` simultaneously, plus the parent `Manga` rows, plus every `History` row — to compute six integers.

## The fix

Push the aggregation into Isar so we never load a row we won't return:

```dart
final totalItems       = await isar.mangas.filter()...count();
final totalChapters    = await isar.chapters.filter()...count();
final readChapters     = await isar.chapters.filter()...isReadEqualTo(true).count();
final downloadedCount  = await isar.downloads.filter()...isDownloadEqualTo(true).count();

// Completed favourites: pull only the IDs, then run two count queries per
// item to check "has chapters && unread == 0". Logic preserved exactly.
final completedFavouriteIds = await isar.mangas
    .filter()
    .favoriteEqualTo(true)
    .itemTypeEqualTo(itemType)
    .statusEqualTo(Status.completed)
    .idProperty()
    .findAll();

int completedItems = 0;
for (final id in completedFavouriteIds) {
  final total  = await isar.chapters.filter().mangaIdEqualTo(id).count();
  if (total == 0) continue;
  final unread = await isar.chapters.filter().mangaIdEqualTo(id).isReadEqualTo(false).count();
  if (unread == 0) completedItems++;
}

// Reading time: project the int field, fold the List<int?>.
final readingTimes = await isar.historys
    .filter()
    .itemTypeEqualTo(itemType)
    .readingTimeSecondsProperty()
    .findAll();
final totalReadingTimeSeconds = readingTimes.fold<int>(0, (s, v) => s + (v ?? 0));
```

Filters are unchanged (`favoriteEqualTo(true)`, `itemTypeEqualTo`, etc.), so every counter returns the same number it did before. The `completedItems` definition is preserved exactly: a favourite manga with `status == completed`, at least one chapter, and zero unread chapters.

## Memory + perf impact

| | Before | After |
|---|---|---|
| Peak chapter rows in Dart heap | total favourite chapters (e.g. 7,500) | 0 |
| Peak history rows in Dart heap | total history rows | 0 |
| Manga rows hydrated | every favourite | only `id` projected for completed favourites |
| DB round-trips | 4 `findAll` + N link-traversals (one per completed favourite) | 4 `count` + 1 `idProperty.findAll` + 2 `count` per completed favourite |

DB round-trips on indexed filter chains (`mangaId` + `isRead`) are sub-millisecond, so the per-completed-favourite cost is negligible compared to the cost of materialising thousands of full chapter rows. End-to-end the function is faster on any non-trivial library and uses orders of magnitude less peak heap.

## Verification

- `flutter analyze` clean on the touched file
- `flutter build macos --release` succeeds
- Manual smoke test on macOS with my local combined-fixes build: same six numbers returned for a small test library before and after the change. The crash repro is on mobile with 75+ favourites; I don't have a populated phone library at hand to reproduce that side, but the memory accounting above is mechanical — every `findAll` that loaded a row to drop later is now a `count`.

## Files

```
lib/modules/more/statistics/statistics_provider.dart | 77 ++++++++++++++++++--------
1 file changed, 52 insertions(+), 25 deletions(-)
```

Single file, no schema changes, no dependency changes.

## Notes

- This is one piece of the larger memory picture (#609 etc.). The reader path already has a bounded `ChapterPreloadManager` so it isn't a hot spot. Library cover image cache + thumbnail decode resolution are the next places worth auditing for memory wins; happy to send those as separate PRs once confirmed.
- The `idIsNotNull()` clauses dropped from the original code were no-ops — Isar IDs are always non-null on returned rows by construction.

