### PR TITLE
feat(android): Android TV / leanback detection (isTv) — #729 foundation

### DIFF
--- a/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
@@ -7,7 +7,11 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.embedding.android.FlutterFragmentActivity
 import androidx.core.content.FileProvider
+import android.app.UiModeManager
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.net.Uri
 import java.io.File
@@ -55,6 +59,33 @@ class MainActivity: FlutterFragmentActivity() {
                 }
             }
         }
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.kodjodevf.mangayomi.device",
+            StandardMethodCodec.INSTANCE
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "isTv" -> {
+                    result.success(isTvDevice())
+                }
+                else -> {
+                    result.notImplemented()
+                }
+            }
+        }
+    }
+
+    // Reports whether this is an Android TV / leanback device. Used by the
+    // Dart side to branch the UI on form factor (see #729). Kept conservative
+    // so a phone is never misdetected as a TV: a phone has neither the
+    // television UI mode nor the leanback feature.
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        if (uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true
+        }
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
     private fun installApk(filePath: String?) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -112,6 +112,9 @@ void main(List<String> args) async {
           );
         }
       }
+      // Detect Android TV once, before the UI builds, so form-factor branches
+      // can read `isTv`. No-op on other platforms. See #729.
+      await initIsTv();
       final storage = StorageProvider();
       await storage.requestPermission();
       Object? startupError;

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 /// macOS, Linux or Windows
 final bool isDesktop =
@@ -9,3 +11,26 @@ final bool isMobile = Platform.isAndroid || Platform.isIOS;
 
 /// macOS or iOS
 final bool isApple = Platform.isMacOS || Platform.isIOS;
+
+/// Whether the app is running on an Android TV / leanback device.
+///
+/// Defaults to false and is hydrated once at startup by [initIsTv] (Android
+/// only); it stays false on every other platform. Nothing branches on this
+/// yet — it's the detection foundation for Android TV support (see #729).
+bool isTv = false;
+
+/// Asks the native side whether this is a TV / leanback device and caches the
+/// answer in [isTv]. No-op (and leaves [isTv] false) on non-Android platforms
+/// or if the channel isn't available. Safe to call once the engine is up.
+Future<void> initIsTv() async {
+  if (!Platform.isAndroid) return;
+  try {
+    const channel = MethodChannel('com.kodjodevf.mangayomi.device');
+    isTv = (await channel.invokeMethod<bool>('isTv')) ?? false;
+  } catch (_) {
+    isTv = false;
+  }
+  if (kDebugMode) {
+    debugPrint('[platform] isTv = $isTv');
+  }
+}


### PR DESCRIPTION
Foundation for the Android TV work (#729). **Purely additive — no behaviour change.** Nothing branches on `isTv` yet; this just makes the form-factor detectable so the follow-up UX can use it.

### what's here
- **`MainActivity.kt`** — a `com.kodjodevf.mangayomi.device` method channel with an `isTv` method, mirroring the existing channel pattern.
- **detection is conservative** so a phone is *never* misdetected as a TV: it returns true only when `UiModeManager.currentModeType == UI_MODE_TYPE_TELEVISION` **or** the device has `FEATURE_LEANBACK`. A normal phone has neither.
- **`platform_utils.dart`** — a `bool isTv` global, hydrated once at startup by `initIsTv()`. No-op (stays `false`) on non-Android platforms or if the channel is missing.
- **`main.dart`** — calls `initIsTv()` before `runApp()` so the value is ready when the UI builds.

### how to verify (on your AVD)
in a debug build it logs:
```
[platform] isTv = true   // on android-tv / google-tv / fire-tv
[platform] isTv = false  // on a phone/tablet
```
so it can be confirmed on `system-images;android-XX;android-tv` before anything is built on top of it.

### what's intentionally NOT here
the actual TV UX that *reads* `isTv` (e.g. anime-only browsing, 10-foot tweaks) is a **follow-up PR**, and it'll be gated with a manual override so a wrong detection can never strand a phone user. Splitting it this way means the risky part (detection) is verifiable in isolation first.

### notes
- **builds in CI now, and the native `isTv` path is confirmed on-device** — logcat shows `[platform] isTv = true` on a physical Android TV. the Kotlin mirrors the existing `MethodChannel` blocks and the Dart wiring is verified.

