### PR TITLE
Fix: reader no longer jumps to duplicate scanlator chapters

### DIFF
--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -130,7 +130,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
       },
       child: chapters.when(
         data: (_) {
-          List<Chapter> chapters = widget.manga!.getFilteredChapterList();
+          List<Chapter> chapters = widget.manga!.getSortedFilteredChapters();
           ref.read(chaptersListttStateProvider.notifier).set(chapters);
           return _buildWidget(chapters: chapters);
         },
@@ -373,7 +373,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                               },
                               onSelected: (value) {
                                 final chapters = widget.manga!
-                                    .getFilteredChapterList();
+                                    .getSortedFilteredChapters();
                                 if (value == 0 ||
                                     value == 1 ||
                                     value == 2 ||
@@ -431,7 +431,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                 } else if (value == 4) {
                                   final List<Chapter> unreadChapters = widget
                                       .manga!
-                                      .getFilteredChapterList()
+                                      .getSortedFilteredChapters()
                                       .where(
                                         (element) => !(element.isRead ?? false),
                                       )
@@ -459,7 +459,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                 } else if (value == 5) {
                                   final List<Chapter> allChapters = widget
                                       .manga!
-                                      .getFilteredChapterList();
+                                      .getSortedFilteredChapters();
                                   for (var chapter in allChapters) {
                                     final entry = isar.downloads
                                         .filter()

--- a/lib/modules/manga/reader/widgets/btn_chapter_list_dialog.dart
+++ b/lib/modules/manga/reader/widgets/btn_chapter_list_dialog.dart
@@ -109,7 +109,8 @@ class ChapterListWidget extends StatefulWidget {
 
 class _ChapterListWidgetState extends State<ChapterListWidget> {
   final controller = ScrollController();
-  late final chapterList = widget.chapter.manga.value!.getFilteredChapterList();
+  late final chapterList = widget.chapter.manga.value!
+      .getSortedFilteredChapters();
   late final currentChapIndex = chapterList.indexWhere(
     (element) =>
         element.name == widget.chapter.name &&

--- a/lib/utils/extensions/manga_extensions.dart
+++ b/lib/utils/extensions/manga_extensions.dart
@@ -7,8 +7,10 @@ import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/utils/chapter_recognition.dart';
 
 extension MangaExtensions on Manga {
-  // ── For the READER: always ascending story order, filters applied ──────────
-  List<Chapter> getChapterListForReading() {
+  /// Filtered chapters respecting the user's active filters (unread,
+  /// bookmarked, downloaded, scanlator). Sorted by chapter number ascending.
+  /// Base list — no user-chosen sort, no deduplication.
+  List<Chapter> getFilteredChapters() {
     final settings = isar.settings.getSync(227)!;
 
     final filterUnread =
@@ -84,8 +86,9 @@ extension MangaExtensions on Manga {
         .toList();
   }
 
-  // ── For the UI LIST: filters + user-chosen sort + reverse ─────────────────
-  List<Chapter> getFilteredChapterList() {
+  /// Filtered chapters for display in the chapter list UI: same filters as
+  /// [getFilteredChapters] with the user's chosen sort order and direction applied.
+  List<Chapter> getSortedFilteredChapters() {
     final settings = isar.settings.getSync(227)!;
 
     final sortChapterEntry =
@@ -94,8 +97,8 @@ extension MangaExtensions on Manga {
     final sortIndex = sortChapterEntry.index!;
     final reverse = sortChapterEntry.reverse!;
 
-    // Start from the reading list so filter logic lives in one place.
-    List<Chapter> list = getChapterListForReading();
+    // Build on getFilteredChapters so filter logic lives in one place.
+    List<Chapter> list = getFilteredChapters();
 
     switch (sortIndex) {
       case 0: // by scanlator, then chapter number
@@ -131,10 +134,28 @@ extension MangaExtensions on Manga {
         break;
       case 1:
       default:
-        // getChapterListForReading already sorted by chapter number; nothing to do.
+        // getFilteredChapters already sorted by chapter number; nothing to do.
         break;
     }
 
     return reverse ? list : list.reversed.toList();
+  }
+
+  /// Filtered chapters ready for sequential reading: same filters as
+  /// [getFilteredChapters] but with duplicate chapter numbers collapsed to a
+  /// single entry so the reader advances to the next story chapter rather than
+  /// another scanlator's copy of the same one.
+  List<Chapter> getChapterListForReading() {
+    final list = getFilteredChapters();
+    final mangaTitle = name ?? '';
+    final recognition = ChapterRecognition();
+    final seen = <int>{};
+    return list
+        .where(
+          (c) => seen.add(
+            recognition.parseChapterNumber(mangaTitle, c.name ?? ''),
+          ),
+        )
+        .toList();
   }
 }


### PR DESCRIPTION
### Problem

When a manga has the same chapter number from multiple scanlators (e.g. ch.1 from scanlator A and B) and no scanlator filter is active, finishing ch.1 (A) in the reader would navigate to ch.1 (B) instead of ch.2.

### Solution

Introduced a dedicated getChapterListForReading() method that deduplicates chapters by chapter number before handing the list to the reader. For each duplicate number, the first occurrence in ascending order is kept. The display layer is completely untouched.

### Method rename

The existing methods were renamed to better reflect what they actually do:

| Old name                    | New name                     | Used by                |
|-----------------------------|------------------------------|------------------------|
| getChapterListForReading() | getFilteredChapters() | Base for the two below |
| getFilteredChapterList() | getSortedFilteredChapters() | Chapter list UI |
| (new) | getChapterListForReading() | Reader navigation |

### What is unaffected

- The chapter list UI still shows all scanlator duplicates
- All filters, sorting, and display badges work exactly as before
- Users who configure the scanlator filter see no change in behaviour