### PR TITLE
fix: delete downloaded chapters from detail view & fix library dialog bugs

### DIFF
--- a/lib/modules/library/widgets/library_dialogs.dart
+++ b/lib/modules/library/widgets/library_dialogs.dart
@@ -82,8 +82,12 @@ void showDeleteMangaDialog({
                             isar.writeTxnSync(() {
                               for (var manga in mangasList) {
                                 if (manga.isLocalArchive ?? false) {
+                                  // Local archives have no remote source, so removing from the
+                                  // library means wiping every related Isar record entirely.
                                   _removeImport(ref, manga);
                                 } else {
+                                  // Regular manga: just unfavourite so it disappears from the
+                                  // library without losing chapter/history data.
                                   manga.favorite = false;
                                   manga.updatedAt =
                                       DateTime.now().millisecondsSinceEpoch;
@@ -97,6 +101,9 @@ void showDeleteMangaDialog({
                             for (var manga in mangasList) {
                               String mangaDirectory = "";
                               if (manga.isLocalArchive ?? false) {
+                                // For local archives the archive file IS the chapter — there is
+                                // nothing to re-download. So we delete the physical files and
+                                // remove all Isar records, mirroring a full library removal.
                                 mangaDirectory = _deleteImport(
                                   manga,
                                   mangaDirectory,
@@ -105,11 +112,16 @@ void showDeleteMangaDialog({
                                   _removeImport(ref, manga);
                                 });
                               } else {
+                                // Regular manga: delete downloaded files and their download
+                                // records, but leave the manga and chapter metadata intact so
+                                // the user can re-download later.
                                 mangaDirectory = await _deleteDownload(
                                   manga,
                                   mangaDirectory,
                                 );
                               }
+                              // If the manga's base directory is now empty,
+                              // remove it too so we don't leave orphaned folders on disk.
                               if (mangaDirectory.isNotEmpty) {
                                 final path = Directory(mangaDirectory);
                                 if (path.existsSync() &&
@@ -142,6 +154,9 @@ void showDeleteMangaDialog({
   );
 }
 
+/// Removes a local-archive manga and all related records from Isar:
+/// history, updates, downloads, chapters, and the manga itself.
+/// Also notifies the sync provider so the removal is propagated.
 void _removeImport(WidgetRef ref, Manga manga) {
   final provider = ref.read(synchingProvider(syncId: 1).notifier);
   final histories = isar.historys
@@ -172,6 +187,9 @@ void _removeImport(WidgetRef ref, Manga manga) {
   provider.addChangedPart(ActionType.removeItem, manga.id, "{}", false);
 }
 
+/// Deletes the physical archive files (zip/cbz/mp4/epub) for a local-archive
+/// manga from disk. Returns the parent directory path so the caller can clean
+/// up the now-empty folder afterwards.
 String _deleteImport(Manga manga, String mangaDirectory) {
   for (var chapter in manga.chapters) {
     final path = chapter.archivePath;

--- a/lib/modules/library/widgets/library_dialogs.dart
+++ b/lib/modules/library/widgets/library_dialogs.dart
@@ -95,28 +95,26 @@ void showDeleteMangaDialog({
                           // Downloaded Chapters
                           if (deleteDownloads) {
                             for (var manga in mangasList) {
-                              if (!(manga.isLocalArchive ?? false)) {
-                                String mangaDirectory = "";
-                                if (manga.isLocalArchive ?? false) {
-                                  mangaDirectory = _deleteImport(
-                                    manga,
-                                    mangaDirectory,
-                                  );
-                                  isar.writeTxnSync(() {
-                                    _removeImport(ref, manga);
-                                  });
-                                } else {
-                                  mangaDirectory = await _deleteDownload(
-                                    manga,
-                                    mangaDirectory,
-                                  );
-                                }
-                                if (mangaDirectory.isNotEmpty) {
-                                  final path = Directory(mangaDirectory);
-                                  if (path.existsSync() &&
-                                      path.listSync().isEmpty) {
-                                    path.deleteSync(recursive: true);
-                                  }
+                              String mangaDirectory = "";
+                              if (manga.isLocalArchive ?? false) {
+                                mangaDirectory = _deleteImport(
+                                  manga,
+                                  mangaDirectory,
+                                );
+                                isar.writeTxnSync(() {
+                                  _removeImport(ref, manga);
+                                });
+                              } else {
+                                mangaDirectory = await _deleteDownload(
+                                  manga,
+                                  mangaDirectory,
+                                );
+                              }
+                              if (mangaDirectory.isNotEmpty) {
+                                final path = Directory(mangaDirectory);
+                                if (path.existsSync() &&
+                                    path.listSync().isEmpty) {
+                                  path.deleteSync(recursive: true);
                                 }
                               }
                             }

--- a/lib/modules/library/widgets/library_dialogs.dart
+++ b/lib/modules/library/widgets/library_dialogs.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isar_community/isar.dart';
@@ -28,8 +27,8 @@ void showDeleteMangaDialog({
   required WidgetRef ref,
   required ItemType itemType,
 }) {
-  Set<int> fromLibList = {};
-  Set<int> downloadedChapsList = {};
+  bool deleteFromLib = false;
+  bool deleteDownloads = false;
   showDialog(
     context: context,
     builder: (context) {
@@ -52,31 +51,17 @@ void showDeleteMangaDialog({
                     children: [
                       ListTileChapterFilter(
                         label: l10n.from_library,
-                        onTap: () {
-                          setState(() {
-                            if (setEquals(fromLibList, mangaIdsList)) {
-                              fromLibList = {};
-                            } else {
-                              fromLibList = {...mangaIdsList};
-                            }
-                          });
-                        },
-                        type: fromLibList.isNotEmpty ? 1 : 0,
+                        onTap: () =>
+                            setState(() => deleteFromLib = !deleteFromLib),
+                        type: deleteFromLib ? 1 : 0,
                       ),
                       ListTileChapterFilter(
                         label: itemType != ItemType.anime
                             ? l10n.downloaded_chapters
                             : l10n.downloaded_episodes,
-                        onTap: () {
-                          setState(() {
-                            if (setEquals(downloadedChapsList, mangaIdsList)) {
-                              downloadedChapsList = {};
-                            } else {
-                              downloadedChapsList = {...mangaIdsList};
-                            }
-                          });
-                        },
-                        type: downloadedChapsList.isNotEmpty ? 1 : 0,
+                        onTap: () =>
+                            setState(() => deleteDownloads = !deleteDownloads),
+                        type: deleteDownloads ? 1 : 0,
                       ),
                     ],
                   ),
@@ -93,7 +78,7 @@ void showDeleteMangaDialog({
                       TextButton(
                         onPressed: () async {
                           // From Library
-                          if (fromLibList.isNotEmpty) {
+                          if (deleteFromLib) {
                             isar.writeTxnSync(() {
                               for (var manga in mangasList) {
                                 if (manga.isLocalArchive ?? false) {
@@ -108,7 +93,7 @@ void showDeleteMangaDialog({
                             });
                           }
                           // Downloaded Chapters
-                          if (downloadedChapsList.isNotEmpty) {
+                          if (deleteDownloads) {
                             for (var manga in mangasList) {
                               if (!(manga.isLocalArchive ?? false)) {
                                 String mangaDirectory = "";

--- a/lib/modules/library/widgets/library_dialogs.dart
+++ b/lib/modules/library/widgets/library_dialogs.dart
@@ -19,7 +19,7 @@ import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
-import 'package:mangayomi/utils/extensions/string_extensions.dart';
+import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
 import 'package:path/path.dart' as p;
 
 /// Shows a dialog for deleting selected manga from library and/or device.
@@ -206,51 +206,19 @@ String _deleteImport(Manga manga, String mangaDirectory) {
   return mangaDirectory;
 }
 
+/// Deletes the downloaded chapter files for a regular (non-local-archive)
+/// manga from disk, then cleans up the corresponding Isar download records.
+/// Returns the manga's base directory path so the caller can remove the
+/// folder if it is left empty.
 Future<String> _deleteDownload(Manga manga, String mangaDirectory) async {
-  final storageProvider = StorageProvider();
   Directory? mangaDir;
-  final idsToDelete = <int>{};
-  final downloadedIds = (await isar.downloads.where().idProperty().findAll())
-      .toSet();
-
-  if (downloadedIds.isEmpty) return mangaDirectory;
-
   for (var chapter in manga.chapters) {
-    if (chapter.id == null || !downloadedIds.contains(chapter.id)) continue;
-
-    mangaDir ??= await storageProvider.getMangaMainDirectory(chapter);
-    final chapterDir = await storageProvider.getMangaChapterDirectory(
-      chapter,
-      mangaMainDirectory: mangaDir,
-    );
-    File? file;
-
-    if (mangaDirectory.isEmpty) mangaDirectory = mangaDir!.path;
-    if (manga.itemType == ItemType.manga) {
-      file = File(p.join(mangaDir!.path, "${chapter.name}.cbz"));
-    } else if (manga.itemType == ItemType.anime) {
-      file = File(
-        p.join(
-          mangaDir!.path,
-          "${chapter.name!.replaceForbiddenCharacters(' ')}.mp4",
-        ),
-      );
+    if (chapter.id == null) continue;
+    await chapter.deleteDownloadedFiles();
+    if (mangaDirectory.isEmpty) {
+      mangaDir ??= await StorageProvider().getMangaMainDirectory(chapter);
+      if (mangaDir != null) mangaDirectory = mangaDir.path;
     }
-
-    try {
-      if (file != null && file.existsSync()) {
-        file.deleteSync();
-      }
-      if (chapterDir!.existsSync()) {
-        chapterDir.deleteSync(recursive: true);
-      }
-    } catch (_) {}
-    idsToDelete.add(chapter.id!);
-  }
-  if (idsToDelete.isNotEmpty) {
-    isar.writeTxnSync(() {
-      isar.downloads.deleteAllSync(idsToDelete.toList());
-    });
   }
   return mangaDirectory;
 }

--- a/lib/modules/library/widgets/library_dialogs.dart
+++ b/lib/modules/library/widgets/library_dialogs.dart
@@ -213,8 +213,14 @@ String _deleteImport(Manga manga, String mangaDirectory) {
 /// folder if it is left empty.
 Future<String> _deleteDownload(Manga manga, String mangaDirectory) async {
   Directory? mangaDir;
+  final downloadedIds = (await isar.downloads.where().idProperty().findAll())
+      .toSet();
+
+  if (downloadedIds.isEmpty) return mangaDirectory;
+
   for (var chapter in manga.chapters) {
-    if (chapter.id == null) continue;
+    if (chapter.id == null || !downloadedIds.contains(chapter.id)) continue;
+
     await chapter.deleteDownloadedFiles();
     if (mangaDirectory.isEmpty) {
       mangaDir ??= await StorageProvider().getMangaMainDirectory(chapter);

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -18,6 +18,7 @@ import 'package:mangayomi/models/track.dart';
 import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/models/track_search.dart';
 import 'package:mangayomi/modules/library/library_screen.dart';
+import 'package:mangayomi/modules/library/providers/library_filter_provider.dart';
 import 'package:mangayomi/modules/library/providers/local_archive.dart';
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/tracker_search_widget.dart';
@@ -807,6 +808,11 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                   chap.isNotEmpty && chap.first.isRead! && getLength1;
               final l10n = l10nLocalizations(context)!;
               final color = Theme.of(context).textTheme.bodyLarge!.color!;
+              final downloadedIds =
+                  ref.watch(downloadedChapterIdsProvider).value ?? <int>{};
+              final isDownloaded = chap
+                  .where((c) => downloadedIds.contains(c.id))
+                  .toSet();
               return BottomSelectBar(
                 isVisible: isLongPressed,
                 actions: [
@@ -910,7 +916,8 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                         ref.read(chaptersListStateProvider.notifier).clear();
                       },
                     ),
-                  if (!isLocalArchive)
+                  // If not local archive and not downloaded, show download button
+                  if (!isLocalArchive && isDownloaded.isEmpty)
                     BottomSelectButton(
                       icon: Icon(Icons.download_outlined, color: color),
                       onPressed: () {
@@ -935,7 +942,8 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                         ref.read(chaptersListStateProvider.notifier).clear();
                       },
                     ),
-                  if (isLocalArchive)
+                  // show delete button if local archive or downloaded
+                  if (isLocalArchive || isDownloaded.isNotEmpty)
                     BottomSelectButton(
                       icon: Icon(Icons.delete_outline_outlined, color: color),
                       onPressed: () {
@@ -962,7 +970,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                           builder: (context) {
                             return AlertDialog(
                               title: Text(l10n.delete_chapters),
-                              content: isLastChapters
+                              content: isLocalArchive && isLastChapters
                                   ? Row(
                                       crossAxisAlignment:
                                           CrossAxisAlignment.start,
@@ -995,14 +1003,19 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                     TextButton(
                                       onPressed: () async {
                                         final navigator = Navigator.of(context);
-                                        await isar.writeTxn(() async {
-                                          final idsToDelete = selectedChapters
-                                              .map((c) => c.id!)
-                                              .toList();
-                                          await isar.chapters.deleteAll(
-                                            idsToDelete,
-                                          );
-                                        });
+                                        if (isLocalArchive) {
+                                          await isar.writeTxn(() async {
+                                            final idsToDelete = selectedChapters
+                                                .map((c) => c.id!)
+                                                .toList();
+                                            await isar.chapters.deleteAll(
+                                              idsToDelete,
+                                            );
+                                          });
+                                        }
+                                        for (final chapter in isDownloaded) {
+                                          chapter.deleteDownloadedFiles();
+                                        }
                                         if (!mounted) return;
                                         ref
                                             .read(
@@ -1017,7 +1030,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                             )
                                             .clear();
                                         navigator.pop();
-                                        if (isLastChapters) {
+                                        if (isLocalArchive && isLastChapters) {
                                           navigator.pop();
                                           Future.delayed(
                                             const Duration(milliseconds: 350),

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -1015,7 +1015,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                           });
                                         }
                                         for (final chapter in isDownloaded) {
-                                          chapter.deleteDownloadedFiles();
+                                          await chapter.deleteDownloadedFiles();
                                         }
                                         if (!mounted) return;
                                         ref

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -809,7 +809,8 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
               final l10n = l10nLocalizations(context)!;
               final color = Theme.of(context).textTheme.bodyLarge!.color!;
               final downloadedIds =
-                  ref.watch(downloadedChapterIdsProvider).value ?? <int>{};
+                  ref.watch(downloadedChapterIdsProvider).asData?.value ??
+                  const <int>{};
               final isDownloaded = chap
                   .where((c) => downloadedIds.contains(c.id))
                   .toSet();

--- a/lib/modules/manga/download/download_page_widget.dart
+++ b/lib/modules/manga/download/download_page_widget.dart
@@ -64,43 +64,6 @@ class ChapterPageDownload extends ConsumerWidget {
     }
   }
 
-  void _deleteFile(int downloadId) async {
-    final storageProvider = StorageProvider();
-    final mangaDir = await storageProvider.getMangaMainDirectory(chapter);
-    final path = await storageProvider.getMangaChapterDirectory(
-      chapter,
-      mangaMainDirectory: mangaDir,
-    );
-
-    try {
-      try {
-        final cbzFile = File(p.join(mangaDir!.path, "${chapter.name}.cbz"));
-        if (cbzFile.existsSync()) {
-          cbzFile.deleteSync();
-        }
-      } catch (_) {}
-      try {
-        final mp4File = File(
-          p.join(
-            mangaDir!.path,
-            "${chapter.name!.replaceForbiddenCharacters(' ')}.mp4",
-          ),
-        );
-        if (mp4File.existsSync()) {
-          mp4File.deleteSync();
-        }
-      } catch (_) {}
-      try {
-        final htmlFile = File(p.join(mangaDir!.path, "${chapter.name}.html"));
-        if (htmlFile.existsSync()) {
-          htmlFile.deleteSync();
-        }
-      } catch (_) {}
-      path!.deleteSync(recursive: true);
-    } catch (_) {}
-    chapter.cancelDownloads(downloadId);
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = l10nLocalizations(context)!;
@@ -132,7 +95,7 @@ class ChapterPageDownload extends ConsumerWidget {
                         if (value == 0) {
                           _sendFile(context);
                         } else if (value == 1) {
-                          _deleteFile(download.id!);
+                          chapter.deleteDownloadedFiles();
                         }
                       },
                       itemBuilder: (context) => [


### PR DESCRIPTION
## Summary

Three related bug fixes and a refactor, all touching the chapter/manga
deletion flow.

## Changes

### feat: add "delete downloaded chapters" button to chapter detail view
The bottom select bar in the manga detail view only had a download
button for non-local-archive chapters, and a delete button exclusively
for local archives. There was no way to delete already-downloaded
chapters of a regular manga from this screen.

- Show the download button only when none of the selected chapters are
  already downloaded
- Show the delete button when the manga is a local archive OR any of
  the selected chapters are downloaded
- Fix the last-chapter warning and the post-delete back-navigation to
  only trigger for local archives, not for regular downloaded chapters

### fix: delete downloads for local archives in the library delete dialog
The "Downloaded Chapters" deletion block in `showDeleteMangaDialog` had
a redundant outer guard `if (!(manga.isLocalArchive ?? false))` wrapping
an inner if/else that already handled both cases correctly. The outer
guard made the local-archive branch unreachable, so selecting "Downloaded
Chapters" on a local archive silently did nothing. The outer guard is
removed to restore the intended behaviour: for local archives, deleting
"downloaded" files removes the physical archive files and wipes all Isar
records, since there is no remote source to re-download from.

### refactor: replace Set checkbox state with plain bools
`fromLibList` and `downloadedChapsList` in `showDeleteMangaDialog` were
Sets of manga IDs used purely as checkbox state trackers — they were
either empty or a full copy of `mangaIdsList`, and were only ever checked
with `.isNotEmpty`. Replace both with plain `bool` flags and simplify
the toggle handlers. Remove the now-unused `setEquals` import.

### refactor: consolidate chapter file deletion into `deleteDownloadedFiles`
`_deleteFile` in `download_page_widget.dart` and the manual loop in
`_deleteDownload` in `library_dialogs.dart` both duplicated the logic
already present in `Chapter.deleteDownloadedFiles()`: locate the chapter
directory, delete the cbz/mp4/html file variants and the chapter folder,
then cancel the download record in Isar. Replace both with calls to
`deleteDownloadedFiles()` and remove the now-redundant code. Add doc
comments to `_removeImport`, `_deleteImport`, and `_deleteDownload`, and
inline comments to the action block in `showDeleteMangaDialog`.