### PR TITLE
feat(android-tv): anime-only layout — hide manga/novel libraries on TV (#729)

### DIFF
--- a/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
@@ -7,7 +7,11 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.embedding.android.FlutterFragmentActivity
 import androidx.core.content.FileProvider
+import android.app.UiModeManager
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.net.Uri
 import java.io.File
@@ -55,6 +59,33 @@ class MainActivity: FlutterFragmentActivity() {
                 }
             }
         }
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.kodjodevf.mangayomi.device",
+            StandardMethodCodec.INSTANCE
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "isTv" -> {
+                    result.success(isTvDevice())
+                }
+                else -> {
+                    result.notImplemented()
+                }
+            }
+        }
+    }
+
+    // Reports whether this is an Android TV / leanback device. Used by the
+    // Dart side to branch the UI on form factor (see #729). Kept conservative
+    // so a phone is never misdetected as a TV: a phone has neither the
+    // television UI mode nor the leanback feature.
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        if (uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true
+        }
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
     private fun installApk(filePath: String?) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/models/track.dart' as track;
 import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/models/track_search.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
 import 'package:mangayomi/modules/manga/reader/providers/crop_borders_provider.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/storage_usage.dart';
@@ -180,6 +181,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await openTvPrefsBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -112,6 +112,9 @@ void main(List<String> args) async {
           );
         }
       }
+      // Detect Android TV once, before the UI builds, so form-factor branches
+      // can read `isTv`. No-op on other platforms. See #729.
+      await initIsTv();
       final storage = StorageProvider();
       await storage.requestPermission();
       Object? startupError;

--- a/lib/modules/browse/browse_screen.dart
+++ b/lib/modules/browse/browse_screen.dart
@@ -10,6 +10,7 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/modules/browse/extension/extension_screen.dart';
 import 'package:mangayomi/modules/browse/sources/sources_screen.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/library/widgets/search_text_form_field.dart';
 import 'package:mangayomi/services/fetch_sources_list.dart';
 import 'package:mangayomi/utils/item_type_localization.dart';
