### PR TITLE
fix(linux): make desktop WebView teardown idempotent (#752)

### DIFF
--- a/lib/modules/webview/webview.dart
+++ b/lib/modules/webview/webview.dart
@@ -45,6 +45,10 @@ class _MangaWebViewState extends ConsumerState<MangaWebView> {
 
   @override
   void dispose() {
+    // Always stop the cookie poll, even if the route is popped externally
+    // (e.g. router/back) without going through _popWebviewRoute — otherwise the
+    // periodic timer keeps hitting a closed WebView and pins this State.
+    _cookieTimer?.cancel();
     if (Platform.isLinux) {
       _closeDesktopWebview();
     } else {
@@ -91,7 +95,7 @@ class _MangaWebViewState extends ConsumerState<MangaWebView> {
     if (Platform.isLinux) {
       _desktopWebview = await WebviewWindow.create();
 
-      _cookieTimer = Timer.periodic(const Duration(seconds: 1), (timer) async {
+      _cookieTimer = Timer.periodic(const Duration(seconds: 1), (_) async {
         try {
           final cookieList = await _desktopWebview!.getAllCookies();
           final ua =

--- a/lib/modules/webview/webview.dart
+++ b/lib/modules/webview/webview.dart
@@ -46,7 +46,7 @@ class _MangaWebViewState extends ConsumerState<MangaWebView> {
   @override
   void dispose() {
     if (Platform.isLinux) {
-      _desktopWebview?.close();
+      _closeDesktopWebview();
     } else {
       if (browser != null) {
         if (browser!.isOpened()) browser!.close();
@@ -57,6 +57,32 @@ class _MangaWebViewState extends ConsumerState<MangaWebView> {
   }
 
   Webview? _desktopWebview;
+  Timer? _cookieTimer;
+  bool _webviewClosed = false;
+  bool _routePopped = false;
+
+  /// Closes the native desktop WebView window at most once. On Linux the close
+  /// can be triggered from three places for a single teardown (the in-app
+  /// button, the `onClose` callback after the user closes the window, and
+  /// `dispose()`). Closing more than once removes the WebView's FlView and then
+  /// the GTK embedder paints the now-invalid view on the next frame → SIGSEGV.
+  /// Guarding it keeps the app from aggravating that. See #752.
+  void _closeDesktopWebview() {
+    if (_webviewClosed) return;
+    _webviewClosed = true;
+    _desktopWebview?.close();
+  }
+
+  /// Pops this route at most once and stops the cookie poll.
+  void _popWebviewRoute() {
+    if (_routePopped) return;
+    _routePopped = true;
+    _cookieTimer?.cancel();
+    if (mounted) {
+      Navigator.pop(context);
+    }
+  }
+
   Future<void> _runWebViewDesktop() async {
     String? ua = ref.watch(userAgentStateProvider);
     if (ua == defaultUserAgent) {
@@ -65,7 +91,7 @@ class _MangaWebViewState extends ConsumerState<MangaWebView> {
     if (Platform.isLinux) {
       _desktopWebview = await WebviewWindow.create();
 
-      final timer = Timer.periodic(const Duration(seconds: 1), (timer) async {
+      _cookieTimer = Timer.periodic(const Duration(seconds: 1), (timer) async {
         try {
           final cookieList = await _desktopWebview!.getAllCookies();
           final ua =
@@ -83,10 +109,10 @@ class _MangaWebViewState extends ConsumerState<MangaWebView> {
         ..setBrightness(Brightness.dark)
         ..launch(widget.url)
         ..onClose.whenComplete(() {
-          timer.cancel();
-          if (mounted) {
-            Navigator.pop(context);
-          }
+          // The native window has already closed itself; mark it so dispose()
+          // doesn't try to close it again, then pop this route once.
+          _webviewClosed = true;
+          _popWebviewRoute();
         });
     } else {
       browser = MyInAppBrowser(
@@ -146,9 +172,8 @@ class _MangaWebViewState extends ConsumerState<MangaWebView> {
               ),
               leading: IconButton(
                 onPressed: () {
-                  if (_desktopWebview != null) _desktopWebview!.close();
-
-                  Navigator.pop(context);
+                  _closeDesktopWebview();
+                  _popWebviewRoute();
                 },
                 icon: const Icon(Icons.close),
               ),


### PR DESCRIPTION
Addresses #752 — **Linux (Wayland): app SIGSEGVs in `gdk_gl_texture_from_surface` when the desktop WebView window is closed** (app-side contributor).

huge thanks to the reporter for the diagnosis — this targets the **secondary, app-side** contributor they identified, not the upstream engine bug.

### what was happening
on Linux, a single WebView teardown could close the native window and pop the route **two or three times**:
- the in-app close button → `_desktopWebview.close()` **+** `Navigator.pop()`
- `onClose.whenComplete` → `Navigator.pop()` again
- `dispose()` → `_desktopWebview.close()` again

`desktop_webview_window` creates a second `FlView` on Linux; closing/removing it more than once is what makes the GTK Flutter embedder paint the now-invalid view on the next frame-clock tick → SIGSEGV in `gdk_gl_texture_from_surface` (matches the `FlutterEngineRemoveView … implicit view cannot be removed` log).

### the fix
make teardown idempotent in `_MangaWebViewState` with two guard flags:
- `_closeDesktopWebview()` closes the native window **at most once**
- `_popWebviewRoute()` pops the route **at most once** (and cancels the cookie poll)
- when the user closes the native window themselves, `onClose` marks it closed so `dispose()` doesn't try to close it again

so across all three triggers the window is closed once and the route popped once — and we never re-close a window the user already closed.

### honesty on scope
the **root cause is an upstream GTK-embedder regression** (flutter/flutter#182192 — `FlutterEngineRemoveView … implicit view cannot be removed`), which can't be fixed from app code. this PR removes Mangayomi's redundant multi-teardown that deterministically triggers it. it should stop the app from aggravating the crash and may resolve it on affected setups, but I can't guarantee it eliminates the SIGSEGV everywhere while the engine bug remains. the Windows/`InAppBrowser` close paths are intentionally untouched (the crash is Linux-desktop-window specific).

### notes
- single-file change in `lib/modules/webview/webview.dart`.
- **builds in CI now** (GitHub Actions), but I still don't have a Wayland/fractional-scale setup to repro the crash — teardown logic verified by review; a test from the reporter on the affected setup would still be appreciated.

