### PR TITLE
add picture in picture + fix clipped player controls

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -39,6 +39,7 @@
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>fetch</string>
 	</array>
 	<key>NSFaceIDUsageDescription</key>

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -826,6 +826,14 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             : "libmpv",
       ),
     );
+    // Picture-in-Picture is implemented natively by the media_kit fork
+    // (VideoOutputPIP) and only exposed on iOS 15+. Enabling auto-PiP makes the
+    // player float into a PiP window when the app is backgrounded instead of
+    // pausing. The call awaits the controller's platform init internally, so
+    // it is safe to fire here without awaiting.
+    if (Platform.isIOS) {
+      _controller.enableAutoPictureInPicture();
+    }
     // If player is being launched the first time,
     // use global "Use Fullscreen" setting.
     // Else (if user already watches an episode and just changes it),
@@ -1555,11 +1563,16 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8),
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 _seekToWidget(),
                 _chapterMarkWidget(),
-                _buildSettingsButtons(context),
+                Expanded(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    reverse: true,
+                    child: _buildSettingsButtons(context),
+                  ),
+                ),
               ],
             ),
           ),
@@ -1814,6 +1827,15 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
                   )
                   .toList(),
         ),
+        if (Platform.isIOS && _controller.isPictureInPictureAvailable())
+          IconButton(
+            tooltip: 'Picture in Picture',
+            icon: const Icon(
+              Icons.picture_in_picture_alt,
+              color: Colors.white,
+            ),
+            onPressed: () => _controller.enterPictureInPicture(),
+          ),
         IconButton(
           icon: const Icon(Icons.fit_screen_outlined, color: Colors.white),
           onPressed: () async {


### PR DESCRIPTION
hey! two small changes to the anime player, both ios-focused.

## picture in picture (ios)
the media_kit fork already ships pip natively (`VideoOutputPIP`), so this is just wiring the existing api into the app, no swift needed:

- enable auto pip in `initState` so the video floats into a small window when you leave the app mid episode instead of just pausing
- add a small pip button to the bottom controls row, gated on `Platform.isIOS && isPictureInPictureAvailable()` so it only shows on ios 15+ and stays hidden on android/desktop (those paths already return false in the plugin)
- add the `audio` background mode in `Info.plist` so playback keeps going while in the pip window

## bottom controls clipping fix
on phones the row of setting icons was getting cut off the right edge once the mpv buttons showed up (the fullscreen toggle was unreachable). wrapped the buttons in a scrollable, right-aligned row so nothing gets clipped.

### notes
- **builds in CI now** — since opening this I compiled it via GitHub Actions: a debug Android APK builds and the app launches on a physical Android TV (combined build with my other open PRs). the clipped-controls fix is in that running build; the iOS PiP path is review-traced (native -> method channel -> dart, safe no-op off iOS 15+) and would want an iOS device run to confirm PiP itself.
- auto pip keeps the pip layer warm every frame, which is the normal cost of instant auto-pip on backgrounding. happy to put it behind a setting instead if you'd prefer.




screenshot on iPhone 14. 
<img width="585" height="1266" alt="IMG_1138" src="https://github.com/user-attachments/assets/327d3dbf-b425-4e44-aaa0-5290c14dca94" />
