### PR TITLE
feat: persistent update-errors screen with migrate-away

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,7 @@ import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/services/http/m_client.dart';
 import 'package:mangayomi/services/isolate_service.dart';
 import 'package:mangayomi/services/m_extension_server.dart';
+import 'package:mangayomi/services/update_errors_provider.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
 import 'package:mangayomi/src/rust/frb_generated.dart';
 import 'package:mangayomi/utils/discord_rpc.dart';
@@ -177,6 +178,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await openUpdateErrorsBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/modules/updates/update_errors_screen.dart
+++ b/lib/modules/updates/update_errors_screen.dart
@@ -1,0 +1,96 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/modules/manga/detail/widgets/migrate_screen.dart';
+import 'package:mangayomi/services/update_errors_provider.dart';
+
+/// Persistent list of the last library update's failures. Each entry can be
+/// dismissed or migrated away, so recurring source failures don't have to be
+/// caught in the transient post-update dialog.
+class UpdateErrorsScreen extends ConsumerWidget {
+  const UpdateErrorsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final errors = ref.watch(updateErrorsProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Update errors'),
+        actions: [
+          if (errors.isNotEmpty)
+            IconButton(
+              tooltip: 'Clear all',
+              icon: const Icon(Icons.clear_all),
+              onPressed: () => ref.read(updateErrorsProvider.notifier).clear(),
+            ),
+        ],
+      ),
+      body: errors.isEmpty
+          ? const Center(child: Text('No update errors'))
+          : ListView.builder(
+              itemCount: errors.length,
+              itemBuilder: (context, index) {
+                final err = errors[index];
+                final manga = isar.mangas.getSync(err.mangaId);
+                return ListTile(
+                  leading: _cover(manga),
+                  title: Text(
+                    err.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Text(
+                    err.error,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (manga != null)
+                        IconButton(
+                          tooltip: 'Migrate',
+                          icon: const Icon(Icons.swap_horiz),
+                          onPressed: () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => MigrationScreen(manga: manga),
+                            ),
+                          ),
+                        ),
+                      IconButton(
+                        tooltip: 'Dismiss',
+                        icon: const Icon(Icons.close),
+                        onPressed: () => ref
+                            .read(updateErrorsProvider.notifier)
+                            .remove(err.mangaId),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+    );
+  }
+
+  Widget _cover(Manga? manga) {
+    final cover = manga?.customCoverImage;
+    return SizedBox(
+      width: 40,
+      height: 56,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(4),
+        child: cover != null && cover.isNotEmpty
+            ? Image.memory(Uint8List.fromList(cover), fit: BoxFit.cover)
+            : const ColoredBox(
+                color: Colors.black12,
+                child: Icon(Icons.broken_image_outlined, size: 20),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/modules/updates/updates_screen.dart
+++ b/lib/modules/updates/updates_screen.dart
@@ -10,6 +10,8 @@ import 'package:mangayomi/models/chapter.dart';
 import 'package:mangayomi/models/update.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/updates/widgets/update_chapter_list_tile_widget.dart';
+import 'package:mangayomi/modules/updates/update_errors_screen.dart';
+import 'package:mangayomi/services/update_errors_provider.dart';
 import 'package:mangayomi/modules/history/providers/isar_providers.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/library_updater.dart';
@@ -60,6 +62,19 @@ class _UpdatesScreenState extends BaseLibraryTabScreenState<UpdatesScreen> {
     final l10n = l10nLocalizations(context)!;
 
     return [
+      if (ref.watch(updateErrorsProvider).isNotEmpty)
+        IconButton(
+          splashRadius: 20,
+          tooltip: 'Update errors',
+          icon: Icon(
+            Icons.error_outline,
+            color: Theme.of(context).colorScheme.error,
+          ),
+          onPressed: () => Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const UpdateErrorsScreen()),
+          ),
+        ),
       IconButton(
         splashRadius: 20,
         icon: Icon(Icons.refresh_outlined, color: Theme.of(context).hintColor),

--- a/lib/services/library_updater.dart
+++ b/lib/services/library_updater.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/log/logger.dart';
 import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/services/update_errors_provider.dart';
 
 Future<void> updateLibrary({
   required WidgetRef ref,
@@ -30,7 +31,7 @@ Future<void> updateLibrary({
     themeDark: isDark,
   );
   int failed = 0;
-  List<String> failedMangas = [];
+  List<UpdateError> failures = [];
   for (var i = 0; i < mangaList.length; i++) {
     final manga = mangaList[i];
     try {
@@ -45,7 +46,13 @@ Future<void> updateLibrary({
       AppLogger.log("Failed to update $itemtype:", logLevel: LogLevel.error);
       AppLogger.log(e.toString(), logLevel: LogLevel.error);
       failed++;
-      failedMangas.add(manga.name ?? "Unknown $itemtype");
+      failures.add(
+        UpdateError(
+          mangaId: manga.id!,
+          name: manga.name ?? "Unknown $itemtype",
+          error: e.toString(),
+        ),
+      );
     }
     if (context.mounted) {
       botToast(
@@ -62,8 +69,12 @@ Future<void> updateLibrary({
   }
   await Future.delayed(const Duration(seconds: 1));
   BotToast.cleanAll();
-  if (context.mounted && failedMangas.isNotEmpty) {
-    final failedListText = failedMangas.map((m) => "• $m").join('\n');
+  // Persist this run's failures (empty list clears any previous ones) so they
+  // can be reviewed and migrated away later from the Updates tab's error
+  // screen, instead of only in this transient toast.
+  ref.read(updateErrorsProvider.notifier).set(failures);
+  if (context.mounted && failures.isNotEmpty) {
+    final failedListText = failures.map((m) => "• ${m.name}").join('\n');
     final plural = failed == 1 ? itemtype : "${itemtype}s";
     botToast(
       "Failed to update $failed $plural:\n$failedListText",

--- a/lib/services/update_errors_provider.dart
+++ b/lib/services/update_errors_provider.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+/// A single failed library-update entry, persisted so the user can review it
+/// (and migrate the entry away) after the update run has finished.
+class UpdateError {
+  final int mangaId;
+  final String name;
+  final String error;
+
+  const UpdateError({
+    required this.mangaId,
+    required this.name,
+    required this.error,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'mangaId': mangaId,
+    'name': name,
+    'error': error,
+  };
+
+  factory UpdateError.fromJson(Map<dynamic, dynamic> json) => UpdateError(
+    mangaId: json['mangaId'] as int,
+    name: (json['name'] ?? '') as String,
+    error: (json['error'] ?? '') as String,
+  );
+}
+
+const _boxName = 'update_errors';
+const _key = 'errors';
+
+/// Opens the backing box. Called once at startup (see main.dart).
+Future<void> openUpdateErrorsBox() async {
+  if (!Hive.isBoxOpen(_boxName)) {
+    await Hive.openBox(_boxName);
+  }
+}
+
+/// The last library update's failures, persisted across restarts so they can be
+/// reviewed on the [UpdateErrorsScreen] rather than only in a transient dialog.
+final updateErrorsProvider =
+    NotifierProvider<UpdateErrorsNotifier, List<UpdateError>>(
+      UpdateErrorsNotifier.new,
+    );
+
+class UpdateErrorsNotifier extends Notifier<List<UpdateError>> {
+  @override
+  List<UpdateError> build() => _read();
+
+  List<UpdateError> _read() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final raw = Hive.box(_boxName).get(_key);
+      if (raw is String && raw.isNotEmpty) {
+        try {
+          return (jsonDecode(raw) as List)
+              .map((e) => UpdateError.fromJson(e as Map))
+              .toList();
+        } catch (_) {}
+      }
+    }
+    return [];
+  }
+
+  /// Replaces the stored failures with the latest update run's results.
+  void set(List<UpdateError> errors) {
+    state = errors;
+    _persist();
+  }
+
+  /// Drops a single entry (e.g. after the user migrated or handled it).
+  void remove(int mangaId) {
+    state = state.where((e) => e.mangaId != mangaId).toList();
+    _persist();
+  }
+
+  void clear() {
+    state = [];
+    _persist();
+  }
+
+  void _persist() {
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(
+        _boxName,
+      ).put(_key, jsonEncode(state.map((e) => e.toJson()).toList()));
+    }
+  }
+}


### PR DESCRIPTION
library update failures were only surfaced in a transient toast, so a
recurring source failure was easy to miss. this persists the last update
run's failures in Hive and adds an "Update errors" screen, reached from an
error action that appears on the Updates tab when failures exist, where each
failed entry can be migrated to another source or dismissed.

- update_errors_provider.dart: Hive-backed store + Notifier for failures
- update_errors_screen.dart: list (cover + name + error) with per-entry
  migrate / dismiss and a clear-all action
- library_updater records structured failures (id + name + error) and
  persists them after each run (an empty run clears old ones)
- Updates tab shows an error action when there are failures

### Notes
- New state is persisted in **Hive** (no Isar schema change / codegen).
- Reuses the existing `MigrationScreen` for migrate-away.
- Verified compiles in CI (I don't have a local Flutter SDK).