### PR TITLE
feat: saved searches per source

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,7 @@ import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/utils/url_protocol/api.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/theme_provider.dart';
 import 'package:mangayomi/modules/library/providers/file_scanner.dart';
+import 'package:mangayomi/modules/manga/home/providers/saved_searches_provider.dart';
 import 'package:mangayomi/modules/more/settings/security/providers/security_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/security/app_lock_screen.dart';
 import 'package:media_kit/media_kit.dart';
@@ -177,6 +178,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await openSavedSearchesBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,7 +42,6 @@ import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/utils/url_protocol/api.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/theme_provider.dart';
 import 'package:mangayomi/modules/library/providers/file_scanner.dart';
-import 'package:mangayomi/modules/manga/home/providers/saved_searches_provider.dart';
 import 'package:mangayomi/modules/more/settings/security/providers/security_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/security/app_lock_screen.dart';
 import 'package:media_kit/media_kit.dart';
@@ -178,7 +177,6 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
-  await openSavedSearchesBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -70,6 +70,9 @@ class Settings {
   /// The last library update's failures, kept so they can be reviewed later.
   List<UpdateError>? updateErrorsList;
 
+  /// User's saved searches (per source; each entry carries its sourceId).
+  List<SavedSearch>? savedSearchesList;
+
   @enumerated
   late ReaderMode defaultReaderMode;
 
@@ -413,6 +416,7 @@ class Settings {
     this.userAgent = defaultUserAgent,
     this.cookiesList,
     this.updateErrorsList,
+    this.savedSearchesList,
     this.defaultReaderMode = ReaderMode.vertical,
     this.personalReaderModeList,
     this.animatePageTransitions = true,
@@ -623,6 +627,11 @@ class Settings {
     if (json['updateErrorsList'] != null) {
       updateErrorsList = (json['updateErrorsList'] as List)
           .map((e) => UpdateError.fromJson(e))
+          .toList();
+    }
+    if (json['savedSearchesList'] != null) {
+      savedSearchesList = (json['savedSearchesList'] as List)
+          .map((e) => SavedSearch.fromJson(e))
           .toList();
     }
     cropBorders = json['cropBorders'];
@@ -907,6 +916,7 @@ class Settings {
     'checkForExtensionUpdates': checkForExtensionUpdates,
     'cookiesList': cookiesList,
     'updateErrorsList': updateErrorsList,
+    'savedSearchesList': savedSearchesList,
     'cropBorders': cropBorders,
     'dateFormat': dateFormat,
     'defaultReaderMode': defaultReaderMode.index,
@@ -1128,6 +1138,23 @@ class UpdateError {
     'mangaId': mangaId,
     'name': name,
     'error': error,
+  };
+}
+
+@embedded
+class SavedSearch {
+  int? sourceId;
+  String name;
+  String query;
+  SavedSearch({this.sourceId, this.name = '', this.query = ''});
+  SavedSearch.fromJson(Map<String, dynamic> json)
+    : sourceId = json['sourceId'],
+      name = json['name'] ?? '',
+      query = json['query'] ?? '';
+  Map<String, dynamic> toJson() => {
+    'sourceId': sourceId,
+    'name': name,
+    'query': query,
   };
 }
 

--- a/lib/models/settings.g.dart
+++ b/lib/models/settings.g.dart
@@ -850,164 +850,171 @@ const SettingsSchema = CollectionSchema(
       name: r'saveAsCBZArchive',
       type: IsarType.bool,
     ),
-    r'scaleType': PropertySchema(
+    r'savedSearchesList': PropertySchema(
       id: 158,
+      name: r'savedSearchesList',
+      type: IsarType.objectList,
+
+      target: r'SavedSearch',
+    ),
+    r'scaleType': PropertySchema(
+      id: 159,
       name: r'scaleType',
       type: IsarType.byte,
       enumMap: _SettingsscaleTypeEnumValueMap,
     ),
     r'showNSFW': PropertySchema(
-      id: 159,
+      id: 160,
       name: r'showNSFW',
       type: IsarType.bool,
     ),
     r'showNavigationOverlayOnStart': PropertySchema(
-      id: 160,
+      id: 161,
       name: r'showNavigationOverlayOnStart',
       type: IsarType.bool,
     ),
     r'showPageGaps': PropertySchema(
-      id: 161,
+      id: 162,
       name: r'showPageGaps',
       type: IsarType.bool,
     ),
     r'showPagesNumber': PropertySchema(
-      id: 162,
+      id: 163,
       name: r'showPagesNumber',
       type: IsarType.bool,
     ),
     r'sortChapterList': PropertySchema(
-      id: 163,
+      id: 164,
       name: r'sortChapterList',
       type: IsarType.objectList,
 
       target: r'SortChapter',
     ),
     r'sortLibraryAnime': PropertySchema(
-      id: 164,
+      id: 165,
       name: r'sortLibraryAnime',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryManga': PropertySchema(
-      id: 165,
+      id: 166,
       name: r'sortLibraryManga',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryNovel': PropertySchema(
-      id: 166,
+      id: 167,
       name: r'sortLibraryNovel',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'splitWidePages': PropertySchema(
-      id: 167,
+      id: 168,
       name: r'splitWidePages',
       type: IsarType.bool,
     ),
     r'startDatebackup': PropertySchema(
-      id: 168,
+      id: 169,
       name: r'startDatebackup',
       type: IsarType.long,
     ),
     r'tappingInversion': PropertySchema(
-      id: 169,
+      id: 170,
       name: r'tappingInversion',
       type: IsarType.long,
     ),
     r'themeIsDark': PropertySchema(
-      id: 170,
+      id: 171,
       name: r'themeIsDark',
       type: IsarType.bool,
     ),
     r'ttsLanguage': PropertySchema(
-      id: 171,
+      id: 172,
       name: r'ttsLanguage',
       type: IsarType.string,
     ),
     r'ttsPitch': PropertySchema(
-      id: 172,
+      id: 173,
       name: r'ttsPitch',
       type: IsarType.double,
     ),
     r'ttsSpeechRate': PropertySchema(
-      id: 173,
+      id: 174,
       name: r'ttsSpeechRate',
       type: IsarType.double,
     ),
     r'ttsVoice': PropertySchema(
-      id: 174,
+      id: 175,
       name: r'ttsVoice',
       type: IsarType.string,
     ),
     r'updateErrorsList': PropertySchema(
-      id: 175,
+      id: 176,
       name: r'updateErrorsList',
       type: IsarType.objectList,
 
       target: r'UpdateError',
     ),
     r'updateProgressAfterReading': PropertySchema(
-      id: 176,
+      id: 177,
       name: r'updateProgressAfterReading',
       type: IsarType.bool,
     ),
     r'updatedAt': PropertySchema(
-      id: 177,
+      id: 178,
       name: r'updatedAt',
       type: IsarType.long,
     ),
     r'useLibass': PropertySchema(
-      id: 178,
+      id: 179,
       name: r'useLibass',
       type: IsarType.bool,
     ),
     r'useMpvConfig': PropertySchema(
-      id: 179,
+      id: 180,
       name: r'useMpvConfig',
       type: IsarType.bool,
     ),
     r'usePageTapZones': PropertySchema(
-      id: 180,
+      id: 181,
       name: r'usePageTapZones',
       type: IsarType.bool,
     ),
     r'useYUV420P': PropertySchema(
-      id: 181,
+      id: 182,
       name: r'useYUV420P',
       type: IsarType.bool,
     ),
     r'userAgent': PropertySchema(
-      id: 182,
+      id: 183,
       name: r'userAgent',
       type: IsarType.string,
     ),
     r'volumeBoostCap': PropertySchema(
-      id: 183,
+      id: 184,
       name: r'volumeBoostCap',
       type: IsarType.long,
     ),
     r'webtoonDisableZoomOut': PropertySchema(
-      id: 184,
+      id: 185,
       name: r'webtoonDisableZoomOut',
       type: IsarType.bool,
     ),
     r'webtoonDoubleTapZoomEnabled': PropertySchema(
-      id: 185,
+      id: 186,
       name: r'webtoonDoubleTapZoomEnabled',
       type: IsarType.bool,
     ),
     r'webtoonSidePadding': PropertySchema(
-      id: 186,
+      id: 187,
       name: r'webtoonSidePadding',
       type: IsarType.long,
     ),
     r'zoomStartPosition': PropertySchema(
-      id: 187,
+      id: 188,
       name: r'zoomStartPosition',
       type: IsarType.long,
     ),
@@ -1037,6 +1044,7 @@ const SettingsSchema = CollectionSchema(
     r'ChapterPageIndex': ChapterPageIndexSchema,
     r'MCookie': MCookieSchema,
     r'UpdateError': UpdateErrorSchema,
+    r'SavedSearch': SavedSearchSchema,
     r'PersonalReaderMode': PersonalReaderModeSchema,
     r'FilterScanlator': FilterScanlatorSchema,
     r'L10nLocale': L10nLocaleSchema,
@@ -1452,6 +1460,23 @@ int _settingsEstimateSize(
     }
   }
   {
+    final list = object.savedSearchesList;
+    if (list != null) {
+      bytesCount += 3 + list.length * 3;
+      {
+        final offsets = allOffsets[SavedSearch]!;
+        for (var i = 0; i < list.length; i++) {
+          final value = list[i];
+          bytesCount += SavedSearchSchema.estimateSize(
+            value,
+            offsets,
+            allOffsets,
+          );
+        }
+      }
+    }
+  }
+  {
     final list = object.sortChapterList;
     if (list != null) {
       bytesCount += 3 + list.length * 3;
@@ -1796,61 +1821,67 @@ void _settingsSerialize(
   writer.writeBool(offsets[155], object.rpcShowReadingWatchingProgress);
   writer.writeBool(offsets[156], object.rpcShowTitle);
   writer.writeBool(offsets[157], object.saveAsCBZArchive);
-  writer.writeByte(offsets[158], object.scaleType.index);
-  writer.writeBool(offsets[159], object.showNSFW);
-  writer.writeBool(offsets[160], object.showNavigationOverlayOnStart);
-  writer.writeBool(offsets[161], object.showPageGaps);
-  writer.writeBool(offsets[162], object.showPagesNumber);
+  writer.writeObjectList<SavedSearch>(
+    offsets[158],
+    allOffsets,
+    SavedSearchSchema.serialize,
+    object.savedSearchesList,
+  );
+  writer.writeByte(offsets[159], object.scaleType.index);
+  writer.writeBool(offsets[160], object.showNSFW);
+  writer.writeBool(offsets[161], object.showNavigationOverlayOnStart);
+  writer.writeBool(offsets[162], object.showPageGaps);
+  writer.writeBool(offsets[163], object.showPagesNumber);
   writer.writeObjectList<SortChapter>(
-    offsets[163],
+    offsets[164],
     allOffsets,
     SortChapterSchema.serialize,
     object.sortChapterList,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[164],
+    offsets[165],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryAnime,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[165],
+    offsets[166],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryManga,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[166],
+    offsets[167],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryNovel,
   );
-  writer.writeBool(offsets[167], object.splitWidePages);
-  writer.writeLong(offsets[168], object.startDatebackup);
-  writer.writeLong(offsets[169], object.tappingInversion);
-  writer.writeBool(offsets[170], object.themeIsDark);
-  writer.writeString(offsets[171], object.ttsLanguage);
-  writer.writeDouble(offsets[172], object.ttsPitch);
-  writer.writeDouble(offsets[173], object.ttsSpeechRate);
-  writer.writeString(offsets[174], object.ttsVoice);
+  writer.writeBool(offsets[168], object.splitWidePages);
+  writer.writeLong(offsets[169], object.startDatebackup);
+  writer.writeLong(offsets[170], object.tappingInversion);
+  writer.writeBool(offsets[171], object.themeIsDark);
+  writer.writeString(offsets[172], object.ttsLanguage);
+  writer.writeDouble(offsets[173], object.ttsPitch);
+  writer.writeDouble(offsets[174], object.ttsSpeechRate);
+  writer.writeString(offsets[175], object.ttsVoice);
   writer.writeObjectList<UpdateError>(
-    offsets[175],
+    offsets[176],
     allOffsets,
     UpdateErrorSchema.serialize,
     object.updateErrorsList,
   );
-  writer.writeBool(offsets[176], object.updateProgressAfterReading);
-  writer.writeLong(offsets[177], object.updatedAt);
-  writer.writeBool(offsets[178], object.useLibass);
-  writer.writeBool(offsets[179], object.useMpvConfig);
-  writer.writeBool(offsets[180], object.usePageTapZones);
-  writer.writeBool(offsets[181], object.useYUV420P);
-  writer.writeString(offsets[182], object.userAgent);
-  writer.writeLong(offsets[183], object.volumeBoostCap);
-  writer.writeBool(offsets[184], object.webtoonDisableZoomOut);
-  writer.writeBool(offsets[185], object.webtoonDoubleTapZoomEnabled);
-  writer.writeLong(offsets[186], object.webtoonSidePadding);
-  writer.writeLong(offsets[187], object.zoomStartPosition);
+  writer.writeBool(offsets[177], object.updateProgressAfterReading);
+  writer.writeLong(offsets[178], object.updatedAt);
+  writer.writeBool(offsets[179], object.useLibass);
+  writer.writeBool(offsets[180], object.useMpvConfig);
+  writer.writeBool(offsets[181], object.usePageTapZones);
+  writer.writeBool(offsets[182], object.useYUV420P);
+  writer.writeString(offsets[183], object.userAgent);
+  writer.writeLong(offsets[184], object.volumeBoostCap);
+  writer.writeBool(offsets[185], object.webtoonDisableZoomOut);
+  writer.writeBool(offsets[186], object.webtoonDoubleTapZoomEnabled);
+  writer.writeLong(offsets[187], object.webtoonSidePadding);
+  writer.writeLong(offsets[188], object.zoomStartPosition);
 }
 
 Settings _settingsDeserialize(
@@ -2117,60 +2148,66 @@ Settings _settingsDeserialize(
     rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[155]),
     rpcShowTitle: reader.readBoolOrNull(offsets[156]),
     saveAsCBZArchive: reader.readBoolOrNull(offsets[157]),
+    savedSearchesList: reader.readObjectList<SavedSearch>(
+      offsets[158],
+      SavedSearchSchema.deserialize,
+      allOffsets,
+      SavedSearch(),
+    ),
     scaleType:
-        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[158])] ??
+        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[159])] ??
         ScaleType.fitScreen,
-    showNSFW: reader.readBoolOrNull(offsets[159]),
-    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[160]),
-    showPageGaps: reader.readBoolOrNull(offsets[161]),
-    showPagesNumber: reader.readBoolOrNull(offsets[162]),
+    showNSFW: reader.readBoolOrNull(offsets[160]),
+    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[161]),
+    showPageGaps: reader.readBoolOrNull(offsets[162]),
+    showPagesNumber: reader.readBoolOrNull(offsets[163]),
     sortChapterList: reader.readObjectList<SortChapter>(
-      offsets[163],
+      offsets[164],
       SortChapterSchema.deserialize,
       allOffsets,
       SortChapter(),
     ),
     sortLibraryAnime: reader.readObjectOrNull<SortLibraryManga>(
-      offsets[164],
-      SortLibraryMangaSchema.deserialize,
-      allOffsets,
-    ),
-    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
       offsets[165],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
       offsets[166],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    splitWidePages: reader.readBoolOrNull(offsets[167]),
-    startDatebackup: reader.readLongOrNull(offsets[168]),
-    tappingInversion: reader.readLongOrNull(offsets[169]),
-    themeIsDark: reader.readBoolOrNull(offsets[170]),
-    ttsLanguage: reader.readStringOrNull(offsets[171]),
-    ttsPitch: reader.readDoubleOrNull(offsets[172]),
-    ttsSpeechRate: reader.readDoubleOrNull(offsets[173]),
-    ttsVoice: reader.readStringOrNull(offsets[174]),
+    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+      offsets[167],
+      SortLibraryMangaSchema.deserialize,
+      allOffsets,
+    ),
+    splitWidePages: reader.readBoolOrNull(offsets[168]),
+    startDatebackup: reader.readLongOrNull(offsets[169]),
+    tappingInversion: reader.readLongOrNull(offsets[170]),
+    themeIsDark: reader.readBoolOrNull(offsets[171]),
+    ttsLanguage: reader.readStringOrNull(offsets[172]),
+    ttsPitch: reader.readDoubleOrNull(offsets[173]),
+    ttsSpeechRate: reader.readDoubleOrNull(offsets[174]),
+    ttsVoice: reader.readStringOrNull(offsets[175]),
     updateErrorsList: reader.readObjectList<UpdateError>(
-      offsets[175],
+      offsets[176],
       UpdateErrorSchema.deserialize,
       allOffsets,
       UpdateError(),
     ),
-    updateProgressAfterReading: reader.readBoolOrNull(offsets[176]),
-    updatedAt: reader.readLongOrNull(offsets[177]),
-    useLibass: reader.readBoolOrNull(offsets[178]),
-    useMpvConfig: reader.readBoolOrNull(offsets[179]),
-    usePageTapZones: reader.readBoolOrNull(offsets[180]),
-    useYUV420P: reader.readBoolOrNull(offsets[181]),
-    userAgent: reader.readStringOrNull(offsets[182]),
-    volumeBoostCap: reader.readLongOrNull(offsets[183]),
-    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[184]),
-    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[185]),
-    webtoonSidePadding: reader.readLongOrNull(offsets[186]),
-    zoomStartPosition: reader.readLongOrNull(offsets[187]),
+    updateProgressAfterReading: reader.readBoolOrNull(offsets[177]),
+    updatedAt: reader.readLongOrNull(offsets[178]),
+    useLibass: reader.readBoolOrNull(offsets[179]),
+    useMpvConfig: reader.readBoolOrNull(offsets[180]),
+    usePageTapZones: reader.readBoolOrNull(offsets[181]),
+    useYUV420P: reader.readBoolOrNull(offsets[182]),
+    userAgent: reader.readStringOrNull(offsets[183]),
+    volumeBoostCap: reader.readLongOrNull(offsets[184]),
+    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[185]),
+    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[186]),
+    webtoonSidePadding: reader.readLongOrNull(offsets[187]),
+    zoomStartPosition: reader.readLongOrNull(offsets[188]),
   );
   object.chapterFilterBookmarkedList = reader
       .readObjectList<ChapterFilterBookmarked>(
@@ -2674,11 +2711,17 @@ P _settingsDeserializeProp<P>(
     case 157:
       return (reader.readBoolOrNull(offset)) as P;
     case 158:
+      return (reader.readObjectList<SavedSearch>(
+            offset,
+            SavedSearchSchema.deserialize,
+            allOffsets,
+            SavedSearch(),
+          ))
+          as P;
+    case 159:
       return (_SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offset)] ??
               ScaleType.fitScreen)
           as P;
