### PR TITLE
fix(anime): keep player orientation across episodes on mobile

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -853,7 +853,13 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     }
     if (!isDesktop) {
       final forceLandscape = ref.read(forceLandscapePlayerStateProvider);
-      if (forceLandscape) {
+      // Preserve the player orientation across episode changes. Playing the next
+      // episode pushes a fresh player, and the old one's dispose() resets the
+      // orientation to portrait. So if the viewer is still in fullscreen — from
+      // the force-landscape setting or a manual toggle that persists across
+      // episodes (fullscreenProvider is global) — re-apply landscape here rather
+      // than stranding them in portrait with the fullscreen button still active.
+      if (forceLandscape || ref.read(fullscreenProvider)) {
         _setLandscapeMode(true);
       }
     }


### PR DESCRIPTION
playing the next episode pushes a fresh player, and the old one's dispose()
resets the orientation to portrait. but the fullscreen button state
(fullscreenProvider) is global and persists, so the viewer was stranded in
portrait with the fullscreen button still active — needing a double-toggle to
get landscape back.

the new player now re-applies landscape when the persisted fullscreen state is
on, not only when the force-landscape setting is on, so the orientation stays
consistent through episode changes for the whole session.

### Repro
Mobile, manually tap fullscreen (landscape) → let the episode end / play next → new episode opens in **portrait** but the fullscreen button still shows active; you had to toggle twice to get landscape back.

### Fix
One condition in the new player's mobile init: re-apply landscape when `fullscreenProvider` is set, not only `forceLandscapePlayerStateProvider`. Both already used in this file; no new state.

Verified compiles in CI.