### PR TITLE
fix(linux): declare deb dependencies so libmpv2 installs (#700)

### DIFF
--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -12,7 +12,7 @@ section: x11
 
 installed_size: 109400
 
-depencencies:
+dependencies:
   - libwebkit2gtk-4.1-0
   - libmpv2
 


### PR DESCRIPTION
Closes #700.

### the bug
installing the Linux `.deb` failed to launch with:
```
mangayomi: error while loading shared libraries: libmpv.so.2: cannot open shared object file: No such file or directory
```

the `.deb` never declared a dependency on libmpv, so on a system without it installed the dynamic linker exits before `main()` runs.

### root cause
`linux/packaging/deb/make_config.yaml` had the dependency key **misspelled** as `depencencies:`. fastforge's deb maker reads `map['dependencies']` and writes it to the control file's `Depends:` — so the misspelled key was silently ignored and **no `Depends:` field was written at all**. the intended packages (`libwebkit2gtk-4.1-0`, `libmpv2`) were listed correctly, just under the wrong key.

### the fix
rename `depencencies` → `dependencies` (one word). now the generated control file gets:
```
Depends: libwebkit2gtk-4.1-0, libmpv2
```
so `apt` / Discover automatically install libmpv2 (and webkit) when installing the `.deb`, and the app launches.

### notes
- the package names were already correct for the Ubuntu 24.04 base that KDE Neon uses (`libmpv2` = mpv 0.37+).
- the CI repack step (`dpkg-deb -R` → `dpkg-deb -b`) preserves the generated `DEBIAN/control`, so the new `Depends:` survives the desktop-file/icon injection.
- the AppImage was unaffected (it already bundles libmpv via linuxdeploy); this only fixes the `.deb`.
- packaging-only change, no app code touched.
