### PR TITLE
feat(android-tv): don't autofocus dialog text fields on TV (#729)

### DIFF
--- a/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
@@ -7,7 +7,11 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.embedding.android.FlutterFragmentActivity
 import androidx.core.content.FileProvider
+import android.app.UiModeManager
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.net.Uri
 import java.io.File
@@ -55,6 +59,33 @@ class MainActivity: FlutterFragmentActivity() {
                 }
             }
         }
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.kodjodevf.mangayomi.device",
+            StandardMethodCodec.INSTANCE
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "isTv" -> {
+                    result.success(isTvDevice())
+                }
+                else -> {
+                    result.notImplemented()
+                }
+            }
+        }
+    }
+
+    // Reports whether this is an Android TV / leanback device. Used by the
+    // Dart side to branch the UI on form factor (see #729). Kept conservative
+    // so a phone is never misdetected as a TV: a phone has neither the
+    // television UI mode nor the leanback feature.
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        if (uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true
+        }
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
     private fun installApk(filePath: String?) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -112,6 +112,9 @@ void main(List<String> args) async {
           );
         }
       }
+      // Detect Android TV once, before the UI builds, so form-factor branches
+      // can read `isTv`. No-op on other platforms. See #729.
+      await initIsTv();
       final storage = StorageProvider();
       await storage.requestPermission();
       Object? startupError;

--- a/lib/modules/more/categories/widgets/custom_textfield.dart
+++ b/lib/modules/more/categories/widgets/custom_textfield.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/models/category.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 
@@ -25,7 +26,7 @@ class CustomTextFormField extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = l10nLocalizations(context);
     return TextFormField(
-      autofocus: true,
+      autofocus: !isTv,
       controller: controller,
       keyboardType: TextInputType.text,
       onChanged: (value) {

--- a/lib/modules/more/settings/browse/extension_server/android_proxy_server_dialog.dart
+++ b/lib/modules/more/settings/browse/extension_server/android_proxy_server_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 
@@ -30,7 +31,7 @@ void showAndroidProxyServerDialog(
                   padding: const EdgeInsets.symmetric(vertical: 10),
                   child: TextFormField(
                     controller: serverController,
-                    autofocus: true,
+                    autofocus: !isTv,
                     onChanged: (value) => setState(() {
                       server = value;
                     }),

--- a/lib/modules/more/settings/browse/source_repositories.dart
+++ b/lib/modules/more/settings/browse/source_repositories.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/eval/model/m_bridge.dart';
@@ -330,7 +331,7 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
                 title: Text(l10n.add_extensions_repo),
                 content: TextFormField(
                   controller: controller,
-                  autofocus: true,
+                  autofocus: !isTv,
                   keyboardType: TextInputType.url,
                   onChanged: (value) => setState(() {}),
                   validator: (value) {

--- a/lib/modules/more/settings/sync/sync.dart
+++ b/lib/modules/more/settings/sync/sync.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isar_community/isar.dart';
 import 'package:mangayomi/eval/model/m_bridge.dart';
@@ -460,7 +461,7 @@ class SyncScreen extends ConsumerWidget {
                     padding: const EdgeInsets.symmetric(vertical: 10),
                     child: TextFormField(
                       controller: serverController,
-                      autofocus: true,
+                      autofocus: !isTv,
                       onChanged: (value) => setState(() {
                         server = value;
                       }),
@@ -488,7 +489,7 @@ class SyncScreen extends ConsumerWidget {
                     padding: const EdgeInsets.symmetric(vertical: 10),
                     child: TextFormField(
                       controller: emailController,
-                      autofocus: true,
+                      autofocus: !isTv,
                       onChanged: (value) => setState(() {
                         email = value;
                       }),

--- a/lib/modules/more/settings/track/track.dart
+++ b/lib/modules/more/settings/track/track.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -237,7 +238,7 @@ Future<void> _showDialogLogin(BuildContext context, WidgetRef ref) async {
                         AutofillHints.email,
                         AutofillHints.username,
                       ],
-                      autofocus: true,
+                      autofocus: !isTv,
                       onChanged: (_) => setState(updateCanLogin),
                       onFieldSubmitted: (_) => passwordFocusNode.requestFocus(),
                       decoration: InputDecoration(

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 /// macOS, Linux or Windows
 final bool isDesktop =
@@ -9,3 +11,26 @@ final bool isMobile = Platform.isAndroid || Platform.isIOS;
 
 /// macOS or iOS
 final bool isApple = Platform.isMacOS || Platform.isIOS;
+
+/// Whether the app is running on an Android TV / leanback device.
+///
+/// Defaults to false and is hydrated once at startup by [initIsTv] (Android
+/// only); it stays false on every other platform. Nothing branches on this
+/// yet — it's the detection foundation for Android TV support (see #729).
+bool isTv = false;
+
+/// Asks the native side whether this is a TV / leanback device and caches the
+/// answer in [isTv]. No-op (and leaves [isTv] false) on non-Android platforms
+/// or if the channel isn't available. Safe to call once the engine is up.
+Future<void> initIsTv() async {
+  if (!Platform.isAndroid) return;
+  try {
+    const channel = MethodChannel('com.kodjodevf.mangayomi.device');
+    isTv = (await channel.invokeMethod<bool>('isTv')) ?? false;
+  } catch (_) {
+    isTv = false;
+  }
+  if (kDebugMode) {
+    debugPrint('[platform] isTv = $isTv');
+  }
+}


### PR DESCRIPTION
Part of **[RFC] Android TV / Leanback support (#729)**.

On Android TV, `autofocus: true` on a dialog's text field instantly pops the full-screen leanback keyboard over the dialog the moment it opens — hiding the Cancel/Add buttons and losing d-pad state, so you have to blindly arrow back out to reach the buttons.

Gate the autofocus to `!isTv` on the settings dialog text fields:

- add-source-repository (the one users hit first)
- tracking login (MAL / AniList)
- sync server + email
- proxy-server IP
- add-category name

On TV the dialog now opens visible and you open the keyboard with **select**, when you actually want to type. Phones keep the ready-to-type autofocus. (The custom DNS / DoH / CF-proxy / user-agent fields in General settings get the same treatment inside their respective PRs #763 / #766, since those dialogs live there.)

**Depends on** #771 (isTv).

**Verification:** on-device on a physical Android TV (the add-repo dialog no longer traps focus). Compiled in GitHub Actions as part of the combined Android TV build; Dart otherwise review-verified (no local Flutter SDK).
