### PR TITLE
fix: blank/unresponsive screen on launch (#737) + actionable NFS db error (#652)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -90,35 +90,41 @@ void main(List<String> args) async {
         return true; // handled — prevent app termination
       };
 
-      MediaKit.ensureInitialized();
-      await RustLib.init();
-      await getIsolateService.start();
-      await ffiImageDecoder.start();
-      if (!isMobile) {
-        await windowManager.ensureInitialized();
-        await WindowGeometry.restore();
-      }
-      if (Platform.isWindows) {
-        registerProtocolHandler("mangayomi");
-      }
-      if (!kIsWeb && defaultTargetPlatform == TargetPlatform.windows) {
-        final availableVersion = await WebViewEnvironment.getAvailableVersion();
-        if (availableVersion != null) {
-          final document = await getApplicationDocumentsDirectory();
-          webViewEnvironment = await WebViewEnvironment.create(
-            settings: WebViewEnvironmentSettings(
-              userDataFolder: p.join(document.path, 'flutter_inappwebview'),
-            ),
-          );
-        }
-      }
       final storage = StorageProvider();
-      await storage.requestPermission();
       Object? startupError;
+      // Guard the whole pre-runApp init, not just the database. A failure in
+      // any of these steps (native rust bridge, background isolates, window
+      // manager, WebView env, database) used to escape main() before runApp()
+      // and leave a blank, unresponsive window. Catching here guarantees
+      // runApp() is always reached so the user sees the error instead.
       try {
+        MediaKit.ensureInitialized();
+        await RustLib.init();
+        await getIsolateService.start();
+        await ffiImageDecoder.start();
+        if (!isMobile) {
+          await windowManager.ensureInitialized();
+          await WindowGeometry.restore();
+        }
+        if (Platform.isWindows) {
+          registerProtocolHandler("mangayomi");
+        }
+        if (!kIsWeb && defaultTargetPlatform == TargetPlatform.windows) {
+          final availableVersion =
+              await WebViewEnvironment.getAvailableVersion();
+          if (availableVersion != null) {
+            final document = await getApplicationDocumentsDirectory();
+            webViewEnvironment = await WebViewEnvironment.create(
+              settings: WebViewEnvironmentSettings(
+                userDataFolder: p.join(document.path, 'flutter_inappwebview'),
+              ),
+            );
+          }
+        }
+        await storage.requestPermission();
         isar = await storage.initDB(null, inspector: kDebugMode);
       } catch (e, st) {
-        AppLogger.log('DB init failed: $e\n$st', logLevel: LogLevel.error);
+        AppLogger.log('Startup init failed: $e\n$st', logLevel: LogLevel.error);
         startupError = e;
       }
       runApp(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -147,12 +147,25 @@ class _StartupErrorApp extends StatelessWidget {
   final String error;
   const _StartupErrorApp({required this.error});
 
+  /// True when the database failed to open because its directory lives on an
+  /// NFS-exported (MNT_EXPORTED) filesystem. libmdbx (used by Isar) refuses to
+  /// open there and returns `MdbxError (15): Block device required`. This is a
+  /// libmdbx limitation, not something Mangayomi can work around in-app, so we
+  /// surface the cause + fix instead of just the raw code. See issue #652.
+  bool get _isExportedFsError {
+    final e = error.toLowerCase();
+    return e.contains('mdbxerror') &&
+        (e.contains('block device required') ||
+            e.contains('mdbxerror (15)') ||
+            e.contains('mnt_exported'));
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
         body: Center(
-          child: Padding(
+          child: SingleChildScrollView(
             padding: const EdgeInsets.all(24),
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -164,6 +177,20 @@ class _StartupErrorApp extends StatelessWidget {
                   style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 8),
+                if (_isExportedFsError) ...[
+                  const Text(
+                    "The database can't be opened because its data folder is on "
+                    "a filesystem exported over NFS (MNT_EXPORTED). This is a "
+                    "limitation of the underlying database (libmdbx), not "
+                    "Mangayomi.\n\n"
+                    "To fix it, stop exporting that location over NFS and "
+                    "relaunch. On macOS this usually means removing the entry "
+                    "from /etc/exports and running `sudo nfsd disable`.",
+                    textAlign: TextAlign.center,
+                    style: TextStyle(fontSize: 13),
+                  ),
+                  const SizedBox(height: 12),
+                ],
                 SelectableText(
                   error,
                   style: const TextStyle(fontFamily: 'monospace', fontSize: 12),

--- a/lib/modules/manga/reader/subsampling_scale_image_view/src/ffi_image_decoder.dart
+++ b/lib/modules/manga/reader/subsampling_scale_image_view/src/ffi_image_decoder.dart
@@ -124,7 +124,15 @@ class FfiImageDecoder {
       }
     });
 
-    _sendPort = await completer.future;
+    // Bound the isolate handshake so a failure inside the isolate entry point
+    // (e.g. a missing or mismatched native library) cannot hang the await
+    // forever. start() runs before runApp(), so that hang surfaces as a blank,
+    // unresponsive window rather than an error the user can act on.
+    _sendPort = await completer.future.timeout(
+      const Duration(seconds: 5),
+      onTimeout: () =>
+          throw StateError('FFI image decoder isolate handshake timed out'),
+    );
     _isRunning = true;
   }
 
@@ -502,10 +510,10 @@ class FfiImageDecoder {
   }
 
   Future<void> stop() async {
-    if (!_isRunning) {
-      return;
-    }
-
+    // No `_isRunning` guard: a failed handshake (e.g. the 5s timeout above)
+    // throws before `_isRunning` is set, so this must still tear down the
+    // spawned isolate and ReceivePort instead of leaking them. Every call
+    // below is null-safe, so a no-op stop stays harmless.
     _sendPort?.send('dispose');
     _cIsolate?.kill(priority: Isolate.immediate);
     _receivePort?.close();

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -27,6 +27,8 @@ class StorageProvider {
   StorageProvider._internal();
   factory StorageProvider() => _instance;
 
+  static const _dbName = "mangayomiDb";
+
   Future<bool> requestPermission() async {
     if (!Platform.isAndroid) return true;
     Permission permission = Permission.manageExternalStorage;
@@ -278,35 +280,27 @@ class StorageProvider {
   }
 
   Future<Isar> initDB(String? path, {bool inspector = false}) async {
-    Directory? dir;
-    if (path == null) {
-      dir = await getDatabaseDirectory();
-    } else {
-      dir = Directory(path);
-    }
+    final Directory dir = path == null
+        ? (await getDatabaseDirectory())!
+        : Directory(path);
 
-    final isar = await Isar.open(
-      [
-        MangaSchema,
-        ChangedPartSchema,
-        ChapterSchema,
-        CategorySchema,
-        CustomButtonSchema,
-        UpdateSchema,
-        HistorySchema,
-        DownloadSchema,
-        SourceSchema,
-        SettingsSchema,
-        TrackPreferenceSchema,
-        TrackSchema,
-        SyncPreferenceSchema,
-        SourcePreferenceSchema,
-        SourcePreferenceStringValueSchema,
-      ],
-      directory: dir!.path,
-      name: "mangayomiDb",
-      inspector: inspector,
-    );
+    // Open the database, recovering automatically from a corrupt or
+    // schema-incompatible file. This commonly happens after reinstalling over
+    // an older build: the leftover database can no longer be opened and
+    // Isar.open throws. Before this guard the exception escaped main() ahead of
+    // runApp(), leaving a blank, unresponsive window. We instead archive the
+    // bad database and open a fresh one so the app still launches; the old
+    // files are renamed (not deleted) for manual recovery.
+    Isar isar;
+    try {
+      isar = await _openIsar(dir, inspector);
+    } catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('Isar.open failed, recovering corrupt DB: $e\n$st');
+      }
+      await _backupCorruptDatabase(dir);
+      isar = await _openIsar(dir, inspector);
+    }
     try {
       final settings = await isar.settings.filter().idEqualTo(227).findFirst();
       if (settings == null) {
@@ -382,5 +376,54 @@ end""",
     }
 
     return isar;
+  }
+
+  Future<Isar> _openIsar(Directory dir, bool inspector) {
+    return Isar.open(
+      [
+        MangaSchema,
+        ChangedPartSchema,
+        ChapterSchema,
+        CategorySchema,
+        CustomButtonSchema,
+        UpdateSchema,
+        HistorySchema,
+        DownloadSchema,
+        SourceSchema,
+        SettingsSchema,
+        TrackPreferenceSchema,
+        TrackSchema,
+        SyncPreferenceSchema,
+        SourcePreferenceSchema,
+        SourcePreferenceStringValueSchema,
+      ],
+      directory: dir.path,
+      name: _dbName,
+      inspector: inspector,
+    );
+  }
+
+  /// Moves a corrupt / schema-incompatible database aside so [initDB] can open
+  /// a fresh one. Files are renamed (kept as `.corrupt-<ts>.bak`) rather than
+  /// deleted so the user can recover their data manually. Best-effort: any
+  /// failure here must not block launch, so if a file can't be renamed we fall
+  /// back to deleting it (e.g. a stale lock) and otherwise swallow the error.
+  Future<void> _backupCorruptDatabase(Directory dir) async {
+    final stamp = DateTime.now().millisecondsSinceEpoch;
+    for (final suffix in const ['.isar', '.isar.lock']) {
+      final file = File(path.join(dir.path, '$_dbName$suffix'));
+      try {
+        if (await file.exists()) {
+          await file.rename('${file.path}.corrupt-$stamp.bak');
+        }
+      } catch (e) {
+        if (kDebugMode) {
+          debugPrint('Could not archive corrupt DB file ${file.path}: $e');
+        }
+        try {
+          if (await file.exists()) await file.delete();
+        } catch (_) {}
+      }
+    }
   }
 }

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -420,9 +420,15 @@ end""",
         if (kDebugMode) {
           debugPrint('Could not archive corrupt DB file ${file.path}: $e');
         }
-        try {
-          if (await file.exists()) await file.delete();
-        } catch (_) {}
+        // Fallback delete only ever applies to the disposable lock file — never
+        // the `.isar` data file. A failed rename must not destroy user data
+        // (it stays put, and a still-failing reopen surfaces the error screen
+        // rather than causing irreversible loss).
+        if (suffix == '.isar.lock') {
+          try {
+            if (await file.exists()) await file.delete();
+          } catch (_) {}
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #737. Also improves the macOS/NFS case from #652.

the app could come up to a blank, unresponsive window on launch, often right after reinstalling, and reported on both windows and mac. the common thread: something in the pre-`runApp` init throws (or hangs), so `runApp` is never reached. the engine + native window are already up, so you get a real window with no flutter tree → blank + no input.

there isn't a single cause, so this handles a few:

### 1. corrupt / out-of-date database
on reinstall the old `mangayomiDb` survives. a newer build opens it, `Isar.open` hits an incompatible/corrupt file and throws before `runApp`. now `initDB` moves the bad db files aside (renamed to `…corrupt-<ts>.bak`, **not deleted**, so data is recoverable) and opens a fresh one, so the app still launches. this also covers the worker isolates that open the same db.

### 2. image decoder isolate could hang forever

`FfiImageDecoder._initCIsolate()` awaits the isolate handshake with **no timeout**. if the isolate entry point throws (a missing or mismatched native library) the SendPort is never delivered and the main isolate waits on it forever. no try/catch can catch that, because a hang is not an error. `start()` runs before `runApp()`, so it surfaces as the blank window this PR is about. now bounded with a 5s timeout, matching what `GetIsolateService` already does.

`stop()` also early-returned on `!_isRunning`, so `start()`'s own failure path could not tear down the spawned isolate: a failed handshake throws before `_isRunning` is ever set, leaking the isolate and its ReceivePort. dropped that guard, since every teardown call is null-safe.

> note: this originally targeted `ImageCropIsolate` in `crop_borders_provider.dart`. the tiling-engine refactor on main deleted that file, but its replacement `FfiImageDecoder` carries the same two bugs, so the fix moved across with the code rather than being dropped in the rebase.

### 3. everything else in startup was unguarded
`RustLib.init()`, the isolates, `windowManager`, the webview env: any of these throwing skipped `runApp` entirely (only the db call was wrapped). wrapped the whole init so any failure shows the existing "failed to start" screen instead of a blank window. `runApp` is now always reached.

### 4. actionable error for NFS-exported db folders (refs #652)
when the db folder is on an NFS-exported (`MNT_EXPORTED`) filesystem, libmdbx returns `MdbxError (15): Block device required`. that's a libmdbx limitation with no in-app fix, so the startup error screen now **detects it and explains the cause + workaround** (stop exporting that path / `sudo nfsd disable` on macOS) instead of showing the raw code. the screen is also scrollable now so longer messages don't overflow.

### notes
- **builds in CI now** (GitHub Actions debug APK) and the app launches cleanly on a physical Android TV, with no blank/unresponsive screen. verified the native runners still show the window, so the broadened guard can't hide the error screen.
- data is never deleted, only renamed, so a corrupt-db recovery is reversible.


