### PR TITLE
fix: library gray squares — don't crash on entries with null source/lang (#708)

### DIFF
--- a/lib/modules/library/widgets/library_app_bar.dart
+++ b/lib/modules/library/widgets/library_app_bar.dart
@@ -204,9 +204,9 @@ class LibraryAppBar extends ConsumerWidget implements PreferredSizeWidget {
                       ? randomManga.id
                       : null,
                   context: context,
-                  lang: randomManga.lang!,
+                  lang: randomManga.lang ?? '',
                   mangaM: randomManga,
-                  source: randomManga.source!,
+                  source: randomManga.source ?? '',
                   sourceId: randomManga.sourceId,
                 );
               });

--- a/lib/modules/library/widgets/library_entry_utils.dart
+++ b/lib/modules/library/widgets/library_entry_utils.dart
@@ -20,17 +20,25 @@ ImageProvider resolveCoverImage(Manga entry, WidgetRef ref) {
   if (entry.customCoverImage != null) {
     return MemoryImage(entry.customCoverImage as Uint8List);
   }
+  // An orphaned/corrupted entry can have a null source or lang (e.g. its
+  // source was uninstalled, or a legacy record). Skip source headers in that
+  // case instead of force-unwrapping — otherwise the whole tile throws while
+  // building and the entry becomes an un-removable "gray square". See #708.
+  final canUseSourceHeaders =
+      !(entry.isLocalArchive ?? false) &&
+      entry.source != null &&
+      entry.lang != null;
   return coverProvider(
     toImgUrl(entry.customCoverFromTracker ?? entry.imageUrl ?? ''),
-    headers: (entry.isLocalArchive ?? false)
-        ? null
-        : ref.watch(
+    headers: canUseSourceHeaders
+        ? ref.watch(
             headersProvider(
               source: entry.source!,
               lang: entry.lang!,
               sourceId: entry.sourceId,
             ),
-          ),
+          )
+        : null,
   );
 }
 
@@ -65,9 +73,9 @@ Future<void> onTapEntry({
     ref: ref,
     archiveId: isLocalArchive ? entry.id : null,
     context: context,
-    lang: entry.lang!,
+    lang: entry.lang ?? '',
     mangaM: entry,
-    source: entry.source!,
+    source: entry.source ?? '',
     sourceId: entry.sourceId,
   );
 

--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -122,7 +122,7 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                       ),
 
                       // ── Top-right: Language ──
-                      if (widget.language && entry.lang!.isNotEmpty)
+                      if (widget.language && (entry.lang?.isNotEmpty ?? false))
                         Positioned(
                           top: 0,
                           right: 0,

--- a/lib/modules/library/widgets/library_listview_widget.dart
+++ b/lib/modules/library/widgets/library_listview_widget.dart
@@ -130,7 +130,8 @@ class LibraryListViewWidget extends StatelessWidget {
                                         ),
                                       ),
                                     ),
-                                    if (language && entry.lang!.isNotEmpty)
+                                    if (language &&
+                                        (entry.lang?.isNotEmpty ?? false))
                                       EntryBadgeChip(
                                         label: entry.lang!.toUpperCase(),
                                       ),


### PR DESCRIPTION
Closes #708.

### the bug
a manga whose source was later deleted — or a legacy/corrupted record — can have a **null `source` or `lang`** (both are `String?` on `Manga`). the library tile force-unwrapped those while building:
- `resolveCoverImage` → `source: entry.source!`, `lang: entry.lang!`
- `onTapEntry` → `entry.lang!`, `entry.source!`
- the language badge → `entry.lang!.isNotEmpty`

so for such an entry the tile **threw while building** and turned into an un-interactable "gray square" you couldn't tap or remove — matching the report and the "clearing the database fixed it" comment (a db wipe removes the malformed records).

### the fix (null-safety hardening)
- **`resolveCoverImage`**: only attach source headers when `source` *and* `lang` are both non-null; otherwise load the cover without them.
- **`onTapEntry`** and the **random-manga** action: pass `''` instead of force-unwrapping, so the detail still opens — where the "In Library" button can remove it.
- **language badge** (grid + list): guard with `(entry.lang?.isNotEmpty ?? false)`.

### scope note
the *common* "source uninstalled" case was already handled on current `main`: the detail view guards `getSource(installedOnly: true)`, shows a ⚠️ when the source is missing, and the "In Library" remove button works without the source. this PR covers the remaining **malformed-record** edge that previously crashed the tile and needed a full database wipe.

### notes
- **builds in CI now** — compiled via GitHub Actions (debug Android APK, runs on Android). verified the remaining `source!`/`lang!` sites are inside null guards.
- no behavior change for normal entries — only adds fallbacks when `source`/`lang` are null.

