### PR TITLE
feat: add autoplay toggle in the player (#739)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/models/track.dart' as track;
 import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/models/track_search.dart';
+import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
 import 'package:mangayomi/modules/manga/reader/providers/crop_borders_provider.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/storage_usage.dart';
@@ -177,6 +178,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await openPlayerPrefsBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -21,6 +21,7 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/video.dart' as vid;
 import 'package:mangayomi/modules/anime/providers/anime_player_controller_provider.dart';
+import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
 import 'package:mangayomi/modules/anime/widgets/aniskip_countdown_btn.dart';
 import 'package:mangayomi/modules/anime/widgets/desktop.dart';
 import 'package:mangayomi/modules/anime/widgets/play_or_pause_button.dart';
@@ -311,7 +312,7 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
 
   late final StreamSubscription<bool> _completed = _player.stream.completed
       .listen((val) {
-        if (hasNextEpisode && val) {
+        if (hasNextEpisode && val && ref.read(autoPlayNextEpisodeProvider)) {
           if (mounted) {
             pushToNewEpisode(context, _streamController.getNextEpisode());
           }
@@ -1896,6 +1897,23 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           ),
           Row(
             children: [
+              Consumer(
+                builder: (context, ref, _) {
+                  final autoPlay = ref.watch(autoPlayNextEpisodeProvider);
+                  return IconButton(
+                    tooltip: autoPlay
+                        ? 'Autoplay next episode: on'
+                        : 'Autoplay next episode: off',
+                    icon: Icon(
+                      Icons.playlist_play,
+                      color: autoPlay ? Colors.white : Colors.white38,
+                    ),
+                    onPressed: () => ref
+                        .read(autoPlayNextEpisodeProvider.notifier)
+                        .toggle(),
+                  );
+                },
+              ),
               if (_supportAlwaysOnTop())
                 IconButton(
                   icon: Icon(

--- a/lib/modules/anime/providers/auto_play_next_provider.dart
+++ b/lib/modules/anime/providers/auto_play_next_provider.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+/// Hive box + key holding the "autoplay next episode" preference.
+///
+/// Stored in Hive (not the Isar Settings collection) so the toggle persists
+/// without touching the generated Isar schema. The box is opened once at
+/// startup in `_postLaunchInit`; see [openPlayerPrefsBox].
+const _playerPrefsBox = 'player_prefs';
+const _autoPlayNextKey = 'auto_play_next_episode';
+
+/// Opens the player-preferences box. Called once during app startup so the
+/// value can be read synchronously by [AutoPlayNextEpisode.build].
+Future<void> openPlayerPrefsBox() async {
+  if (!Hive.isBoxOpen(_playerPrefsBox)) {
+    await Hive.openBox(_playerPrefsBox);
+  }
+}
+
+/// Whether the player should automatically start the next episode when the
+/// current one finishes. Defaults to `true` (the previous always-on behavior).
+/// Toggled from a button in the player and persisted across sessions.
+final autoPlayNextEpisodeProvider =
+    NotifierProvider<AutoPlayNextEpisode, bool>(AutoPlayNextEpisode.new);
+
+class AutoPlayNextEpisode extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_playerPrefsBox)) {
+      return Hive.box(_playerPrefsBox).get(_autoPlayNextKey, defaultValue: true)
+          as bool;
+    }
+    return true;
+  }
+
+  void toggle() => set(!state);
+
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_playerPrefsBox)) {
+      Hive.box(_playerPrefsBox).put(_autoPlayNextKey, value);
+    }
+  }
+}

--- a/lib/modules/anime/providers/auto_play_next_provider.dart
+++ b/lib/modules/anime/providers/auto_play_next_provider.dart
@@ -27,8 +27,10 @@ class AutoPlayNextEpisode extends Notifier<bool> {
   @override
   bool build() {
     if (Hive.isBoxOpen(_playerPrefsBox)) {
-      return Hive.box(_playerPrefsBox).get(_autoPlayNextKey, defaultValue: true)
-          as bool;
+      // Read defensively: a missing or non-bool value (corrupt / hand-edited
+      // box) falls back to the default rather than throwing during build.
+      final value = Hive.box(_playerPrefsBox).get(_autoPlayNextKey);
+      if (value is bool) return value;
     }
     return true;
   }


### PR DESCRIPTION
Closes #739.

adds a youtube-style autoplay toggle in the video player, so you can turn off auto-advancing to the next episode. the choice is remembered across sessions.

### what it does
- a toggle button in the player top bar (playlist icon — white when autoplay is on, dimmed when off, with a tooltip showing the state). tap to flip it.
- **on by default**, so existing behavior is unchanged unless you turn it off.
- only the **automatic** advance (when an episode finishes) is gated. the manual skip-next button and the `aniyomi/switch_episode` command still always work.

### how it persists (no codegen)
- stored in a small **hive** box (`player_prefs`), opened once at startup, instead of adding an isar `Settings` field. that keeps it out of the generated `settings.g.dart` schema, so there's **no `build_runner` step** to run.
- the toggle is a plain riverpod `Notifier<bool>` (`autoPlayNextEpisodeProvider`), no `@riverpod` codegen.

### files
- `lib/modules/anime/providers/auto_play_next_provider.dart` (new) — hive-backed provider + `openPlayerPrefsBox()`
- `lib/main.dart` — open the box during startup
- `lib/modules/anime/anime_player_view.dart` — gate the auto-advance + add the toggle button

### notes
- **builds in CI now** — compiled via GitHub Actions (debug Android APK, runs on Android). verified `Consumer` resolves to flutter_riverpod and `hive` is a direct dependency.

