### PR TITLE
Fix Flutter Framework Warning

### DIFF
--- a/lib/modules/manga/detail/widgets/chapter_list_tile_widget.dart
+++ b/lib/modules/manga/detail/widgets/chapter_list_tile_widget.dart
@@ -81,10 +81,10 @@ class ChapterListTileWidget extends ConsumerWidget {
           color: Colors.white,
         ),
       ),
-      child: Container(
+      child: Material(
         color: chapterList.contains(chapter)
             ? context.primaryColor.withValues(alpha: 0.4)
-            : null,
+            : Colors.transparent,
         child: GestureDetector(
           onLongPress: () => _handleInteraction(ref),
           onSecondaryTap: () => _handleInteraction(ref),

--- a/lib/modules/widgets/custom_draggable_tabbar.dart
+++ b/lib/modules/widgets/custom_draggable_tabbar.dart
@@ -125,79 +125,81 @@ Future<void> customDraggableTabBar({
                 : 0;
             return Scaffold(
               backgroundColor: Platform.isLinux ? null : Colors.transparent,
-              body: Container(
+              body: SizedBox(
                 width: context.width(1) - width,
-                decoration: BoxDecoration(
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(20),
-                    topRight: Radius.circular(20),
-                  ),
+                child: Material(
                   color: Theme.of(context).scaffoldBackgroundColor,
-                ),
-                child: DefaultTabController(
-                  length: tabs.length,
-                  child: Column(
-                    children: [
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.end,
-                        children: [
-                          Flexible(
-                            flex: 9,
-                            child: TabBar(
-                              unselectedLabelStyle: const TextStyle(
-                                fontWeight: FontWeight.w500,
-                              ),
-                              labelStyle: const TextStyle(
-                                fontWeight: FontWeight.bold,
-                              ),
-                              dividerColor: context.isLight
-                                  ? Colors.black
-                                  : Colors.grey,
-                              dividerHeight: 0.4,
-                              controller: tabBarController,
-                              tabs: tabs,
-                            ),
-                          ),
-                          if (moreWidget != null)
+                  shape: const RoundedRectangleBorder(
+                    borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(20),
+                      topRight: Radius.circular(20),
+                    ),
+                  ),
+                  child: DefaultTabController(
+                    length: tabs.length,
+                    child: Column(
+                      children: [
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
                             Flexible(
-                              flex: 1,
-                              child: Column(
-                                children: [
-                                  moreWidget,
-                                  const SizedBox(height: 2),
-                                  Row(
-                                    children: [
-                                      Flexible(
-                                        child: Container(
-                                          color: context.isLight
-                                              ? Colors.black
-                                              : Colors.grey,
-                                          height: 0.4,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ],
+                              flex: 9,
+                              child: TabBar(
+                                unselectedLabelStyle: const TextStyle(
+                                  fontWeight: FontWeight.w500,
+                                ),
+                                labelStyle: const TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                ),
+                                dividerColor: context.isLight
+                                    ? Colors.black
+                                    : Colors.grey,
+                                dividerHeight: 0.4,
+                                controller: tabBarController,
+                                tabs: tabs,
                               ),
                             ),
-                        ],
-                      ),
-                      Flexible(
-                        child: TabBarView(
-                          controller: tabBarController,
-                          children: children
-                              .map(
-                                (e) => SingleChildScrollView(
-                                  child: MeasureWidgetSize(
-                                    onCalculateSize: (_) => refresh(),
-                                    child: e,
-                                  ),
+                            if (moreWidget != null)
+                              Flexible(
+                                flex: 1,
+                                child: Column(
+                                  children: [
+                                    moreWidget,
+                                    const SizedBox(height: 2),
+                                    Row(
+                                      children: [
+                                        Flexible(
+                                          child: Container(
+                                            color: context.isLight
+                                                ? Colors.black
+                                                : Colors.grey,
+                                            height: 0.4,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ],
                                 ),
-                              )
-                              .toList(),
+                              ),
+                          ],
                         ),
-                      ),
-                    ],
+                        Flexible(
+                          child: TabBarView(
+                            controller: tabBarController,
+                            children: children
+                                .map(
+                                  (e) => SingleChildScrollView(
+                                    child: MeasureWidgetSize(
+                                      onCalculateSize: (_) => refresh(),
+                                      child: e,
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
The change in `chapter_list_tile_widget.dart` fixes this:

```
════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════
```

It happens when long- or second pressing a chapter in the manga detail view.

The change in `custom_draggable_tabbar.dart` fixes this:

```
════════ Exception caught by Flutter framework ═════════════════════════════════
The following assertion was thrown:
ListTile background color or ink splashes may be invisible.
The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.
To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate DecoratedBox.

ListTile: ListTile
    dense: true
    selectedColor: Color(alpha: 0.0000, red: 0.0000, green: 0.0000, blue: 0.0000, colorSpace: ColorSpace.sRGB)
    onTap: Closure: () => void from Function '_handleValueChange@3478134056':.
DecoratedBox: DecoratedBox
    bg: BoxDecoration(color: Color(alpha: 1.0000, red: 0.9539, green: 0.8948, blue: 0.9045, colorSpace: ColorSpace.sRGB), borderRadius: BorderRadius.only(topLeft: Radius.circular(20.0), topRight: Radius.circular(20.0)))
        color: Color(alpha: 1.0000, red: 0.9539, green: 0.8948, blue: 0.9045, colorSpace: ColorSpace.sRGB)
        borderRadius: BorderRadius.only(topLeft: Radius.circular(20.0), topRight: Radius.circular(20.0))
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════

════════ Exception caught by Flutter framework ═════════════════════════════════
ListTile background color or ink splashes may be invisible.
════════════════════════════════════════════════════════════════════════════════
```

It happens when opening the filter menu inside manga detail view, on every tab change.