### PR TITLE
feat: visible focus ring on cover cards for keyboard / d-pad navigation (#729)

### DIFF
--- a/lib/modules/widgets/cover_view_widget.dart
+++ b/lib/modules/widgets/cover_view_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 
-class CoverViewWidget extends StatelessWidget {
+class CoverViewWidget extends StatefulWidget {
   final List<Widget> children;
   final bool? isLongPressed;
   final ImageProvider? image;
@@ -23,38 +23,74 @@ class CoverViewWidget extends StatelessWidget {
   });
 
   @override
+  State<CoverViewWidget> createState() => _CoverViewWidgetState();
+}
+
+class _CoverViewWidgetState extends State<CoverViewWidget> {
+  // Whether the card should draw a focus ring. Only set when focus arrives via
+  // keyboard / d-pad navigation (FocusHighlightMode.traditional), so touch
+  // input on phones/tablets never shows a ring. Gives d-pad/remote users on
+  // Android TV — and keyboard users anywhere — a clearly visible focus target.
+  bool _focused = false;
+
+  void _onFocusChange(bool hasFocus) {
+    final show =
+        hasFocus &&
+        FocusManager.instance.highlightMode == FocusHighlightMode.traditional;
+    if (mounted && show != _focused) {
+      setState(() => _focused = show);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(5),
       child: Column(
         children: [
           Expanded(
-            child: Material(
-              borderRadius: BorderRadius.circular(5),
-              color: Colors.transparent,
-              clipBehavior: Clip.antiAlias,
-              child: InkWell(
-                onTap: onTap,
-                onLongPress: onLongPress,
-                onSecondaryTap: onSecondaryTap,
-                child: Container(
-                  color: isLongPressed != null && isLongPressed!
-                      ? context.primaryColor.withValues(alpha: 0.4)
-                      : Colors.transparent,
-                  child: image == null
-                      ? isComfortableGrid
-                            ? Column(children: [...children, bottomTextWidget!])
-                            : Stack(children: children)
-                      : Ink.image(
-                          fit: BoxFit.cover,
-                          image: image!,
-                          child: Stack(children: children),
-                        ),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 120),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(7),
+                border: Border.all(
+                  color: _focused ? context.primaryColor : Colors.transparent,
+                  width: 3,
+                ),
+              ),
+              child: Material(
+                borderRadius: BorderRadius.circular(5),
+                color: Colors.transparent,
+                clipBehavior: Clip.antiAlias,
+                child: InkWell(
+                  onTap: widget.onTap,
+                  onLongPress: widget.onLongPress,
+                  onSecondaryTap: widget.onSecondaryTap,
+                  onFocusChange: _onFocusChange,
+                  child: Container(
+                    color: widget.isLongPressed != null && widget.isLongPressed!
+                        ? context.primaryColor.withValues(alpha: 0.4)
+                        : Colors.transparent,
+                    child: widget.image == null
+                        ? widget.isComfortableGrid
+                              ? Column(
+                                  children: [
+                                    ...widget.children,
+                                    widget.bottomTextWidget!,
+                                  ],
+                                )
+                              : Stack(children: widget.children)
+                        : Ink.image(
+                            fit: BoxFit.cover,
+                            image: widget.image!,
+                            child: Stack(children: widget.children),
+                          ),
+                  ),
                 ),
               ),
             ),
           ),
-          if (isComfortableGrid) bottomTextWidget!,
+          if (widget.isComfortableGrid) widget.bottomTextWidget!,
         ],
       ),
     );

--- a/lib/modules/widgets/cover_view_widget.dart
+++ b/lib/modules/widgets/cover_view_widget.dart
@@ -33,6 +33,27 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
   // Android TV — and keyboard users anywhere — a clearly visible focus target.
   bool _focused = false;
 
+  @override
+  void initState() {
+    super.initState();
+    // Track highlight-mode changes so the ring is dropped immediately if the
+    // user switches to touch input while a card is focused (it must never show
+    // for touch), not only when focus is lost.
+    FocusManager.instance.addHighlightModeListener(_onHighlightModeChanged);
+  }
+
+  @override
+  void dispose() {
+    FocusManager.instance.removeHighlightModeListener(_onHighlightModeChanged);
+    super.dispose();
+  }
+
+  void _onHighlightModeChanged(FocusHighlightMode mode) {
+    if (mode != FocusHighlightMode.traditional && _focused) {
+      setState(() => _focused = false);
+    }
+  }
+
   void _onFocusChange(bool hasFocus) {
     final show =
         hasFocus &&
@@ -44,6 +65,10 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
 
   @override
   Widget build(BuildContext context) {
+    // Comfortable grid renders the label below the card, so it must not also be
+    // placed inside the card. Render it once, and only when provided.
+    final showBottomText =
+        widget.isComfortableGrid && widget.bottomTextWidget != null;
     return Padding(
       padding: const EdgeInsets.all(5),
       child: Column(
@@ -52,7 +77,9 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 120),
               decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(7),
+                // Outer radius = inner clip radius (5) + border width (3) so the
+                // ring's corners stay concentric with the card and don't clip.
+                borderRadius: BorderRadius.circular(8),
                 border: Border.all(
                   color: _focused ? context.primaryColor : Colors.transparent,
                   width: 3,
@@ -73,12 +100,9 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
                         : Colors.transparent,
                     child: widget.image == null
                         ? widget.isComfortableGrid
-                              ? Column(
-                                  children: [
-                                    ...widget.children,
-                                    widget.bottomTextWidget!,
-                                  ],
-                                )
+                              // bottomTextWidget is rendered once below the card,
+                              // so it's not duplicated inside here anymore.
+                              ? Column(children: widget.children)
                               : Stack(children: widget.children)
                         : Ink.image(
                             fit: BoxFit.cover,
@@ -90,7 +114,7 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
               ),
             ),
           ),
-          if (widget.isComfortableGrid) widget.bottomTextWidget!,
+          if (showBottomText) widget.bottomTextWidget!,
         ],
       ),
     );


### PR DESCRIPTION
Phase 2 increment for #729, and a standalone keyboard-accessibility win.

`CoverViewWidget` — the cover card used across the **browse** and **library** grids — is already keyboard/d-pad focusable (its `InkWell` is activatable with Enter/DPAD-center), but it only draws Flutter's **default focus overlay, which is nearly invisible** — especially on a TV from the couch. This adds a clear focus **ring**.

### behaviour
- the ring is gated on `FocusManager.instance.highlightMode == FocusHighlightMode.traditional`, so it appears **only** for keyboard / d-pad focus and **never on touch** — no change for phone/tablet users.
- benefits **desktop keyboard** users immediately, and is the first concrete usability step of the Android-TV RFC (#729) phase 2.

### scope
- one widget (the central grid card), so it covers both main grids in one place. per-screen polish (list tiles, dialogs, app-bar order) is the larger phase-2 audit, left for follow-up.
- strictly additive.

### notes
- **builds in CI now** (GitHub Actions debug APK) and runs on a physical Android TV; the ring only triggers in traditional (d-pad/keyboard) highlight mode. a focused check on a TV / with a keyboard would confirm the visual.

