### PR TITLE
Recognize "S<n>" as a season prefix

### DIFF
--- a/lib/utils/chapter_recognition.dart
+++ b/lib/utils/chapter_recognition.dart
@@ -4,7 +4,7 @@ class ChapterRecognition {
   );
   static final _unwantedWhiteSpace = RegExp(r"\s(?=extra|special|omake)");
   static final _seasonKeyword = RegExp(
-    r"\b(?:staffel|season|saison|temporada)\s*([0-9]+)",
+    r"\b(?:staffel|season|saison|temporada|s)\s*([0-9]+)",
   );
   static final _episodeKeyword = RegExp(
     r"\b(?:folge|episode|ep\.?)\s*([0-9]+(?:\.[0-9]+)?)",


### PR DESCRIPTION
The season keyword regex only matched full words (season, staffel, saison, temporada) but not the common abbreviation "S". This caused "S1 - Episode 28" and "S3 - Episode 28" to both parse as episode 28 with no season context.

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/e7f8ef9a-52c1-44b7-8552-6ab2647035cf" />

Added "s" as the last alternative in `_seasonKeyword` so that "S1E28", "S1 - Episode 28" etc. correctly extract the season and produce distinct sort keys (season * 100000 + episode). Placement last in the alternation ensures full words like "season" and "staffel" are still matched in preference to the bare abbreviation.

`_unwanted` already included "s" for stripping purposes, so this change closes that inconsistency in the extraction side.