### PR TITLE
feat: custom Cloudflare bypass proxy (FlareSolverr / Byparr) (#709)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/theme_mode_state_provider.dart';
 import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/services/http/m_client.dart';
+import 'package:mangayomi/services/http/cf_proxy_store.dart';
 import 'package:mangayomi/services/isolate_service.dart';
 import 'package:mangayomi/services/m_extension_server.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
@@ -177,6 +178,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await CfProxyStore.openBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/modules/more/settings/general/general_screen.dart
+++ b/lib/modules/more/settings/general/general_screen.dart
@@ -464,7 +464,7 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
                           ? () {
                               CfProxyStore.setUrl(trimmed);
                               Navigator.pop(dialogContext);
-                              setState(() {});
+                              if (mounted) setState(() {});
                             }
                           : null,
                       child: Text(context.l10n.dialog_confirm),

--- a/lib/modules/more/settings/general/general_screen.dart
+++ b/lib/modules/more/settings/general/general_screen.dart
@@ -7,6 +7,7 @@ import 'package:mangayomi/modules/more/providers/algorithm_weights_state_provide
 import 'package:mangayomi/modules/more/settings/general/providers/general_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/modules/more/settings/general/providers/doh_provider_notifier.dart';
+import 'package:mangayomi/services/http/cf_proxy_store.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
@@ -146,6 +147,16 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
               title: Text(context.l10n.default_user_agent),
               subtitle: Text(
                 userAgent,
+                style: TextStyle(fontSize: 11, color: context.secondaryColor),
+              ),
+            ),
+            ListTile(
+              onTap: () => _showCfProxyDialog(context),
+              title: const Text('Cloudflare bypass proxy'),
+              subtitle: Text(
+                CfProxyStore.url.isEmpty
+                    ? 'Optional FlareSolverr / Byparr URL'
+                    : CfProxyStore.url,
                 style: TextStyle(fontSize: 11, color: context.secondaryColor),
               ),
             ),
