### PR TITLE
fix bug

### DIFF
--- a/lib/modules/library/widgets/library_entry_utils.dart
+++ b/lib/modules/library/widgets/library_entry_utils.dart
@@ -41,7 +41,7 @@ ImageProvider resolveCoverImage(Manga entry, WidgetRef ref) {
 void handleLongOrSecondaryTap(bool isLongPressed, WidgetRef ref, Manga entry) {
   ref.read(mangasListStateProvider.notifier).update(entry);
   if (!isLongPressed) {
-    ref.read(isLongPressedStateProvider.notifier).update(isLongPressed);
+    ref.read(isLongPressedStateProvider.notifier).update(!isLongPressed);
   }
 }
 


### PR DESCRIPTION
bottom_select_bar was not appearing, when secondary or long pressing a manga card.

This bug was introduced with commit 116ade1bb83735255111c52f5334b9f79686621a