### PR TITLE
Fix bug: update tracker with latest selected chapter 

### DIFF
--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -23,6 +23,7 @@ import 'package:mangayomi/modules/library/providers/local_archive.dart';
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/tracker_search_widget.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/tracker_widget.dart';
+import 'package:mangayomi/utils/chapter_recognition.dart';
 import 'package:mangayomi/utils/extensions/manga_extensions.dart';
 import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
 import 'package:mangayomi/modules/more/providers/algorithm_weights_state_provider.dart';
@@ -863,18 +864,28 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                       final chapters = ref.watch(chaptersListStateProvider);
                       final List<Chapter> updatedChapters = [];
                       final now = DateTime.now().millisecondsSinceEpoch;
+                      Chapter? highestChapter;
+                      int highestNum = -1;
+                      final recognition = ChapterRecognition();
+                      final mangaTitle = widget.manga!.name ?? '';
                       for (var chapter in chapters) {
                         chapter.isRead = !chapter.isRead!;
-                        if (!chapter.isRead!) {
-                          chapter.lastPageRead = "1";
-                        }
+                        if (!chapter.isRead!) chapter.lastPageRead = "1";
                         chapter.updatedAt = now;
                         chapter.manga.value = widget.manga;
                         updatedChapters.add(chapter);
                         if (chapter.isRead!) {
-                          chapter.updateTrackChapterRead(ref);
+                          final num = recognition.parseEpisodeNumber(
+                            mangaTitle,
+                            chapter.name ?? '',
+                          );
+                          if (num > highestNum) {
+                            highestNum = num;
+                            highestChapter = chapter;
+                          }
                         }
                       }
+                      highestChapter?.updateTrackChapterRead(ref);
                       isar.writeTxnSync(() {
                         isar.chapters.putAllSync(updatedChapters);
                         isar.mangas.putSync(widget.manga!);

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -294,7 +294,7 @@ class _MangaChapterPageGalleryState
 
   /// Guard flag: suppresses [_readProgressListener] during scroll position
   /// adjustment after prepending previous-chapter pages.
-  final bool _isAdjustingScroll = false;
+  final bool _isAdjustingScroll = false; // TODO. The variable is never changed
 
   late int pagePreloadAmount = ref.read(pagePreloadAmountStateProvider);
   late bool _isBookmarked = _readerController.getChapterBookmarked();

--- a/lib/utils/extensions/chapter_extensions.dart
+++ b/lib/utils/extensions/chapter_extensions.dart
@@ -108,7 +108,6 @@ extension ChapterExtension on Chapter {
         .mangaIdEqualTo(manga.id!)
         .findAllSync();
 
-    if (tracks.isEmpty) return;
     for (var track in tracks) {
       final service = isar.trackPreferences
           .filter()


### PR DESCRIPTION
Previously, marking multiple chapters as read triggered updateTrackChapterRead() for every chapter individually.
Because these updates ran concurrently and each read stale tracker state,
the final tracked chapter was nondeterministic (e.g., chapter 8 or 9 instead of 10).

This patch parses the numeric chapter value for each selected chapter,
determines the highest one, and updates the tracker only once using that chapter.