@@ -388,6 +399,82 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  void _showCfProxyDialog(BuildContext context) {
+    final controller = TextEditingController(text: CfProxyStore.url);
+    String url = CfProxyStore.url;
+    showDialog(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (dialogContext, setLocalState) {
+          final trimmed = url.trim();
+          final isValid =
+              trimmed.isEmpty || trimmed.startsWith('http://') ||
+              trimmed.startsWith('https://');
+          return AlertDialog(
+            title: const Text(
+              'Cloudflare bypass proxy',
+              style: TextStyle(fontSize: 24),
+            ),
+            content: SizedBox(
+              width: context.width(0.8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 10),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                    child: TextFormField(
+                      controller: controller,
+                      autofocus: true,
+                      keyboardType: TextInputType.url,
+                      onChanged: (value) => setLocalState(() => url = value),
+                      decoration: InputDecoration(
+                        hintText: 'http://localhost:8191/v1',
+                        helperText:
+                            'FlareSolverr / Byparr endpoint. Leave empty to '
+                            'disable.',
+                        helperMaxLines: 2,
+                        filled: false,
+                        contentPadding: const EdgeInsets.all(12),
+                        enabledBorder: OutlineInputBorder(
+                          borderSide: const BorderSide(width: 0.4),
+                          borderRadius: BorderRadius.circular(5),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderSide: const BorderSide(),
+                          borderRadius: BorderRadius.circular(5),
+                        ),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(5),
+                          borderSide: const BorderSide(),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  SizedBox(
+                    width: context.width(1),
+                    child: ElevatedButton(
+                      onPressed: isValid
+                          ? () {
+                              CfProxyStore.setUrl(trimmed);
+                              Navigator.pop(dialogContext);
+                              setState(() {});
+                            }
+                          : null,
+                      child: Text(context.l10n.dialog_confirm),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/modules/more/settings/general/general_screen.dart
+++ b/lib/modules/more/settings/general/general_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/settings.dart';
@@ -430,7 +431,7 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
                     padding: const EdgeInsets.symmetric(vertical: 10),
                     child: TextFormField(
                       controller: controller,
-                      autofocus: true,
+                      autofocus: !isTv,
                       keyboardType: TextInputType.url,
                       onChanged: (value) => setLocalState(() => url = value),
                       decoration: InputDecoration(
@@ -506,7 +507,7 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
                     padding: const EdgeInsets.symmetric(vertical: 10),
                     child: TextFormField(
                       controller: dnsController,
-                      autofocus: true,
+                      autofocus: !isTv,
                       onChanged: (value) => setState(() {
                         dns = value;
                       }),
@@ -579,7 +580,7 @@ void _showDefaultUserAgentDialog(
                   padding: const EdgeInsets.symmetric(vertical: 10),
                   child: TextFormField(
                     controller: uaController,
-                    autofocus: true,
+                    autofocus: !isTv,
 
                     decoration: InputDecoration(
                       hintText: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)...",

--- a/lib/services/http/cf_proxy_store.dart
+++ b/lib/services/http/cf_proxy_store.dart
@@ -1,0 +1,32 @@
+import 'package:hive/hive.dart';
+
+/// Persists the URL of an external Cloudflare-bypass proxy
+/// (FlareSolverr / Byparr), e.g. `http://localhost:8191/v1`.
+///
+/// Stored in Hive rather than the Isar `Settings` collection so the feature
+/// needs no generated schema field. The box is opened once at startup (see
+/// [openBox]); reads return an empty string when it isn't open (e.g. a
+/// background isolate), which callers treat as "no proxy configured".
+class CfProxyStore {
+  static const _boxName = 'cf_prefs';
+  static const _urlKey = 'cf_proxy_url';
+
+  /// Opens the backing box. Called once during app startup.
+  static Future<void> openBox() async {
+    if (!Hive.isBoxOpen(_boxName)) {
+      await Hive.openBox(_boxName);
+    }
+  }
+
+  /// The saved proxy URL, or an empty string if none / box not open.
+  static String get url => Hive.isBoxOpen(_boxName)
+      ? (Hive.box(_boxName).get(_urlKey, defaultValue: '') as String)
+      : '';
+
+  /// Persists [value] as the proxy URL (best-effort if the box is open).
+  static void setUrl(String value) {
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_urlKey, value);
+    }
+  }
+}

--- a/lib/services/http/cf_proxy_store.dart
+++ b/lib/services/http/cf_proxy_store.dart
@@ -13,9 +13,14 @@ class CfProxyStore {
 
   /// Opens the backing box. Called once during app startup.
   static Future<void> openBox() async {
-    if (!Hive.isBoxOpen(_boxName)) {
-      await Hive.openBox(_boxName);
-    }
+    // Best-effort: this is an optional preference store, so a failure to open
+    // (corruption, permissions, …) must not block startup. Reads then fall
+    // back to "no proxy configured".
+    try {
+      if (!Hive.isBoxOpen(_boxName)) {
+        await Hive.openBox(_boxName);
+      }
+    } catch (_) {}
   }
 
   /// The saved proxy URL, or an empty string if none / box not open.

--- a/lib/services/http/m_client.dart
+++ b/lib/services/http/m_client.dart
@@ -16,6 +16,7 @@ import 'package:mangayomi/utils/log/log.dart';
 import 'package:mangayomi/services/http/rhttp/rhttp.dart' as rhttp;
 import 'package:mangayomi/services/http/doh/doh_resolver.dart';
 import 'package:mangayomi/services/http/doh/doh_providers.dart';
+import 'package:mangayomi/services/http/cf_proxy_store.dart';
 
 class MClient {
   MClient();
@@ -280,28 +281,81 @@ class ResolveCloudFlareChallenge extends RetryPolicy {
   int get maxRetryAttempts => 2;
   @override
   Future<bool> shouldAttemptRetryOnResponse(BaseResponse response) async {
-    if (!showCloudFlareError || Platform.isLinux) return false;
-    bool isCloudFlare = isCloudflare(response);
-    if (isCloudFlare) {
-      try {
-        return http
-            .post(
-              Uri.parse('http://localhost:$cfPort/resolve_cf'),
-              headers: {HttpHeaders.contentTypeHeader: 'application/json'},
-              body: jsonEncode({'url': response.request!.url.toString()}),
-            )
-            .then((res) {
-              if (res.statusCode == 200) {
-                final data = jsonDecode(res.body) as Map<String, dynamic>;
-                return data['result'] as bool;
-              }
-              return false;
-            });
-      } catch (e) {
-        return false;
-      }
+    if (!showCloudFlareError) return false;
+    if (!isCloudflare(response)) return false;
+    final url = response.request!.url.toString();
+
+    // Prefer an external Cloudflare-bypass proxy (FlareSolverr / Byparr) when
+    // one is configured. It also works on Linux, where the in-app webview
+    // resolver below is disabled.
+    final proxyUrl = CfProxyStore.url.trim();
+    if (proxyUrl.isNotEmpty) {
+      return _solveWithCfProxy(proxyUrl, url);
     }
 
+    // Fall back to the bundled webview resolver (not available on Linux).
+    if (Platform.isLinux) return false;
+    try {
+      return http
+          .post(
+            Uri.parse('http://localhost:$cfPort/resolve_cf'),
+            headers: {HttpHeaders.contentTypeHeader: 'application/json'},
+            body: jsonEncode({'url': url}),
+          )
+          .then((res) {
+            if (res.statusCode == 200) {
+              final data = jsonDecode(res.body) as Map<String, dynamic>;
+              return data['result'] as bool;
+            }
+            return false;
+          });
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+/// Solves a Cloudflare challenge for [targetUrl] through a FlareSolverr- /
+/// Byparr-compatible proxy at [proxyUrl] (e.g. `http://localhost:8191/v1`).
+///
+/// On success it stores the returned `cf_clearance` cookies + user-agent via
+/// [MClient.setCookie] (exactly like the webview resolver does), so the retried
+/// request carries them, and returns `true` to trigger the retry.
+Future<bool> _solveWithCfProxy(String proxyUrl, String targetUrl) async {
+  try {
+    final res = await http
+        .post(
+          Uri.parse(proxyUrl),
+          headers: {HttpHeaders.contentTypeHeader: 'application/json'},
+          body: jsonEncode({
+            'cmd': 'request.get',
+            'url': targetUrl,
+            'maxTimeout': 60000,
+          }),
+        )
+        .timeout(const Duration(seconds: 70));
+    if (res.statusCode != 200) return false;
+
+    final data = jsonDecode(res.body) as Map<String, dynamic>;
+    if (data['status'] != 'ok') return false;
+
+    final solution = data['solution'] as Map<String, dynamic>?;
+    if (solution == null) return false;
+
+    final cookieList = (solution['cookies'] as List?) ?? [];
+    final cookie = cookieList
+        .whereType<Map>()
+        .map((c) => "${c['name']}=${c['value']}")
+        .join(';');
+    if (cookie.isEmpty) return false;
+
+    final ua = (solution['userAgent'] as String?) ?? '';
+    await MClient.setCookie(targetUrl, ua, null, cookie: cookie);
+    return true;
+  } catch (e) {
+    if (kDebugMode) {
+      debugPrint('CF proxy solve failed: $e');
+    }
     return false;
   }
 }

--- a/lib/services/http/m_client.dart
+++ b/lib/services/http/m_client.dart
@@ -346,7 +346,7 @@ Future<bool> _solveWithCfProxy(String proxyUrl, String targetUrl) async {
     final cookie = cookieList
         .whereType<Map>()
         .map((c) => "${c['name']}=${c['value']}")
-        .join(';');
+        .join('; ');
     if (cookie.isEmpty) return false;
 
     final ua = (solution['userAgent'] as String?) ?? '';


### PR DESCRIPTION
Closes #709 — **Add config to set a custom cloudflare bypass proxy**.

adds an optional **"Cloudflare bypass proxy"** field under **Settings → General** where you can point at a [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr)- or [Byparr](https://github.com/ThePhaseless/Byparr)-compatible endpoint (e.g. `http://localhost:8191/v1`).

### how it works
when a Cloudflare challenge is detected and a proxy URL is set, the existing `ResolveCloudFlareChallenge` retry policy:
1. POSTs the target URL to the proxy — `{"cmd":"request.get","url":<target>,"maxTimeout":60000}`
2. reads the returned `cf_clearance` cookies + `userAgent` from `solution`
3. stores them via `MClient.setCookie(...)` — **exactly** what the bundled webview resolver does
4. returns `true`, so the request retries and the `MCookieManager` interceptor attaches the new cookie → the cleared request goes through

### why this helps (the issue's setup)
the bundled in-app webview resolver is **hard-disabled on Linux** (`if (... || Platform.isLinux) return false;`), which is why the reporter's bypasses "basically never work" on their Linux deb build. an external proxy runs over plain HTTP, so this path **works on Linux too**. when no proxy is configured, behaviour is unchanged (it falls back to the webview resolver on non-Linux).

it also offloads bypassing from per-extension hacks (refs #611).

### persistence (no codegen)
the URL is stored in a small **Hive** box (`CfProxyStore`), opened once at startup — no new Isar `Settings` field, so **no `build_runner`**. leaving the field empty disables it.

### files
- `lib/services/http/cf_proxy_store.dart` (new) — Hive-backed URL store
- `lib/services/http/m_client.dart` — proxy-first branch in the retry policy + `_solveWithCfProxy`
- `lib/modules/more/settings/general/general_screen.dart` — settings field + dialog
- `lib/main.dart` — open the box at startup

### notes / testing
- **builds in CI now** (GitHub Actions debug APK), but I still have no FlareSolverr/Byparr instance to verify the round-trip end to end. the request/response shape follows FlareSolverr's documented `request.get` API and cookie handling mirrors the existing webview resolver — a real-world test (ideally the reporter, on Linux) would still be very welcome before merge.
- verified imports, brace/paren balance, and the cookie/retry wiring by hand.
- timeouts: `maxTimeout` 60s + a 70s client timeout, since solving a challenge can be slow.

