### PR TITLE
feat: show library-update failures in a dismissible dialog (#623)

### DIFF
--- a/lib/services/library_updater.dart
+++ b/lib/services/library_updater.dart
@@ -63,14 +63,37 @@ Future<void> updateLibrary({
   await Future.delayed(const Duration(seconds: 1));
   BotToast.cleanAll();
   if (context.mounted && failedMangas.isNotEmpty) {
-    final failedListText = failedMangas.map((m) => "• $m").join('\n');
     final plural = failed == 1 ? itemtype : "${itemtype}s";
-    botToast(
-      "Failed to update $failed $plural:\n$failedListText",
-      fontSize: 13,
-      second: 10,
-      alignY: !context.isTablet ? 0.85 : 1,
-      themeDark: isDark,
+    // Show the failures in a dismissible dialog rather than a transient toast,
+    // so the list can be reviewed at the user's pace and isn't missed when many
+    // entries fail. See #623.
+    await showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text("Failed to update $failed $plural"),
+        content: SizedBox(
+          width: context.width(0.8),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (final name in failedMangas)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 2),
+                    child: Text("• $name"),
+                  ),
+              ],
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(context.l10n.ok),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/services/library_updater.dart
+++ b/lib/services/library_updater.dart
@@ -73,17 +73,17 @@ Future<void> updateLibrary({
         title: Text("Failed to update $failed $plural"),
         content: SizedBox(
           width: context.width(0.8),
-          child: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                for (final name in failedMangas)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 2),
-                    child: Text("• $name"),
-                  ),
-              ],
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: context.height(0.5)),
+            // ListView.builder so rows are built lazily — a large library with
+            // many failed updates won't build one widget per entry up front.
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: failedMangas.length,
+              itemBuilder: (context, index) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2),
+                child: Text("• ${failedMangas[index]}"),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Addresses #623 — **[Feature request] Able to see which manga failed to update**.

### context
this is *mostly already implemented*: since v0.6.95, `updateLibrary` collects the manga that fail and shows them after the run. but it does so in a **transient ~10s toast**, which is easy to miss when several fail and can't be reviewed afterwards — so the request ("be able to *see* which failed") wasn't really satisfied for anything more than a couple of entries.

### what this changes
replaces that final failure toast with a **dismissible, scrollable dialog**:

```
Failed to update N Manga
• Title A
• Title B
• Title C
            [ OK ]
```

- only appears when something actually failed (no dialog on a clean update)
- scrolls when many entries fail, and stays until you dismiss it
- the per-item progress toast during the update (`updating_library`) is unchanged
- reuses the existing `failedMangas` list and the `l10n.ok` string — no new strings / codegen

### files
- `lib/services/library_updater.dart` — swap the summary toast for an `AlertDialog`

### notes
- **builds in CI now** — compiled via GitHub Actions (debug Android APK, runs on Android). verified imports/balance and that the existing toast + `BotToast.cleanAll()` usage is intact.
- kept it minimal: same data, just a more reviewable presentation. happy to also surface the per-manga failure *reason* (currently only logged) if that's wanted.

