### PR TITLE
feat(android-tv): d-pad navigation for the tab rail (#729)

### DIFF
--- a/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
@@ -7,7 +7,11 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.embedding.android.FlutterFragmentActivity
 import androidx.core.content.FileProvider
+import android.app.UiModeManager
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.net.Uri
 import java.io.File
@@ -55,6 +59,33 @@ class MainActivity: FlutterFragmentActivity() {
                 }
             }
         }
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.kodjodevf.mangayomi.device",
+            StandardMethodCodec.INSTANCE
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "isTv" -> {
+                    result.success(isTvDevice())
+                }
+                else -> {
+                    result.notImplemented()
+                }
+            }
+        }
+    }
+
+    // Reports whether this is an Android TV / leanback device. Used by the
+    // Dart side to branch the UI on form factor (see #729). Kept conservative
+    // so a phone is never misdetected as a TV: a phone has neither the
+    // television UI mode nor the leanback feature.
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        if (uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true
+        }
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
     private fun installApk(filePath: String?) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/models/track.dart' as track;
 import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/models/track_search.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
 import 'package:mangayomi/modules/manga/reader/providers/crop_borders_provider.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/storage_usage.dart';
@@ -180,6 +181,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await openTvPrefsBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -112,6 +112,9 @@ void main(List<String> args) async {
           );
         }
       }
+      // Detect Android TV once, before the UI builds, so form-factor branches
+      // can read `isTv`. No-op on other platforms. See #729.
+      await initIsTv();
       final storage = StorageProvider();
       await storage.requestPermission();
       Object? startupError;

--- a/lib/modules/browse/browse_screen.dart
+++ b/lib/modules/browse/browse_screen.dart
@@ -10,6 +10,7 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/modules/browse/extension/extension_screen.dart';
 import 'package:mangayomi/modules/browse/sources/sources_screen.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/library/widgets/search_text_form_field.dart';
 import 'package:mangayomi/services/fetch_sources_list.dart';
 import 'package:mangayomi/utils/item_type_localization.dart';