-    case 159:
-      return (reader.readBoolOrNull(offset)) as P;
     case 160:
       return (reader.readBoolOrNull(offset)) as P;
     case 161:
@@ -2686,18 +2729,13 @@ P _settingsDeserializeProp<P>(
     case 162:
       return (reader.readBoolOrNull(offset)) as P;
     case 163:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 164:
       return (reader.readObjectList<SortChapter>(
             offset,
             SortChapterSchema.deserialize,
             allOffsets,
             SortChapter(),
-          ))
-          as P;
-    case 164:
-      return (reader.readObjectOrNull<SortLibraryManga>(
-            offset,
-            SortLibraryMangaSchema.deserialize,
-            allOffsets,
           ))
           as P;
     case 165:
@@ -2715,22 +2753,29 @@ P _settingsDeserializeProp<P>(
           ))
           as P;
     case 167:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readObjectOrNull<SortLibraryManga>(
+            offset,
+            SortLibraryMangaSchema.deserialize,
+            allOffsets,
+          ))
+          as P;
     case 168:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 169:
       return (reader.readLongOrNull(offset)) as P;
     case 170:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 171:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 172:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 173:
       return (reader.readDoubleOrNull(offset)) as P;
     case 174:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 175:
+      return (reader.readStringOrNull(offset)) as P;
+    case 176:
       return (reader.readObjectList<UpdateError>(
             offset,
             UpdateErrorSchema.deserialize,
@@ -2738,12 +2783,10 @@ P _settingsDeserializeProp<P>(
             UpdateError(),
           ))
           as P;
-    case 176:
-      return (reader.readBoolOrNull(offset)) as P;
     case 177:
-      return (reader.readLongOrNull(offset)) as P;
-    case 178:
       return (reader.readBoolOrNull(offset)) as P;
+    case 178:
+      return (reader.readLongOrNull(offset)) as P;
     case 179:
       return (reader.readBoolOrNull(offset)) as P;
     case 180:
@@ -2751,16 +2794,18 @@ P _settingsDeserializeProp<P>(
     case 181:
       return (reader.readBoolOrNull(offset)) as P;
     case 182:
-      return (reader.readStringOrNull(offset)) as P;
-    case 183:
-      return (reader.readLongOrNull(offset)) as P;
-    case 184:
       return (reader.readBoolOrNull(offset)) as P;
+    case 183:
+      return (reader.readStringOrNull(offset)) as P;
+    case 184:
+      return (reader.readLongOrNull(offset)) as P;
     case 185:
       return (reader.readBoolOrNull(offset)) as P;
     case 186:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 187:
+      return (reader.readLongOrNull(offset)) as P;
+    case 188:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -13647,6 +13692,83 @@ extension SettingsQueryFilter
     });
   }
 
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  savedSearchesListIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'savedSearchesList'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  savedSearchesListIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'savedSearchesList'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  savedSearchesListLengthEqualTo(int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'savedSearchesList', length, true, length, true);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  savedSearchesListIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'savedSearchesList', 0, true, 0, true);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  savedSearchesListIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'savedSearchesList', 0, false, 999999, true);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  savedSearchesListLengthLessThan(int length, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'savedSearchesList', 0, true, length, include);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  savedSearchesListLengthGreaterThan(int length, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'savedSearchesList',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  savedSearchesListLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'savedSearchesList',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
+      );
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterFilterCondition> scaleTypeEqualTo(
     ScaleType value,
   ) {
@@ -15526,6 +15648,13 @@ extension SettingsQueryObject
   playerSubtitleSettings(FilterQuery<PlayerSubtitleSettings> q) {
     return QueryBuilder.apply(this, (query) {
       return query.object(q, r'playerSubtitleSettings');
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  savedSearchesListElement(FilterQuery<SavedSearch> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.object(q, r'savedSearchesList');
     });
   }
 
@@ -22005,6 +22134,13 @@ extension SettingsQueryProperty
     });
   }
 
