### PR TITLE
perf(library): decode covers at thumbnail resolution to cut image-cache RAM (refs #609)

### DIFF
--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -7,7 +7,7 @@ import 'package:mangayomi/modules/library/providers/library_state_provider.dart'
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/library/widgets/continue_reader_button.dart';
 import 'package:mangayomi/modules/manga/detail/providers/state_providers.dart';
-import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
+import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/constant.dart';
 import 'package:mangayomi/utils/headers.dart';
@@ -77,7 +77,7 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                     image: entry.customCoverImage != null
                         ? MemoryImage(entry.customCoverImage as Uint8List)
                               as ImageProvider
-                        : CustomExtendedNetworkImageProvider(
+                        : coverProvider(
                             toImgUrl(
                               entry.customCoverFromTracker ??
                                   entry.imageUrl ??

--- a/lib/modules/library/widgets/library_listview_widget.dart
+++ b/lib/modules/library/widgets/library_listview_widget.dart
@@ -7,7 +7,7 @@ import 'package:mangayomi/modules/library/providers/library_state_provider.dart'
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/library/widgets/continue_reader_button.dart';
 import 'package:mangayomi/modules/manga/detail/providers/state_providers.dart';
-import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
+import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/constant.dart';
 import 'package:mangayomi/utils/headers.dart';
@@ -127,7 +127,7 @@ class LibraryListViewWidget extends StatelessWidget {
                                                       as Uint8List,
                                                 )
                                                 as ImageProvider
-                                          : CustomExtendedNetworkImageProvider(
+                                          : coverProvider(
                                               toImgUrl(
                                                 entry.customCoverFromTracker ??
                                                     entry.imageUrl!,

--- a/lib/modules/widgets/manga_image_card_widget.dart
+++ b/lib/modules/widgets/manga_image_card_widget.dart
@@ -9,7 +9,7 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/modules/manga/detail/manga_detail_main.dart';
-import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
+import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/constant.dart';
@@ -46,7 +46,7 @@ class MangaImageCardWidget extends ConsumerWidget {
       image: hasData && libraryManga!.customCoverImage != null
           ? MemoryImage(libraryManga!.customCoverImage as Uint8List)
                 as ImageProvider
-          : CustomExtendedNetworkImageProvider(
+          : coverProvider(
               toImgUrl(
                 hasData
                     ? libraryManga!.customCoverFromTracker ??
@@ -61,7 +61,6 @@ class MangaImageCardWidget extends ConsumerWidget {
                   sourceId: source.id,
                 ),
               ),
-              cache: true,
               cacheMaxAge: const Duration(days: 7),
             ),
       onTap: () => pushToMangaReaderDetail(
@@ -151,7 +150,7 @@ class MangaImageCardListTileWidget extends ConsumerWidget {
     final image = hasData && libraryManga!.customCoverImage != null
         ? MemoryImage(libraryManga!.customCoverImage as Uint8List)
               as ImageProvider
-        : CustomExtendedNetworkImageProvider(
+        : coverProvider(
             toImgUrl(
               hasData
                   ? libraryManga!.customCoverFromTracker ??

--- a/lib/utils/cached_network.dart
+++ b/lib/utils/cached_network.dart
@@ -2,6 +2,47 @@ import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
 import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
 
+/// Default upper bound on the encoded byte size of a thumbnail-sized cover
+/// after `ExtendedResizeImage` resamples. 200 KB roughly maps to a 400x600
+/// JPEG / WebP — sharp enough at typical grid / list display sizes on
+/// high-DPR screens, while keeping the *decoded* RAM footprint small (the
+/// resampled image goes into Flutter's `imageCache` decoded, where every
+/// saved KB matters).
+const int _coverMaxBytes = 200 << 10;
+
+/// Returns an `ImageProvider` for a manga / anime cover URL that decodes at
+/// thumbnail resolution rather than the source resolution.
+///
+/// Source covers are commonly 720x1080 or larger (~3 MB decoded RGBA per
+/// cover). When used directly in a library grid or list, every visible
+/// thumbnail fills `imageCache` with a 3 MB blob even though it renders at
+/// ~150x220 logical pixels. Wrapping the provider in `ExtendedResizeImage`
+/// instructs the decoder to resample to a much smaller bitmap before it
+/// hits the cache, so the same in-memory budget holds far more thumbnails
+/// and scrolling stops thrashing.
+///
+/// Use this for thumbnail call sites (library grid / list, browse search
+/// cards, tracker results, calendar, etc.). Do *not* use it for large hero
+/// covers (manga detail page) or for reader pages, which need full
+/// resolution.
+ImageProvider coverProvider(
+  String url, {
+  Map<String, String>? headers,
+  int maxBytes = _coverMaxBytes,
+  bool cache = true,
+  Duration? cacheMaxAge,
+}) {
+  return ExtendedResizeImage(
+    CustomExtendedNetworkImageProvider(
+      url,
+      headers: headers,
+      cache: cache,
+      cacheMaxAge: cacheMaxAge,
+    ),
+    maxBytes: maxBytes,
+  );
+}
+
 Widget cachedNetworkImage({
   Map<String, String>? headers,
   required String imageUrl,


### PR DESCRIPTION
## Summary

Refs #609 (high RAM with stutters). Decode library / browse covers at thumbnail resolution instead of source resolution. Same pattern Mangayomi already uses for History thumbnails (`cachedCompressedNetworkImage`), generalised into a reusable helper and applied to the three high-traffic thumbnail surfaces.

## Why

Manga / anime covers from sources are typically **720×1080 or larger** — that's `720 × 1080 × 4 = ~3 MB` decoded RGBA per cover. The library grid, library list, and browse / search card widgets render those covers at roughly **150×220 logical pixels**, but every cover decoded to its full source resolution and that decoded bitmap landed in Flutter's `imageCache`.

For a library grid scrolled aggressively with ~30–50 covers in flight:

```
50 covers × 720 × 1080 × 4 bytes ≈ 150 MB decoded peak
```

That overflows Flutter's default 100 MB `imageCache.maximumSizeBytes`, and the engine starts evicting + re-decoding aggressively. Exact symptom in #609 (stutters during fast scroll + elevated RAM).

The encoded-bytes LRU in `CustomExtendedNetworkImageProvider` (50 MB) avoids re-fetching from disk, but each cover gets re-decoded at full resolution every time it's restored.

## What

### 1. New helper: `coverProvider()` in `lib/utils/cached_network.dart`

```dart
/// 200 KB encoded — roughly 400×600 JPEG / WebP, sharp at typical thumbnail
/// display sizes on high-DPR screens. Resampled before it hits imageCache,
/// so every saved KB compounds across the cache.
const int _coverMaxBytes = 200 << 10;

ImageProvider coverProvider(
  String url, {
  Map<String, String>? headers,
  int maxBytes = _coverMaxBytes,
  bool cache = true,
  Duration? cacheMaxAge,
}) {
  return ExtendedResizeImage(
    CustomExtendedNetworkImageProvider(
      url,
      headers: headers,
      cache: cache,
      cacheMaxAge: cacheMaxAge,
    ),
    maxBytes: maxBytes,
  );
}
```

Same pattern as the pre-existing `cachedCompressedNetworkImage` (used for History thumbnails). Pass-through for `cache` / `cacheMaxAge` so the underlying disk-cache behaviour is preserved per call site.

### 2. Three thumbnail call sites swapped

| File | Surface |
|---|---|
| `lib/modules/library/widgets/library_gridview_widget.dart` | Library grid |
| `lib/modules/library/widgets/library_listview_widget.dart` | Library list |
| `lib/modules/widgets/manga_image_card_widget.dart` | Browse / search results (both `MangaImageCardWidget` and `MangaImageCardListTileWidget`) |

Each is a one-liner: `image: CustomExtendedNetworkImageProvider(...)` becomes `image: coverProvider(...)`. The unused direct import is replaced with the helper's import.

## Memory math after fix

```
50 thumbnail covers × 400 × 600 × 4 ≈ 46 MB decoded peak
```

Comfortably under the 100 MB cache cap with breathing room — no more evict-thrash during scrolls. Combined with #727 (which lowers the cap on mobile to 64 MB), this gives constrained-heap users the headroom they were missing.

## Files

```
lib/utils/cached_network.dart                            | 41 ++++++++++++++++++++++
lib/modules/library/widgets/library_gridview_widget.dart |  4 +--
lib/modules/library/widgets/library_listview_widget.dart |  4 +--
lib/modules/widgets/manga_image_card_widget.dart         |  7 ++--
4 files changed, 48 insertions(+), 8 deletions(-)
```

## What this PR explicitly does NOT change

| Surface | Why kept on full-resolution provider |
|---|---|
| Manga / anime detail page hero cover | Large display, source resolution is appropriate |
| Reader pages | Already memory-managed by `ChapterPreloadManager`, and full resolution is needed for actual reading |
| Tracker / calendar / recommendation thumbnails | Lower traffic. Easy to extend in a follow-up if anyone asks; kept narrow here for reviewability. |
| `cachedNetworkImage()` helper | Untouched — used by various non-thumbnail surfaces |

## Risk

- **Visual quality:** 200 KB encoded thumbnails are sharp at the displayed scale (~150×220 logical px on 3× DPR ≈ 450×660 actual pixels — within the resampled output range). If anyone notices fuzz, bumping `_coverMaxBytes` is a one-character change.
- **Cache behaviour:** unchanged. Disk caching, encoded-bytes LRU, and `cacheMaxAge` semantics are passed through.
- **API surface:** one new exported function. No breaking changes.

## Verified

- `flutter analyze` clean on all four touched files
- `flutter build macos --release` succeeds
- Smoke-tested on macOS with my local combined-fixes build: library grid, library list, and browse card all render identical-looking covers at thumbnail size; no visible quality regression at the displayed scale.

## Notes

- This is a follow-up to #727, which capped the decoded `imageCache` budget. That PR sets a ceiling; this one reduces what every individual cover spends, so the same budget holds many more thumbnails. They compose well; either alone helps; both together is the proper fix for #609.
- The pre-existing `cachedCompressedNetworkImage` in this same file uses `maxBytes: 5 << 10` (5 KB) for History thumbnails — that's intentional for that screen's much smaller display size. 200 KB here is a reasonable middle ground for grid / list cover thumbnails.