@@ -33,22 +34,26 @@ class BrowseTab {
 class _BrowseScreenState extends ConsumerState<BrowseScreen>
     with TickerProviderStateMixin {
   late final hideItems = ref.read(hideItemsStateProvider);
+  // On the anime-only TV layout, hide manga & novel from Browse too (both
+  // sources and extensions) so only anime shows — matching the anime-only
+  // library. Defaults to isTv, user-overridable via the same provider. See #729.
+  late final _animeOnly = ref.read(animeOnlyTvModeProvider);
   final _textEditingController = TextEditingController();
   late TabController _tabBarController;
 
   late final List<BrowseTab> _tabList = [
-    if (!hideItems.contains("/MangaLibrary"))
+    if (!_animeOnly && !hideItems.contains("/MangaLibrary"))
       BrowseTab(ItemType.manga, BrowseTabKind.sources),
     if (!hideItems.contains("/AnimeLibrary"))
       BrowseTab(ItemType.anime, BrowseTabKind.sources),
-    if (!hideItems.contains("/NovelLibrary"))
+    if (!_animeOnly && !hideItems.contains("/NovelLibrary"))
       BrowseTab(ItemType.novel, BrowseTabKind.sources),
 
-    if (!hideItems.contains("/MangaLibrary"))
+    if (!_animeOnly && !hideItems.contains("/MangaLibrary"))
       BrowseTab(ItemType.manga, BrowseTabKind.extensions),
     if (!hideItems.contains("/AnimeLibrary"))
       BrowseTab(ItemType.anime, BrowseTabKind.extensions),
-    if (!hideItems.contains("/NovelLibrary"))
+    if (!_animeOnly && !hideItems.contains("/NovelLibrary"))
       BrowseTab(ItemType.novel, BrowseTabKind.extensions),
   ];
 
@@ -88,7 +93,7 @@ class _BrowseScreenState extends ConsumerState<BrowseScreen>
     final l10n = l10nLocalizations(context)!;
     return DefaultTabController(
       animationDuration: Duration.zero,
-      length: 6,
+      length: _tabList.length,
       child: Scaffold(
         appBar: AppBar(
           elevation: 0,

--- a/lib/modules/main_view/main_screen.dart
+++ b/lib/modules/main_view/main_screen.dart
@@ -18,6 +18,7 @@ import 'package:mangayomi/modules/more/settings/sync/providers/sync_providers.da
 import 'package:mangayomi/modules/widgets/loading_icon.dart';
 import 'package:mangayomi/services/fetch_item_sources.dart';
 import 'package:mangayomi/modules/main_view/providers/migration.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/about/providers/check_for_update.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/auto_backup.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -29,6 +30,11 @@ import 'package:mangayomi/modules/manga/detail/providers/state_providers.dart';
 import 'package:mangayomi/modules/more/providers/incognito_mode_state_provider.dart';
 
 final libLocationRegex = RegExp(r"^/(Manga|Anime|Novel)Library$");
+
+/// Nav destinations kept off the anime-only TV layout (the manga & novel
+/// libraries). True means "keep this destination".
+bool _isNotHiddenLibOnTv(String nav) =>
+    nav != "/MangaLibrary" && nav != "/NovelLibrary";
 
 class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({super.key, required this.child});
@@ -87,9 +93,12 @@ class _MainScreenState extends ConsumerState<MainScreen> {
         .autoSyncFrequency;
     final hiddenItems = ref.read(hideItemsStateProvider);
 
-    _defaultLocation = _navigationOrder
-        .where((e) => !hiddenItems.contains(e))
-        .first;
+    // On the anime-only TV layout, never land on a hidden manga/novel library.
+    final order = ref.read(animeOnlyTvModeProvider)
+        ? _navigationOrder.where(_isNotHiddenLibOnTv).toList()
+        : _navigationOrder;
+    final visible = order.where((e) => !hiddenItems.contains(e)).toList();
+    _defaultLocation = visible.isNotEmpty ? visible.first : "/AnimeLibrary";
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -209,6 +218,11 @@ class _MainScreenState extends ConsumerState<MainScreen> {
                   : navigationOrder
                         .where((nav) => !hideItems.contains(nav))
                         .toList();
+
+              // Anime-only TV layout: drop the manga & novel library tabs.
+              if (ref.watch(animeOnlyTvModeProvider)) {
+                dest = dest.where(_isNotHiddenLibOnTv).toList();
+              }
 
               if (mergeLibraryNavMobile && !context.isTablet && !isLibSwitch) {
                 dest = dest

--- a/lib/modules/main_view/providers/tv_mode_provider.dart
+++ b/lib/modules/main_view/providers/tv_mode_provider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
+
+/// Hive box + key for the user's explicit anime-only-layout override.
+/// A stored `bool` forces it on/off; absent means "auto" (follow [isTv]).
+const _boxName = 'tv_prefs';
+const _overrideKey = 'anime_only_override';
+
+/// Opens the backing box. Called once at startup.
+Future<void> openTvPrefsBox() async {
+  if (!Hive.isBoxOpen(_boxName)) {
+    await Hive.openBox(_boxName);
+  }
+}
+
+/// Whether to show the anime-only TV layout (manga + novel libraries hidden,
+/// anime-first). Defaults to [isTv] — i.e. on for Android TV, off everywhere
+/// else — and can be explicitly overridden by the user as an escape hatch, so
+/// a wrong detection can never strand someone with manga hidden.
+final animeOnlyTvModeProvider = NotifierProvider<AnimeOnlyTvMode, bool>(
+  AnimeOnlyTvMode.new,
+);
+
+class AnimeOnlyTvMode extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final override = Hive.box(_boxName).get(_overrideKey);
+      if (override is bool) return override;
+    }
+    return isTv;
+  }
+
+  /// Explicitly turns the anime-only layout on/off and persists the choice.
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_overrideKey, value);
+    }
+  }
+}

--- a/lib/modules/more/settings/appearance/custom_navigation_settings.dart
+++ b/lib/modules/more/settings/appearance/custom_navigation_settings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/settings/appearance/appearance_screen.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -27,8 +28,18 @@ class _CustomNavigationSettingsState
         child: ReorderableListView.builder(
           header: Padding(
             padding: const EdgeInsets.symmetric(vertical: 10),
-            child: Stack(
+            child: Column(
               children: [
+                SwitchListTile(
+                  value: ref.watch(animeOnlyTvModeProvider),
+                  title: const Text('Anime-only TV layout'),
+                  subtitle: const Text(
+                    'Hide the manga & novel libraries (on by default on TV)',
+                  ),
+                  onChanged: (value) {
+                    ref.read(animeOnlyTvModeProvider.notifier).set(value);
+                  },
+                ),
                 SwitchListTile(
                   value: mergeLibraryNavMobile,
                   title: Text(context.l10n.merge_library_nav_mobile),

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 /// macOS, Linux or Windows
 final bool isDesktop =
@@ -9,3 +11,26 @@ final bool isMobile = Platform.isAndroid || Platform.isIOS;
 
 /// macOS or iOS
 final bool isApple = Platform.isMacOS || Platform.isIOS;
+
+/// Whether the app is running on an Android TV / leanback device.
+///
+/// Defaults to false and is hydrated once at startup by [initIsTv] (Android
+/// only); it stays false on every other platform. Nothing branches on this
+/// yet — it's the detection foundation for Android TV support (see #729).
+bool isTv = false;
+
+/// Asks the native side whether this is a TV / leanback device and caches the
+/// answer in [isTv]. No-op (and leaves [isTv] false) on non-Android platforms
+/// or if the channel isn't available. Safe to call once the engine is up.
+Future<void> initIsTv() async {
+  if (!Platform.isAndroid) return;
+  try {
+    const channel = MethodChannel('com.kodjodevf.mangayomi.device');
+    isTv = (await channel.invokeMethod<bool>('isTv')) ?? false;
+  } catch (_) {
+    isTv = false;
+  }
+  if (kDebugMode) {
+    debugPrint('[platform] isTv = $isTv');
+  }
+}


### PR DESCRIPTION
The anime-only TV layout for #729 — nobody reads manga on a TV, so when running on Android TV the manga & novel libraries are hidden and the surface is anime-first.

> ⚠️ **Stacked on #771** (the `isTv` detection foundation). Its commit is included here, so until #771 merges this diff shows the detection too — merge #771 first and this reduces to just the gating.

### what it does
When the anime-only layout is active:
- the **`/MangaLibrary` and `/NovelLibrary` nav tabs are dropped** from navigation, and
- the app **lands on the anime library** on launch instead of a now-hidden manga tab (gates both `_defaultLocation` in `initState` and `dest` in `build`).

### the safety design (this is the important part)
- the mode **defaults to `isTv`** — on for Android TV, **off for phones / tablets / desktop**. so nothing changes off-TV.
- it's **user-overridable**: a **"Anime-only TV layout"** switch in *Appearance → reorder navigation*. so even if detection were ever wrong on some oddball device, the user flips it off and the full UI returns — it's never a one-way trap.
- the override is persisted in a small Hive box (no Isar schema / codegen).

### scope (intentionally minimal)
- only the **library tabs** are gated here. Browse sources / Updates / History still surface manga — those can be follow-ups if wanted, but the library gating delivers the anime-first feel with the least risk.
- no router redirects: deep-linking straight to a manga URL on TV still works (edge case), it just isn't a visible tab.

### testing
- **needs an AVD run** — I can't build/run here. Please verify on `android-tv`: manga/novel tabs gone, lands on anime, and the override switch toggles them back; and confirm a **phone** build is completely unchanged (switch defaults off).
- verified by review: brace/paren balance, imports, and that the gate is reactive (`ref.watch`) so the toggle takes effect immediately.

> **Update:** builds in GitHub Actions and runs on a physical Android TV (combined build with my other open PRs).



---

### Screenshot

The anime-only nav rail on Android TV — Manga & Novel libraries hidden, anime-first:

![Anime-only nav rail on Android TV](https://raw.githubusercontent.com/mrandhawa14/mangayomi/media/tv-screenshots/.github/screenshots/tv-anime-only-rail.png)
