### PR TITLE
feat: add AES-GCM decryption to the extension bridge (#732)

### DIFF
--- a/lib/eval/dart/bridge/m_provider.dart
+++ b/lib/eval/dart/bridge/m_provider.dart
@@ -103,6 +103,15 @@ class MProviderBridged {
       ),
     );
     interpreter.registertopLevelFunction(
+      'decryptAESGCM',
+      (visitor, positionalArgs, namedArgs, _) => MBridge.decryptAESGCM(
+        positionalArgs[0] as String,
+        positionalArgs[1] as String,
+        positionalArgs[2] as String,
+        positionalArgs[3] as String,
+      ),
+    );
+    interpreter.registertopLevelFunction(
       'deobfuscateJsPassword',
       (visitor, positionalArgs, namedArgs, _) =>
           MBridge.deobfuscateJsPassword(positionalArgs[0] as String),

--- a/lib/eval/dart/bridge/m_provider.dart
+++ b/lib/eval/dart/bridge/m_provider.dart
@@ -108,7 +108,9 @@ class MProviderBridged {
         positionalArgs[0] as String,
         positionalArgs[1] as String,
         positionalArgs[2] as String,
-        positionalArgs[3] as String,
+        // tagHex is optional (empty when the tag is already appended); coerce a
+        // null/missing arg to "" so the call can't throw before the try/catch.
+        positionalArgs[3] as String? ?? '',
       ),
     );
     interpreter.registertopLevelFunction(

--- a/lib/eval/javascript/utils.dart
+++ b/lib/eval/javascript/utils.dart
@@ -43,7 +43,8 @@ class JsUtils {
       return MBridge.decryptAESCryptoJS(args[0], args[1]);
     });
     runtime.onMessage('decryptAESGCM', (dynamic args) {
-      return MBridge.decryptAESGCM(args[0], args[1], args[2], args[3]);
+      // tagHex is optional (empty when already appended); coerce null → "".
+      return MBridge.decryptAESGCM(args[0], args[1], args[2], args[3] ?? '');
     });
     runtime.onMessage('deobfuscateJsPassword', (dynamic args) {
       return MBridge.deobfuscateJsPassword(args[0]);
@@ -170,7 +171,7 @@ function decryptAESCryptoJS(encrypted, passphrase) {
         JSON.stringify([encrypted, passphrase])
     );
 }
-function decryptAESGCM(encrypted, keyHex, ivHex, tagHex) {
+function decryptAESGCM(encrypted, keyHex, ivHex, tagHex = "") {
     return sendMessage(
         "decryptAESGCM",
         JSON.stringify([encrypted, keyHex, ivHex, tagHex])

--- a/lib/eval/javascript/utils.dart
+++ b/lib/eval/javascript/utils.dart
@@ -42,6 +42,9 @@ class JsUtils {
     runtime.onMessage('decryptAESCryptoJS', (dynamic args) {
       return MBridge.decryptAESCryptoJS(args[0], args[1]);
     });
+    runtime.onMessage('decryptAESGCM', (dynamic args) {
+      return MBridge.decryptAESGCM(args[0], args[1], args[2], args[3]);
+    });
     runtime.onMessage('deobfuscateJsPassword', (dynamic args) {
       return MBridge.deobfuscateJsPassword(args[0]);
     });
@@ -165,6 +168,12 @@ function decryptAESCryptoJS(encrypted, passphrase) {
     return sendMessage(
         "decryptAESCryptoJS",
         JSON.stringify([encrypted, passphrase])
+    );
+}
+function decryptAESGCM(encrypted, keyHex, ivHex, tagHex) {
+    return sendMessage(
+        "decryptAESGCM",
+        JSON.stringify([encrypted, keyHex, ivHex, tagHex])
     );
 }
 function deobfuscateJsPassword(inputString) {

--- a/lib/eval/model/m_bridge.dart
+++ b/lib/eval/model/m_bridge.dart
@@ -571,10 +571,13 @@ class MBridge {
   /// AES-GCM decryption for extensions (parity with Java's
   /// `Cipher.getInstance("AES/GCM/NoPadding")`).
   ///
-  /// - [encrypted] : base64 ciphertext (without the auth tag)
+  /// - [encrypted] : base64 ciphertext. If the 16-byte GCM auth tag is already
+  ///                 appended to it (as Java's `Cipher.doFinal` produces),
+  ///                 pass an empty [tagHex].
   /// - [keyHex]    : hex-encoded key (16/24/32 bytes → AES-128/192/256)
   /// - [ivHex]     : hex-encoded IV / nonce (typically 12 bytes for GCM)
-  /// - [tagHex]    : hex-encoded 16-byte authentication tag
+  /// - [tagHex]    : hex-encoded auth tag (usually 16 bytes), appended to the
+  ///                 ciphertext before decryption; empty if already appended
   ///
   /// Returns the decrypted UTF-8 string, or the original [encrypted] input if
   /// decryption/authentication fails (mirrors [cryptoHandler]'s behavior).

--- a/lib/eval/model/m_bridge.dart
+++ b/lib/eval/model/m_bridge.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 import 'package:bot_toast/bot_toast.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -33,6 +34,7 @@ import 'package:mangayomi/utils/extensions/string_extensions.dart';
 import 'package:mangayomi/utils/reg_exp_matcher.dart';
 import 'package:xpath_selector_html_parser/xpath_selector_html_parser.dart';
 import 'package:encrypt/encrypt.dart' as encrypt;
+import 'package:convert/convert.dart' show hex;
 import 'package:mangayomi/services/anime_extractors/quarkuc_extractor.dart';
 
 class WordSet {
@@ -564,6 +566,40 @@ class MBridge {
       subtitles: subtitles ?? [],
       audios: audios ?? [],
     );
+  }
+
+  /// AES-GCM decryption for extensions (parity with Java's
+  /// `Cipher.getInstance("AES/GCM/NoPadding")`).
+  ///
+  /// - [encrypted] : base64 ciphertext (without the auth tag)
+  /// - [keyHex]    : hex-encoded key (16/24/32 bytes → AES-128/192/256)
+  /// - [ivHex]     : hex-encoded IV / nonce (typically 12 bytes for GCM)
+  /// - [tagHex]    : hex-encoded 16-byte authentication tag
+  ///
+  /// Returns the decrypted UTF-8 string, or the original [encrypted] input if
+  /// decryption/authentication fails (mirrors [cryptoHandler]'s behavior).
+  static String decryptAESGCM(
+    String encrypted,
+    String keyHex,
+    String ivHex,
+    String tagHex,
+  ) {
+    try {
+      final key = encrypt.Key(Uint8List.fromList(hex.decode(keyHex)));
+      final iv = encrypt.IV(Uint8List.fromList(hex.decode(ivHex)));
+      // PointyCastle's GCM (and Java's AES/GCM/NoPadding) expect the 128-bit
+      // auth tag appended to the ciphertext, so concatenate the two.
+      final dataWithTag = Uint8List.fromList([
+        ...base64.decode(encrypted),
+        ...hex.decode(tagHex),
+      ]);
+      final encrypter = encrypt.Encrypter(
+        encrypt.AES(key, mode: encrypt.AESMode.gcm),
+      );
+      return encrypter.decrypt(encrypt.Encrypted(dataWithTag), iv: iv);
+    } catch (_) {
+      return encrypted;
+    }
   }
 
   static String cryptoHandler(


### PR DESCRIPTION
Closes #732.

extensions could only do AES-CBC (through `cryptoHandler`) — AES-GCM wasn't available, which blocked porting extractors like [MoonExtractor](https://github.com/yuzono/anime-extensions/blob/master/src/en/animenosub/src/eu/kanade/tachiyomi/animeextension/en/animenosub/extractors/MoonExtractor.kt) that use `AES/GCM/NoPadding`. this adds a `decryptAESGCM` bridge function.

### api
```dart
decryptAESGCM(String encrypted, String keyHex, String ivHex, String tagHex)
```
- `encrypted` = base64 ciphertext, `keyHex` / `ivHex` / `tagHex` = hex
- decodes the inputs, appends the 16-byte auth tag to the ciphertext (what pointycastle's GCM and java's `AES/GCM/NoPadding` both expect), and decrypts **with tag verification**
- returns the decrypted utf-8 string, or the original input on failure (mirrors the existing `cryptoHandler` behavior)

### handles both tag conventions
- **separate tag** (as proposed in the issue): `decryptAESGCM(ctB64, key, iv, tag)`
- **tag already appended to the ciphertext** (what java's `Cipher.doFinal` outputs, as in MoonExtractor): pass an empty `tagHex` — `hex.decode("")` is empty so nothing extra is appended

### wired in all three layers, matching the existing crypto helpers
- `lib/eval/model/m_bridge.dart` — implementation, via the `encrypt` package (`AESMode.gcm`)
- `lib/eval/dart/bridge/m_provider.dart` — dart/d4rt `registertopLevelFunction('decryptAESGCM', ...)`
- `lib/eval/javascript/utils.dart` — js `onMessage` handler + prelude `function decryptAESGCM(...)` for js parity

(the issue mentioned `lib/bridge_lib.dart`, but that file doesn't exist — d4rt is a tree-walking interpreter, so the runtime registration is the binding, same as `cryptoHandler`.)

### notes
- uses the `encrypt` package already in the project; `hex` comes from `package:convert`, already a direct dependency.
- **builds in CI now** — compiled via GitHub Actions (debug Android APK). checked the gcm path against the `encrypt` 5.0.3 source (128-bit mac, default padding routes `decrypt` through the tag-verifying `process()`); a source that exercises `decryptAESGCM` would confirm end-to-end.

