### PR TITLE
fix(m3u8): add missing / separator in segment and key URI construction

### DIFF
--- a/lib/services/download_manager/m3u8/m3u8_downloader.dart
+++ b/lib/services/download_manager/m3u8/m3u8_downloader.dart
@@ -278,7 +278,7 @@ class M3u8Downloader {
       index++;
       final tsUrl = line.startsWith('http')
           ? line
-          : '$host${line.replaceFirst("/", "")}';
+          : '$host/${line.replaceFirst("/", "")}';
       tsList.add(TsInfo('TS_$index', tsUrl));
     }
     return tsList;
@@ -318,7 +318,7 @@ class M3u8Downloader {
 
     String? uri = match.group(1);
     if (uri != null && !uri.contains('http')) {
-      uri = '$host$uri';
+      uri = '$host/${uri.replaceFirst("/", "")}';
     }
 
     final ivStr = match.group(2);


### PR DESCRIPTION
## Problem

Two lines in `_parseTsList` and `_extractKeyAttributes` were building URLs by concatenating `$host` directly with the path, missing the `/` separator:

```dart
// BEFORE (buggy) - produces: https://host.compath/to/segment
final tsUrl = line.startsWith("http") ? line : "$host${line.replaceFirst("/", "")}";

// BEFORE (buggy) - produces: https://host.compath/to/key
uri = "$host$uri";
```

This causes segment and AES-128 key requests to hit the wrong URL path, resulting in Cloudflare challenges instead of the actual content.

## Fix

Add the missing `/` separator (matching the pattern already correct in `voe_extractor.dart`):

```dart
// AFTER (fixed)
final tsUrl = line.startsWith("http") ? line : "$host/${line.replaceFirst("/", "")}";

// AFTER (fixed)
uri = "$host/${uri.replaceFirst("/", "")}";
```

## Impact

Fixes HLS downloads (both plain and AES-128 encrypted) where segment URLs are relative paths. Without this fix, segments hit an incorrect path that is Cloudflare-protected, making all such downloads fail silently.