@@ -33,22 +34,26 @@ class BrowseTab {
 class _BrowseScreenState extends ConsumerState<BrowseScreen>
     with TickerProviderStateMixin {
   late final hideItems = ref.read(hideItemsStateProvider);
+  // On the anime-only TV layout, hide manga & novel from Browse too (both
+  // sources and extensions) so only anime shows — matching the anime-only
+  // library. Defaults to isTv, user-overridable via the same provider. See #729.
+  late final _animeOnly = ref.read(animeOnlyTvModeProvider);
   final _textEditingController = TextEditingController();
   late TabController _tabBarController;
 
   late final List<BrowseTab> _tabList = [
-    if (!hideItems.contains("/MangaLibrary"))
+    if (!_animeOnly && !hideItems.contains("/MangaLibrary"))
       BrowseTab(ItemType.manga, BrowseTabKind.sources),
     if (!hideItems.contains("/AnimeLibrary"))
       BrowseTab(ItemType.anime, BrowseTabKind.sources),
-    if (!hideItems.contains("/NovelLibrary"))
+    if (!_animeOnly && !hideItems.contains("/NovelLibrary"))
       BrowseTab(ItemType.novel, BrowseTabKind.sources),
 
-    if (!hideItems.contains("/MangaLibrary"))
+    if (!_animeOnly && !hideItems.contains("/MangaLibrary"))
       BrowseTab(ItemType.manga, BrowseTabKind.extensions),
     if (!hideItems.contains("/AnimeLibrary"))
       BrowseTab(ItemType.anime, BrowseTabKind.extensions),
-    if (!hideItems.contains("/NovelLibrary"))
+    if (!_animeOnly && !hideItems.contains("/NovelLibrary"))
       BrowseTab(ItemType.novel, BrowseTabKind.extensions),
   ];
 
@@ -88,7 +93,7 @@ class _BrowseScreenState extends ConsumerState<BrowseScreen>
     final l10n = l10nLocalizations(context)!;
     return DefaultTabController(
       animationDuration: Duration.zero,
-      length: 6,
+      length: _tabList.length,
       child: Scaffold(
         appBar: AppBar(
           elevation: 0,

--- a/lib/modules/main_view/main_screen.dart
+++ b/lib/modules/main_view/main_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -636,7 +637,7 @@ class _IncognitoModeBar extends StatelessWidget {
   }
 }
 
-class _TabletLayout extends StatelessWidget {
+class _TabletLayout extends StatefulWidget {
   const _TabletLayout({
     required this.isLongPressed,
     required this.location,
@@ -663,13 +664,102 @@ class _TabletLayout extends StatelessWidget {
   buildNavigationWidgetsDesktop;
 
   @override
+  State<_TabletLayout> createState() => _TabletLayoutState();
+}
+
+class _TabletLayoutState extends State<_TabletLayout> {
+  // Explicit focus scopes for the rail and the routed content, used on Android
+  // TV only. Directional (d-pad) focus traversal doesn't cross into the rail —
+  // the routed page lives in its own FocusScope and arrows only move focus
+  // within it — so we move focus between the two scopes ourselves. A scope
+  // wraps the whole rail because NavigationRail doesn't expose its
+  // destinations' focus nodes.
+  final FocusScopeNode _railScope = FocusScopeNode(debugLabel: 'navRailScope');
+  final FocusScopeNode _contentScope = FocusScopeNode(
+    debugLabel: 'navContentScope',
+  );
+  bool _didAutofocusRail = false;
+
+  @override
+  void dispose() {
+    _railScope.dispose();
+    _contentScope.dispose();
+    super.dispose();
+  }
+
+  // TV d-pad crossing: LEFT that can't move any further inside the content
+  // pulls focus onto the rail; RIGHT from the rail dives into the content.
+  // Other keys (up/down/select) fall through to the default handler. Only
+  // active while the rail is visible (library tabs), never in the reader.
+  KeyEventResult _handleTvKey(KeyEvent event, bool railVisible) {
+    if (!railVisible) return KeyEventResult.ignored;
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    final key = event.logicalKey;
+    if (key == LogicalKeyboardKey.arrowLeft) {
+      if (_railScope.hasFocus) return KeyEventResult.ignored;
+      final current = FocusManager.instance.primaryFocus;
+      final moved = current?.focusInDirection(TraversalDirection.left) ?? false;
+      if (!moved) _railScope.requestFocus();
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowRight && _railScope.hasFocus) {
+      _contentScope.requestFocus();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final destinations = buildNavigationWidgetsDesktop(ref, dest, context);
-    return Row(
+    final destinations = widget.buildNavigationWidgetsDesktop(
+      widget.ref,
+      widget.dest,
+      context,
+    );
+    final railWidth = _getNavigationRailWidth(
+      widget.isLongPressed,
+      widget.location,
+    );
+    final railVisible = railWidth > 0;
+
+    // On a TV, open with the tab rail focused so the user lands on the tabs and
+    // dives into content with RIGHT. One-shot per mount.
+    if (isTv && railVisible && !_didAutofocusRail) {
+      _didAutofocusRail = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _railScope.requestFocus();
+      });
+    }
+
+    Widget navRail = NavigationRail(
+      labelType: NavigationRailLabelType.all,
+      useIndicator: true,
+      destinations: destinations,
+      selectedIndex:
+          (widget.currentIndex >= 0 &&
+              widget.currentIndex < destinations.length)
+          ? widget.currentIndex
+          : 0,
+      onDestinationSelected: (newIndex) {
+        widget.route.go(widget.dest[newIndex]);
+      },
+    );
+    if (isTv) {
+      navRail = FocusScope(node: _railScope, child: navRail);
+    }
+
+    Widget content = widget.child;
+    if (isTv) {
+      content = FocusScope(node: _contentScope, child: content);
+    }
+
+    Widget row = Row(
       children: [
         AnimatedContainer(
           duration: const Duration(milliseconds: 0),
-          width: _getNavigationRailWidth(isLongPressed, location),
+          width: railWidth,
           child: Stack(
             children: [
               NavigationRailTheme(
@@ -678,25 +768,38 @@ class _TabletLayout extends StatelessWidget {
                     borderRadius: BorderRadius.circular(30),
                   ),
                 ),
-                child: NavigationRail(
-                  labelType: NavigationRailLabelType.all,
-                  useIndicator: true,
-                  destinations: destinations,
-                  selectedIndex:
-                      (currentIndex >= 0 && currentIndex < destinations.length)
-                      ? currentIndex
-                      : 0,
-                  onDestinationSelected: (newIndex) {
-                    route.go(dest[newIndex]);
-                  },
+                // On Android TV the rail destination's default d-pad focus
+                // overlay is too faint to see from across a room. The
+                // destination InkResponse draws its focus highlight from the
+                // ambient Theme.focusColor, so a bold primary-tinted focusColor
+                // makes the focused tab clearly visible. No-op off TV.
+                child: Theme(
+                  data: Theme.of(context).copyWith(
+                    focusColor: isTv
+                        ? context.primaryColor.withValues(alpha: 0.45)
+                        : Theme.of(context).focusColor,
+                  ),
+                  child: navRail,
                 ),
               ),
             ],
           ),
         ),
-        Expanded(child: child),
+        Expanded(child: content),
       ],
     );
+
+    // Wrap in a non-focusable key handler on TV so we can move focus across the
+    // rail/content scope boundary that directional traversal won't cross.
+    if (isTv) {
+      row = Focus(
+        canRequestFocus: false,
+        skipTraversal: true,
+        onKeyEvent: (node, event) => _handleTvKey(event, railVisible),
+        child: row,
+      );
+    }
+    return row;
   }
 
   static double _getNavigationRailWidth(bool isLongPressed, String? location) {

--- a/lib/modules/main_view/main_screen.dart
+++ b/lib/modules/main_view/main_screen.dart
@@ -18,6 +18,7 @@ import 'package:mangayomi/modules/more/settings/sync/providers/sync_providers.da
 import 'package:mangayomi/modules/widgets/loading_icon.dart';
 import 'package:mangayomi/services/fetch_item_sources.dart';
 import 'package:mangayomi/modules/main_view/providers/migration.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/about/providers/check_for_update.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/auto_backup.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -29,6 +30,11 @@ import 'package:mangayomi/modules/manga/detail/providers/state_providers.dart';
 import 'package:mangayomi/modules/more/providers/incognito_mode_state_provider.dart';
 
 final libLocationRegex = RegExp(r"^/(Manga|Anime|Novel)Library$");
+
+/// Nav destinations kept off the anime-only TV layout (the manga & novel
+/// libraries). True means "keep this destination".
+bool _isNotHiddenLibOnTv(String nav) =>
+    nav != "/MangaLibrary" && nav != "/NovelLibrary";
 
 class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({super.key, required this.child});
@@ -87,9 +93,12 @@ class _MainScreenState extends ConsumerState<MainScreen> {
         .autoSyncFrequency;
     final hiddenItems = ref.read(hideItemsStateProvider);
 
-    _defaultLocation = _navigationOrder
-        .where((e) => !hiddenItems.contains(e))
-        .first;
+    // On the anime-only TV layout, never land on a hidden manga/novel library.
+    final order = ref.read(animeOnlyTvModeProvider)
+        ? _navigationOrder.where(_isNotHiddenLibOnTv).toList()
+        : _navigationOrder;
+    final visible = order.where((e) => !hiddenItems.contains(e)).toList();
+    _defaultLocation = visible.isNotEmpty ? visible.first : "/AnimeLibrary";
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -209,6 +218,11 @@ class _MainScreenState extends ConsumerState<MainScreen> {
                   : navigationOrder
                         .where((nav) => !hideItems.contains(nav))
                         .toList();
+
+              // Anime-only TV layout: drop the manga & novel library tabs.
+              if (ref.watch(animeOnlyTvModeProvider)) {
+                dest = dest.where(_isNotHiddenLibOnTv).toList();
+              }
 
               if (mergeLibraryNavMobile && !context.isTablet && !isLibSwitch) {
                 dest = dest

--- a/lib/modules/main_view/main_screen.dart
+++ b/lib/modules/main_view/main_screen.dart
@@ -679,6 +679,9 @@ class _TabletLayoutState extends State<_TabletLayout> {
     debugLabel: 'navContentScope',
   );
   bool _didAutofocusRail = false;
+  // Remembers where focus was in the content when the user crossed to the rail,
+  // so RIGHT returns them to the exact same spot.
+  FocusNode? _lastContentFocus;
 
   @override
   void dispose() {
@@ -687,10 +690,11 @@ class _TabletLayoutState extends State<_TabletLayout> {
     super.dispose();
   }
 
-  // TV d-pad crossing: LEFT that can't move any further inside the content
-  // pulls focus onto the rail; RIGHT from the rail dives into the content.
-  // Other keys (up/down/select) fall through to the default handler. Only
-  // active while the rail is visible (library tabs), never in the reader.
+  // TV d-pad crossing: a single LEFT pulls focus straight onto the rail (no need
+  // to walk the whole content grid to reach its edge first); RIGHT from the rail
+  // returns to exactly where the user left the content. Other keys (up/down/
+  // select) fall through to the default handler. Only active while the rail is
+  // visible (library tabs), never in the reader.
   KeyEventResult _handleTvKey(KeyEvent event, bool railVisible) {
     if (!railVisible) return KeyEventResult.ignored;
     if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
@@ -699,13 +703,17 @@ class _TabletLayoutState extends State<_TabletLayout> {
     final key = event.logicalKey;
     if (key == LogicalKeyboardKey.arrowLeft) {
       if (_railScope.hasFocus) return KeyEventResult.ignored;
-      final current = FocusManager.instance.primaryFocus;
-      final moved = current?.focusInDirection(TraversalDirection.left) ?? false;
-      if (!moved) _railScope.requestFocus();
+      _lastContentFocus = FocusManager.instance.primaryFocus;
+      _railScope.requestFocus();
       return KeyEventResult.handled;
     }
     if (key == LogicalKeyboardKey.arrowRight && _railScope.hasFocus) {
-      _contentScope.requestFocus();
+      final last = _lastContentFocus;
+      if (last != null && last.context != null) {
+        last.requestFocus();
+      } else {
+        _contentScope.requestFocus();
+      }
       return KeyEventResult.handled;
     }
     return KeyEventResult.ignored;
@@ -721,6 +729,7 @@ class _TabletLayoutState extends State<_TabletLayout> {
     final railWidth = _getNavigationRailWidth(
       widget.isLongPressed,
       widget.location,
+      isTv,
     );
     final railVisible = railWidth > 0;
 
@@ -736,6 +745,14 @@ class _TabletLayoutState extends State<_TabletLayout> {
     Widget navRail = NavigationRail(
       labelType: NavigationRailLabelType.all,
       useIndicator: true,
+      // Scale the rail up on TV for couch-distance readability.
+      minWidth: isTv ? 96.0 : null,
+      selectedIconTheme: isTv ? const IconThemeData(size: 32) : null,
+      unselectedIconTheme: isTv ? const IconThemeData(size: 30) : null,
+      selectedLabelTextStyle: isTv
+          ? const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)
+          : null,
+      unselectedLabelTextStyle: isTv ? const TextStyle(fontSize: 13) : null,
       destinations: destinations,
       selectedIndex:
           (widget.currentIndex >= 0 &&
@@ -802,7 +819,11 @@ class _TabletLayoutState extends State<_TabletLayout> {
     return row;
   }
 
-  static double _getNavigationRailWidth(bool isLongPressed, String? location) {
+  static double _getNavigationRailWidth(
+    bool isLongPressed,
+    String? location,
+    bool isTv,
+  ) {
     if (isLongPressed) return 0;
 
     const validLocations = {
@@ -816,7 +837,10 @@ class _TabletLayoutState extends State<_TabletLayout> {
       '/trackerLibrary',
     };
 
-    return (location == null || validLocations.contains(location)) ? 100 : 0;
+    final visible = location == null || validLocations.contains(location);
+    if (!visible) return 0;
+    // A wider rail on TV so the bigger icons + labels are readable from the couch.
+    return isTv ? 140 : 100;
   }
 }
 

--- a/lib/modules/main_view/providers/tv_mode_provider.dart
+++ b/lib/modules/main_view/providers/tv_mode_provider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
+
+/// Hive box + key for the user's explicit anime-only-layout override.
+/// A stored `bool` forces it on/off; absent means "auto" (follow [isTv]).
+const _boxName = 'tv_prefs';
+const _overrideKey = 'anime_only_override';
+
+/// Opens the backing box. Called once at startup.
+Future<void> openTvPrefsBox() async {
+  if (!Hive.isBoxOpen(_boxName)) {
+    await Hive.openBox(_boxName);
+  }
+}
+
+/// Whether to show the anime-only TV layout (manga + novel libraries hidden,
+/// anime-first). Defaults to [isTv] — i.e. on for Android TV, off everywhere
+/// else — and can be explicitly overridden by the user as an escape hatch, so
+/// a wrong detection can never strand someone with manga hidden.
+final animeOnlyTvModeProvider = NotifierProvider<AnimeOnlyTvMode, bool>(
+  AnimeOnlyTvMode.new,
+);
+
+class AnimeOnlyTvMode extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final override = Hive.box(_boxName).get(_overrideKey);
+      if (override is bool) return override;
+    }
+    return isTv;
+  }
+
+  /// Explicitly turns the anime-only layout on/off and persists the choice.
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_overrideKey, value);
+    }
+  }
+}

--- a/lib/modules/more/settings/appearance/custom_navigation_settings.dart
+++ b/lib/modules/more/settings/appearance/custom_navigation_settings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/settings/appearance/appearance_screen.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -27,8 +28,18 @@ class _CustomNavigationSettingsState
         child: ReorderableListView.builder(
           header: Padding(
             padding: const EdgeInsets.symmetric(vertical: 10),
-            child: Stack(
+            child: Column(
               children: [
+                SwitchListTile(
+                  value: ref.watch(animeOnlyTvModeProvider),
+                  title: const Text('Anime-only TV layout'),
+                  subtitle: const Text(
+                    'Hide the manga & novel libraries (on by default on TV)',
+                  ),
+                  onChanged: (value) {
+                    ref.read(animeOnlyTvModeProvider.notifier).set(value);
+                  },
+                ),
                 SwitchListTile(
                   value: mergeLibraryNavMobile,
                   title: Text(context.l10n.merge_library_nav_mobile),

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 /// macOS, Linux or Windows
 final bool isDesktop =
@@ -9,3 +11,26 @@ final bool isMobile = Platform.isAndroid || Platform.isIOS;
 
 /// macOS or iOS
 final bool isApple = Platform.isMacOS || Platform.isIOS;
+
+/// Whether the app is running on an Android TV / leanback device.
+///
+/// Defaults to false and is hydrated once at startup by [initIsTv] (Android
+/// only); it stays false on every other platform. Nothing branches on this
+/// yet — it's the detection foundation for Android TV support (see #729).
+bool isTv = false;
+
+/// Asks the native side whether this is a TV / leanback device and caches the
+/// answer in [isTv]. No-op (and leaves [isTv] false) on non-Android platforms
+/// or if the channel isn't available. Safe to call once the engine is up.
+Future<void> initIsTv() async {
+  if (!Platform.isAndroid) return;
+  try {
+    const channel = MethodChannel('com.kodjodevf.mangayomi.device');
+    isTv = (await channel.invokeMethod<bool>('isTv')) ?? false;
+  } catch (_) {
+    isTv = false;
+  }
+  if (kDebugMode) {
+    debugPrint('[platform] isTv = $isTv');
+  }
+}


### PR DESCRIPTION
Part of **[RFC] Android TV / Leanback support (#729)**.

On Android TV the desktop nav rail was effectively unreachable with a remote: directional (d-pad) focus doesn't cross into it, because the routed content page sits in its own `FocusScope` and arrows only move focus within it. So focus moved *within* the library grid but never escaped to the tabs.

This wires the rail and content into explicit focus scopes and bridges them deterministically (TV only):

- **autofocus the rail on launch** — you land on the tabs and dive into content with RIGHT
- **d-pad LEFT** at the content's edge → jumps to the rail
- **d-pad RIGHT** from the rail → into the content
- up/down + select on the rail work as normal
- the focused tab is made clearly visible via `Theme.focusColor`

All of it is gated on `isTv`, so desktop/tablet keep the stock `NavigationRail` behaviour byte-for-byte.

**Depends on** #771 (isTv) and #772 (anime-only rail); this branch is stacked on them, so its diff reduces to just the nav-focus change once those merge.

**Verification:** on-device on a physical Android TV, d-pad now reaches and highlights the tabs. Compiled in GitHub Actions as part of the combined Android TV build. No local Flutter SDK, so the Dart is otherwise review-verified.



---

### Screenshot

The nav rail focused on launch (Anime tab highlighted) on a physical Android TV:

![Nav rail focus on Android TV](https://raw.githubusercontent.com/mrandhawa14/mangayomi/media/tv-screenshots/.github/screenshots/tv-anime-only-rail.png)
