### PR TITLE
ci: build & analyze checks on pull requests and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+# Build/compile checks for pull requests and main. The release workflow only
+# runs on version tags, so without this nothing verifies that a PR (or main)
+# actually compiles until a release is cut. This catches that earlier.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # Generated files (frb_generated.dart, *.g.dart, l10n) are committed, so
+      # analyze runs without the Rust/codegen toolchain. Fail only on errors
+      # (e.g. undefined symbols / type errors), not pre-existing infos/warnings.
+      - name: Analyze
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+  build-android:
+    name: Build (Android debug)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Java toolchain
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.18.1"
+
+      - name: Setup ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+
+      - name: Install flutter_rust_bridge_codegen
+        run: cargo install 'flutter_rust_bridge_codegen'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # Debug build: needs no signing secrets, so it also runs on fork PRs,
+      # while still compiling the full Dart + Kotlin + Rust bridge.
+      - name: Build debug APK
+        run: flutter build apk --debug

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,6 +10,11 @@
 analyzer:
   errors:
     unintended_html_in_doc_comment: ignore
+  exclude:
+    # Vendored flutter_rust_bridge build tool — a separate package with its own
+    # dependencies that aren't resolved in the app's analysis context, so it
+    # reports false errors. It's build-time only, not app code.
+    - rust_builder/**
 include: package:flutter_lints/flutter.yaml
 
 linter:


### PR DESCRIPTION
### the problem
the only workflow in the repo (`release.yml`) triggers **solely on `push: tags: v*`**. there's no `pull_request` or push-to-`main` check anywhere. so nothing verifies that a PR — or even `main` — actually **compiles** until a release tag is cut (every week or two). a PR with a compile error can merge cleanly and only surface when the next release build fails, leaving you to bisect across everything merged since.

### what this adds
a lightweight `CI` workflow on `pull_request` + `push` to `main`:

- **analyze** — `flutter pub get` + `flutter analyze --no-fatal-infos --no-fatal-warnings`. the generated files (`frb_generated.dart`, `*.g.dart`, l10n) are committed, so this needs **no Rust/codegen toolchain** — it's fast and catches the common stuff (undefined symbols, type errors, bad args). fatal-on-errors-only so pre-existing infos/warnings don't make every PR red.
- **build-android** — a full **debug** APK build (flutter + rust + java 17 + cmake + ninja, mirroring `release.yml`'s setup). debug needs **no signing secrets**, so it also runs on **fork PRs** while still compiling the whole Dart + Kotlin + Rust-bridge stack.

### why it's worth it
- catches compile breaks **at PR time** instead of at release time.
- `analyze` is cheap and gives fast feedback; `build-android` is the thorough gate.
- no secrets required, so it works for outside contributors' PRs too.

### notes
- additive — doesn't touch the existing release workflow.
- if CI minutes are a concern, the `analyze` job alone already catches most issues and the `build-android` job can be dropped or made `workflow_dispatch`.
- couldn't run Actions from here; validated the YAML structure and modelled the build steps on `release.yml`'s android job.

> **Update:** this workflow has been running green on my fork (build + analyze), and a sibling job builds a debug APK artifact I've been using to test the Android TV work on a physical device.