+  QueryBuilder<Settings, List<SavedSearch>?, QQueryOperations>
+  savedSearchesListProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'savedSearchesList');
+    });
+  }
+
   QueryBuilder<Settings, ScaleType, QQueryOperations> scaleTypeProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'scaleType');
@@ -22628,6 +22764,452 @@ extension UpdateErrorQueryFilter
 
 extension UpdateErrorQueryObject
     on QueryBuilder<UpdateError, UpdateError, QFilterCondition> {}
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+const SavedSearchSchema = Schema(
+  name: r'SavedSearch',
+  id: -4038919227263572545,
+  properties: {
+    r'name': PropertySchema(id: 0, name: r'name', type: IsarType.string),
+    r'query': PropertySchema(id: 1, name: r'query', type: IsarType.string),
+    r'sourceId': PropertySchema(id: 2, name: r'sourceId', type: IsarType.long),
+  },
+
+  estimateSize: _savedSearchEstimateSize,
+  serialize: _savedSearchSerialize,
+  deserialize: _savedSearchDeserialize,
+  deserializeProp: _savedSearchDeserializeProp,
+);
+
+int _savedSearchEstimateSize(
+  SavedSearch object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.name.length * 3;
+  bytesCount += 3 + object.query.length * 3;
+  return bytesCount;
+}
+
+void _savedSearchSerialize(
+  SavedSearch object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.name);
+  writer.writeString(offsets[1], object.query);
+  writer.writeLong(offsets[2], object.sourceId);
+}
+
+SavedSearch _savedSearchDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = SavedSearch(
+    name: reader.readStringOrNull(offsets[0]) ?? '',
+    query: reader.readStringOrNull(offsets[1]) ?? '',
+    sourceId: reader.readLongOrNull(offsets[2]),
+  );
+  return object;
+}
+
+P _savedSearchDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readStringOrNull(offset) ?? '') as P;
+    case 1:
+      return (reader.readStringOrNull(offset) ?? '') as P;
+    case 2:
+      return (reader.readLongOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+extension SavedSearchQueryFilter
+    on QueryBuilder<SavedSearch, SavedSearch, QFilterCondition> {
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> nameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> nameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> nameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> nameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'name',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> nameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> nameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> nameContains(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> nameMatches(
+    String pattern, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'name',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> nameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'name', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition>
+  nameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'name', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> queryEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'query',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition>
+  queryGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'query',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> queryLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'query',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> queryBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'query',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> queryStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'query',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> queryEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'query',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> queryContains(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'query',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> queryMatches(
+    String pattern, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'query',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> queryIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'query', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition>
+  queryIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'query', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition>
+  sourceIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'sourceId'),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition>
+  sourceIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'sourceId'),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> sourceIdEqualTo(
+    int? value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'sourceId', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition>
+  sourceIdGreaterThan(int? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'sourceId',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition>
+  sourceIdLessThan(int? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'sourceId',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SavedSearch, SavedSearch, QAfterFilterCondition> sourceIdBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'sourceId',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+}
+
+extension SavedSearchQueryObject
+    on QueryBuilder<SavedSearch, SavedSearch, QFilterCondition> {}
 
 // coverage:ignore-file
 // ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types

--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -19,6 +19,7 @@ import 'package:mangayomi/services/get_filter_list.dart';
 import 'package:mangayomi/services/get_latest_updates.dart';
 import 'package:mangayomi/services/get_popular.dart';
 import 'package:mangayomi/services/get_source_baseurl.dart';
+import 'package:mangayomi/modules/manga/home/providers/saved_searches_provider.dart';
 import 'package:mangayomi/services/search.dart';
 import 'package:mangayomi/services/supports_latest.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
@@ -176,6 +177,101 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
         });
       }
     }
+  }
+
+  void _promptSaveSearch() {
+    final query = _query.trim();
+    if (query.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Enter a search to save first')),
+      );
+      return;
+    }
+    final controller = TextEditingController(text: query);
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Save search'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Name'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(context.l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () {
+              ref
+                  .read(savedSearchesProvider.notifier)
+                  .add(source.id!, controller.text, query);
+              Navigator.pop(ctx);
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showSavedSearches() {
+    showModalBottomSheet(
+      context: context,
+      builder: (ctx) => Consumer(
+        builder: (ctx, ref, _) {
+          final saved =
+              ref.watch(savedSearchesProvider)[source.id] ??
+              const <SavedSearch>[];
+          if (saved.isEmpty) {
+            return const Padding(
+              padding: EdgeInsets.all(24),
+              child: Text(
+                'No saved searches for this source yet.\n'
+                'Run a search, then pick "Save search".',
+                textAlign: TextAlign.center,
+              ),
+            );
+          }
+          return ListView(
+            shrinkWrap: true,
+            children: [
+              for (final s in saved)
+                ListTile(
+                  leading: const Icon(Icons.bookmark_outline),
+                  title: Text(s.name),
+                  subtitle: Text(
+                    s.query,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete_outline),
+                    onPressed: () => ref
+                        .read(savedSearchesProvider.notifier)
+                        .remove(source.id!, s.name),
+                  ),
+                  onTap: () {
+                    Navigator.pop(ctx);
+                    _runSavedSearch(s.query);
+                  },
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  void _runSavedSearch(String query) {
+    _mangaList.clear();
+    _textEditingController.text = query;
+    setState(() {
+      _isSearch = true;
+      _selectedIndex = 2;
+      _query = query;
+      _page = 1;
+    });
   }
 
   late final _textEditingController = TextEditingController(text: widget.query);
@@ -343,6 +439,14 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                     value: 1,
                     child: Text(context.l10n.settings),
                   ),
+                  const PopupMenuItem<int>(
+                    value: 2,
+                    child: Text('Save search'),
+                  ),
+                  const PopupMenuItem<int>(
+                    value: 3,
+                    child: Text('Saved searches'),
+                  ),
                 ];
               },
               onSelected: (value) async {
@@ -356,7 +460,7 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                     'title': '',
                   };
                   context.push("/mangawebview", extra: data);
-                } else {
+                } else if (value == 1) {
                   final res = await context.push(
                     '/extension_detail',
                     extra: source,
@@ -366,6 +470,10 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                       source = res as Source;
                     });
                   }
+                } else if (value == 2) {
+                  _promptSaveSearch();
+                } else if (value == 3) {
+                  _showSavedSearches();
                 }
               },
             ),

--- a/lib/modules/manga/home/providers/saved_searches_provider.dart
+++ b/lib/modules/manga/home/providers/saved_searches_provider.dart
@@ -1,35 +1,14 @@
-import 'dart:convert';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hive/hive.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/settings.dart';
 
-/// A named search query the user saved for a source, so frequent searches can
-/// be re-run from the source browse with one tap.
-class SavedSearch {
-  final String name;
-  final String query;
+// SavedSearch is an @embedded model on the Settings collection; re-export it so
+// existing call sites can keep importing it from this provider.
+export 'package:mangayomi/models/settings.dart' show SavedSearch;
 
-  const SavedSearch({required this.name, required this.query});
-
-  Map<String, dynamic> toJson() => {'name': name, 'query': query};
-
-  factory SavedSearch.fromJson(Map<dynamic, dynamic> json) => SavedSearch(
-    name: (json['name'] ?? '') as String,
-    query: (json['query'] ?? '') as String,
-  );
-}
-
-const _boxName = 'saved_searches';
-
-/// Opens the backing box. Called once at startup (see main.dart).
-Future<void> openSavedSearchesBox() async {
-  if (!Hive.isBoxOpen(_boxName)) {
-    await Hive.openBox(_boxName);
-  }
-}
-
-/// Saved searches keyed by source id. Persisted in Hive (one JSON value per
-/// source, key `src_<id>`), so it needs no Isar schema change.
+/// Saved searches keyed by source id, so frequent searches can be re-run from
+/// the source browse with one tap. Persisted on the Settings collection as a
+/// flat list where each entry carries its `sourceId`.
 final savedSearchesProvider =
     NotifierProvider<SavedSearchesNotifier, Map<int, List<SavedSearch>>>(
       SavedSearchesNotifier.new,
@@ -39,21 +18,11 @@ class SavedSearchesNotifier extends Notifier<Map<int, List<SavedSearch>>> {
   @override
   Map<int, List<SavedSearch>> build() {
     final result = <int, List<SavedSearch>>{};
-    if (Hive.isBoxOpen(_boxName)) {
-      final box = Hive.box(_boxName);
-      for (final key in box.keys) {
-        if (key is! String || !key.startsWith('src_')) continue;
-        final id = int.tryParse(key.substring(4));
-        if (id == null) continue;
-        final raw = box.get(key);
-        if (raw is String && raw.isNotEmpty) {
-          try {
-            result[id] = (jsonDecode(raw) as List)
-                .map((e) => SavedSearch.fromJson(e as Map))
-                .toList();
-          } catch (_) {}
-        }
-      }
+    final list = isar.settings.getSync(227)?.savedSearchesList ?? const [];
+    for (final s in list) {
+      final id = s.sourceId;
+      if (id == null) continue;
+      (result[id] ??= []).add(s);
     }
     return result;
   }
@@ -66,10 +35,10 @@ class SavedSearchesNotifier extends Notifier<Map<int, List<SavedSearch>>> {
     if (n.isEmpty || q.isEmpty) return;
     final list = [
       ...forSource(sourceId).where((e) => e.name != n),
-      SavedSearch(name: n, query: q),
+      SavedSearch(sourceId: sourceId, name: n, query: q),
     ];
     state = {...state, sourceId: list};
-    _persist(sourceId);
+    _persist();
   }
 
   void remove(int sourceId, String name) {
@@ -77,14 +46,16 @@ class SavedSearchesNotifier extends Notifier<Map<int, List<SavedSearch>>> {
       ...state,
       sourceId: forSource(sourceId).where((e) => e.name != name).toList(),
     };
-    _persist(sourceId);
+    _persist();
   }
 
-  void _persist(int sourceId) {
-    if (!Hive.isBoxOpen(_boxName)) return;
-    Hive.box(_boxName).put(
-      'src_$sourceId',
-      jsonEncode(forSource(sourceId).map((e) => e.toJson()).toList()),
-    );
+  void _persist() {
+    final flat = [for (final entry in state.values) ...entry];
+    isar.writeTxnSync(() {
+      final settings = isar.settings.getSync(227);
+      if (settings != null) {
+        isar.settings.putSync(settings..savedSearchesList = flat);
+      }
+    });
   }
 }

--- a/lib/modules/manga/home/providers/saved_searches_provider.dart
+++ b/lib/modules/manga/home/providers/saved_searches_provider.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+/// A named search query the user saved for a source, so frequent searches can
+/// be re-run from the source browse with one tap.
+class SavedSearch {
+  final String name;
+  final String query;
+
+  const SavedSearch({required this.name, required this.query});
+
+  Map<String, dynamic> toJson() => {'name': name, 'query': query};
+
+  factory SavedSearch.fromJson(Map<dynamic, dynamic> json) => SavedSearch(
+    name: (json['name'] ?? '') as String,
+    query: (json['query'] ?? '') as String,
+  );
+}
+
+const _boxName = 'saved_searches';
+
+/// Opens the backing box. Called once at startup (see main.dart).
+Future<void> openSavedSearchesBox() async {
+  if (!Hive.isBoxOpen(_boxName)) {
+    await Hive.openBox(_boxName);
+  }
+}
+
+/// Saved searches keyed by source id. Persisted in Hive (one JSON value per
+/// source, key `src_<id>`), so it needs no Isar schema change.
+final savedSearchesProvider =
+    NotifierProvider<SavedSearchesNotifier, Map<int, List<SavedSearch>>>(
+      SavedSearchesNotifier.new,
+    );
+
+class SavedSearchesNotifier extends Notifier<Map<int, List<SavedSearch>>> {
+  @override
+  Map<int, List<SavedSearch>> build() {
+    final result = <int, List<SavedSearch>>{};
+    if (Hive.isBoxOpen(_boxName)) {
+      final box = Hive.box(_boxName);
+      for (final key in box.keys) {
+        if (key is! String || !key.startsWith('src_')) continue;
+        final id = int.tryParse(key.substring(4));
+        if (id == null) continue;
+        final raw = box.get(key);
+        if (raw is String && raw.isNotEmpty) {
+          try {
+            result[id] = (jsonDecode(raw) as List)
+                .map((e) => SavedSearch.fromJson(e as Map))
+                .toList();
+          } catch (_) {}
+        }
+      }
+    }
+    return result;
+  }
+
+  List<SavedSearch> forSource(int sourceId) => state[sourceId] ?? const [];
+
+  void add(int sourceId, String name, String query) {
+    final n = name.trim();
+    final q = query.trim();
+    if (n.isEmpty || q.isEmpty) return;
+    final list = [
+      ...forSource(sourceId).where((e) => e.name != n),
+      SavedSearch(name: n, query: q),
+    ];
+    state = {...state, sourceId: list};
+    _persist(sourceId);
+  }
+
+  void remove(int sourceId, String name) {
+    state = {
+      ...state,
+      sourceId: forSource(sourceId).where((e) => e.name != name).toList(),
+    };
+    _persist(sourceId);
+  }
+
+  void _persist(int sourceId) {
+    if (!Hive.isBoxOpen(_boxName)) return;
+    Hive.box(_boxName).put(
+      'src_$sourceId',
+      jsonEncode(forSource(sourceId).map((e) => e.toJson()).toList()),
+    );
+  }
+}


### PR DESCRIPTION
adds "Save search" and "Saved searches" to a source's browse overflow menu:
save the current search query under a name, then re-run it later from a bottom
sheet with one tap (or delete it). Persisted on the Settings collection (a
`SavedSearch` `@embedded` list, grouped by source), so it lives with the app's
other preferences. No layout surgery on the source browse; it reuses the
existing overflow menu.

### Notes
- Stored on the Settings collection (`SavedSearch` `@embedded`), no separate box; reuses the existing source-browse overflow menu (no app-bar layout changes).
- Query only for now (filters not serialized), a sensible first cut.
- Verified compiles in CI.
