### PR TITLE
feat(anime): dedicated Netflix-style TV player controls (#729)

### DIFF
--- a/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
@@ -7,7 +7,11 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.embedding.android.FlutterFragmentActivity
 import androidx.core.content.FileProvider
+import android.app.UiModeManager
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.net.Uri
 import java.io.File
@@ -55,6 +59,33 @@ class MainActivity: FlutterFragmentActivity() {
                 }
             }
         }
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.kodjodevf.mangayomi.device",
+            StandardMethodCodec.INSTANCE
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "isTv" -> {
+                    result.success(isTvDevice())
+                }
+                else -> {
+                    result.notImplemented()
+                }
+            }
+        }
+    }
+
+    // Reports whether this is an Android TV / leanback device. Used by the
+    // Dart side to branch the UI on form factor (see #729). Kept conservative
+    // so a phone is never misdetected as a TV: a phone has neither the
+    // television UI mode nor the leanback feature.
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        if (uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true
+        }
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
     private fun installApk(filePath: String?) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/models/track.dart' as track;
 import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/models/track_search.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
 import 'package:mangayomi/modules/manga/reader/providers/crop_borders_provider.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/storage_usage.dart';
@@ -180,6 +181,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await openTvPrefsBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/models/track.dart' as track;
 import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/models/track_search.dart';
+import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
 import 'package:mangayomi/modules/manga/reader/providers/crop_borders_provider.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/storage_usage.dart';
@@ -177,6 +178,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await openPlayerPrefsBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -112,6 +112,9 @@ void main(List<String> args) async {
           );
         }
       }
+      // Detect Android TV once, before the UI builds, so form-factor branches
+      // can read `isTv`. No-op on other platforms. See #729.
+      await initIsTv();
       final storage = StorageProvider();
       await storage.requestPermission();
       Object? startupError;

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -2106,7 +2106,9 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             visible: false,
             style: subtileTextStyle(ref),
           ),
-          fit: fit,
+          // Docked in the split view, always contain so the whole frame shows
+          // at its true aspect ratio rather than cropping to the narrower slot.
+          fit: splitSettings ? BoxFit.contain : fit,
           key: _key,
           controls: (state) => (isTv && ref.read(tvPlayerStyleProvider))
               ? (_tvSettingsOpen ? const SizedBox.shrink() : _tvControls())
@@ -2231,6 +2233,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
               padding: const EdgeInsets.all(16),
               child: TvVideoFocusFrame(
                 accent: accent,
+                player: _player,
                 onSelect: () => _player.playOrPause(),
                 child: player,
               ),

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -24,6 +24,7 @@ import 'package:mangayomi/modules/anime/providers/anime_player_controller_provid
 import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
 import 'package:mangayomi/modules/anime/widgets/aniskip_countdown_btn.dart';
 import 'package:mangayomi/modules/anime/widgets/tv_player_controls.dart';
+import 'package:mangayomi/modules/anime/widgets/tv_player_settings_panel.dart';
 import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/anime/widgets/desktop.dart';
 import 'package:mangayomi/modules/anime/widgets/play_or_pause_button.dart';
@@ -966,6 +967,9 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
   // Bumped on each d-pad key (see _onPlayerKey) so the mobile controls reveal
   // themselves on a TV remote.
   final ValueNotifier<int> _revealControls = ValueNotifier(0);
+  // TV-only: when the advanced settings panel is open the video docks left and
+  // the panel slides in on the right (YouTube-style), instead of a bottom sheet.
+  bool _tvSettingsOpen = false;
 
   @override
   void dispose() {
@@ -1579,7 +1583,13 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
       // panel first.
       onBack: () => Navigator.pop(context),
       onRestart: () => _player.seek(Duration.zero),
-      onSettings: () => _videoSettingDraggableMenu(context),
+      onSettings: () {
+        if (isTv && ref.read(tvAdvancedSettingsProvider)) {
+          setState(() => _tvSettingsOpen = true);
+        } else {
+          _videoSettingDraggableMenu(context);
+        }
+      },
       hasNext: hasNextEpisode,
       onNext: hasNextEpisode
           ? () => pushToNewEpisode(context, _streamController.getNextEpisode())
@@ -2088,7 +2098,8 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     final enableAutoSkip = ref.read(enableAutoSkipStateProvider);
     final aniSkipTimeoutLength = ref.read(aniSkipTimeoutLengthStateProvider);
     final skipIntroLength = ref.read(defaultSkipIntroLengthStateProvider);
-    return Stack(
+    final splitSettings = isTv && _tvSettingsOpen;
+    final Widget player = Stack(
       children: [
         Video(
           subtitleViewConfiguration: SubtitleViewConfiguration(
@@ -2098,7 +2109,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           fit: fit,
           key: _key,
           controls: (state) => (isTv && ref.read(tvPlayerStyleProvider))
-              ? _tvControls()
+              ? (_tvSettingsOpen ? const SizedBox.shrink() : _tvControls())
               : (isDesktop || isTv)
               ? DesktopControllerWidget(
                   videoController: _controller,
@@ -2134,8 +2145,10 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
                   chapterMarks: _chapterMarks,
                 ),
           controller: _controller,
-          width: context.width(1),
-          height: context.height(1),
+          // When docked left for the settings panel, fill the (narrower) slot
+          // the Row gives us rather than forcing full-screen width.
+          width: splitSettings ? null : context.width(1),
+          height: splitSettings ? null : context.height(1),
           resumeUponEnteringForegroundMode: true,
         ),
         Stack(
@@ -2203,6 +2216,38 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             ),
           ),
       ],
+    );
+    if (!splitSettings) return player;
+    // YouTube-style split: video docks left (a single focusable unit — Left
+    // from the panel focuses it, Select toggles play/pause), a gap, then the
+    // settings panel on the right.
+    final accent = Theme.of(context).colorScheme.primary;
+    return ColoredBox(
+      color: Colors.black,
+      child: Row(
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: TvVideoFocusFrame(
+                accent: accent,
+                onSelect: () => _player.playOrPause(),
+                child: player,
+              ),
+            ),
+          ),
+          TvPlayerSettingsPanel(
+            player: _player,
+            speedListenable: _playbackSpeed,
+            onSetSpeed: _setPlaybackSpeed,
+            selectedShaderListenable: _selectedShader,
+            qualityWidget: _videoQualityWidget(context),
+            subtitleWidget: _videoSubtitle(context, (_) {}),
+            audioWidget: _videoAudios(context),
+            onClose: () => setState(() => _tvSettingsOpen = false),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -23,6 +23,8 @@ import 'package:mangayomi/models/video.dart' as vid;
 import 'package:mangayomi/modules/anime/providers/anime_player_controller_provider.dart';
 import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
 import 'package:mangayomi/modules/anime/widgets/aniskip_countdown_btn.dart';
+import 'package:mangayomi/modules/anime/widgets/tv_player_controls.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/anime/widgets/desktop.dart';
 import 'package:mangayomi/modules/anime/widgets/play_or_pause_button.dart';
 import 'package:mangayomi/modules/library/providers/local_archive.dart';
@@ -827,6 +829,14 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             : "libmpv",
       ),
     );
+    // Picture-in-Picture is implemented natively by the media_kit fork
+    // (VideoOutputPIP) and only exposed on iOS 15+. Enabling auto-PiP makes the
+    // player float into a PiP window when the app is backgrounded instead of
+    // pausing. The call awaits the controller's platform init internally, so
+    // it is safe to fire here without awaiting.
+    if (Platform.isIOS) {
+      _controller.enableAutoPictureInPicture();
+    }
     // If player is being launched the first time,
     // use global "Use Fullscreen" setting.
     // Else (if user already watches an episode and just changes it),
@@ -953,8 +963,13 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     });
   }
 
+  // Bumped on each d-pad key (see _onPlayerKey) so the mobile controls reveal
+  // themselves on a TV remote.
+  final ValueNotifier<int> _revealControls = ValueNotifier(0);
+
   @override
   void dispose() {
+    _revealControls.dispose();
     _watchStopwatch.stop();
     _currentPosition.removeListener(_updateRpcTimestamp);
     _subDelayController.removeListener(_onSubDelayChanged);
@@ -1553,6 +1568,65 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     );
   }
 
+  Widget _tvControls() {
+    return TvPlayerControls(
+      player: _player,
+      revealControls: _revealControls,
+      title: widget.episode.manga.value?.name ?? '',
+      episodeLabel: widget.episode.name ?? '',
+      onBack: () => Navigator.maybePop(context),
+      onRestart: () => _player.seek(Duration.zero),
+      onSettings: () => _videoSettingDraggableMenu(context),
+      hasNext: hasNextEpisode,
+      onNext: hasNextEpisode
+          ? () => pushToNewEpisode(context, _streamController.getNextEpisode())
+          : null,
+      qualityListenable: _video,
+      buildQualityOptions: _buildTvQualityOptions,
+    );
+  }
+
+  // The source video list is the real dub/sub control (entries like "1080p Sub"
+  // / "1080p Dub"); switching re-opens the stream at that source. Mirrors
+  // _videoQualityWidget's selection logic for the TV pill bar.
+  List<TvTrackOption> _buildTvQualityOptions() {
+    if (widget.isLocal || widget.videos.isEmpty) return const <TvTrackOption>[];
+    final currentTitle = _video.value?.videoTrack?.title;
+    return [
+      for (final video in widget.videos)
+        TvTrackOption(
+          label: _shortQuality(video.quality),
+          selected: currentTitle == video.quality,
+          onSelect: () {
+            if (_video.value?.videoTrack?.title == video.quality) return;
+            final prefs = VideoPrefs(
+              videoTrack: VideoTrack(video.url, video.quality, video.quality),
+              headers: video.headers,
+              isLocal: false,
+            );
+            _video.value = prefs;
+            _player.stop();
+            _openMedia(prefs);
+            _initSubtitleAndAudio = true;
+          },
+        ),
+    ];
+  }
+
+  // Shorten a source quality label like "1080p (Sub)" to "1080-sub"/"1080-dub".
+  String _shortQuality(String raw) {
+    final lower = raw.toLowerCase();
+    final res = RegExp(r'(\d{3,4})\s*p?').firstMatch(lower)?.group(1);
+    final tag = lower.contains('sub')
+        ? 'sub'
+        : lower.contains('dub')
+        ? 'dub'
+        : null;
+    if (res != null && tag != null) return '$res-$tag';
+    if (res != null) return '${res}p';
+    return raw;
+  }
+
   Widget _mobileBottomButtonBar(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 30),
@@ -1562,11 +1636,16 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8),
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 _seekToWidget(),
                 _chapterMarkWidget(),
-                _buildSettingsButtons(context),
+                Expanded(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    reverse: true,
+                    child: _buildSettingsButtons(context),
+                  ),
+                ),
               ],
             ),
           ),
@@ -1821,6 +1900,15 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
                   )
                   .toList(),
         ),
+        if (Platform.isIOS && _controller.isPictureInPictureAvailable())
+          IconButton(
+            tooltip: 'Picture in Picture',
+            icon: const Icon(
+              Icons.picture_in_picture_alt,
+              color: Colors.white,
+            ),
+            onPressed: () => _controller.enterPictureInPicture(),
+          ),
         IconButton(
           icon: const Icon(Icons.fit_screen_outlined, color: Colors.white),
           onPressed: () async {
@@ -1832,7 +1920,8 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             controller: _controller,
             desktopFullScreenPlayer: widget.desktopFullScreenPlayer,
           )
-        else
+        // A TV is always fullscreen, so the toggle is useless there — hide it.
+        else if (!isTv)
           IconButton(
             icon: Icon(isFullscreen ? Icons.fullscreen_exit : Icons.fullscreen),
             iconSize: 25,
@@ -1906,17 +1995,28 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
               Consumer(
                 builder: (context, ref, _) {
                   final autoPlay = ref.watch(autoPlayNextEpisodeProvider);
-                  return IconButton(
-                    tooltip: autoPlay
+                  // Same drawn play/pause switch as the TV player, for a
+                  // consistent autoplay toggle across all players.
+                  return Tooltip(
+                    message: autoPlay
                         ? 'Autoplay next episode: on'
                         : 'Autoplay next episode: off',
-                    icon: Icon(
-                      Icons.playlist_play,
-                      color: autoPlay ? Colors.white : Colors.white38,
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(20),
+                      onTap: () => ref
+                          .read(autoPlayNextEpisodeProvider.notifier)
+                          .toggle(),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 8,
+                        ),
+                        child: AutoplaySwitch(
+                          on: autoPlay,
+                          accent: Theme.of(context).colorScheme.primary,
+                        ),
+                      ),
                     ),
-                    onPressed: () => ref
-                        .read(autoPlayNextEpisodeProvider.notifier)
-                        .toggle(),
                   );
                 },
               ),
@@ -1992,7 +2092,9 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           ),
           fit: fit,
           key: _key,
-          controls: (state) => isDesktop
+          controls: (state) => (isTv && ref.read(tvPlayerStyleProvider))
+              ? _tvControls()
+              : (isDesktop || isTv)
               ? DesktopControllerWidget(
                   videoController: _controller,
                   topButtonBarWidget: _topButtonBar(context),
@@ -2012,6 +2114,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
                   defaultSkipIntroLength: skipIntroLength,
                   desktopFullScreenPlayer: widget.desktopFullScreenPlayer,
                   chapterMarks: _chapterMarks,
+                  revealControls: _revealControls,
                 )
               : MobileControllerWidget(
                   videoController: _controller,
@@ -2019,6 +2122,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
                   videoStatekey: _key,
                   bottomButtonBarWidget: _mobileBottomButtonBar(context),
                   streamController: _streamController,
+                  revealControls: _revealControls,
                   doubleSpeed: (value) {
                     _isDoubleSpeed.value = value ?? false;
                   },
@@ -2354,8 +2458,30 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           }
         },
       },
-      child: Focus(autofocus: true, child: child),
+      child: Focus(autofocus: true, onKeyEvent: _onPlayerKey, child: child),
     );
+  }
+
+  // On a TV remote / keyboard, reveal the on-screen controls when the user
+  // presses the d-pad. The arrow keys stay unbound above (so they still drive
+  // focus traversal between the control buttons) — we just bump [_revealControls]
+  // so the controls become visible and the focus is on something the user can
+  // see. Returns ignored so traversal + the media shortcuts still run.
+  KeyEventResult _onPlayerKey(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent || event is KeyRepeatEvent) {
+      final k = event.logicalKey;
+      final isNav =
+          k == LogicalKeyboardKey.arrowUp ||
+          k == LogicalKeyboardKey.arrowDown ||
+          k == LogicalKeyboardKey.arrowLeft ||
+          k == LogicalKeyboardKey.arrowRight ||
+          k == LogicalKeyboardKey.select ||
+          k == LogicalKeyboardKey.enter ||
+          k == LogicalKeyboardKey.numpadEnter ||
+          k == LogicalKeyboardKey.gameButtonA;
+      if (isNav) _revealControls.value++;
+    }
+    return KeyEventResult.ignored;
   }
 }
 

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -2311,10 +2311,11 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
         const SingleActivator(LogicalKeyboardKey.mediaPause): () {
           _player.pause();
         },
+        // Seek via J/L and the dedicated media keys only. Arrow keys are left
+        // unbound so they keep driving d-pad focus traversal on Android TV
+        // (and arrow-key focus movement with a keyboard) instead of seeking.
         const SingleActivator(LogicalKeyboardKey.keyJ): () => seekBy(-10),
         const SingleActivator(LogicalKeyboardKey.keyL): () => seekBy(10),
-        const SingleActivator(LogicalKeyboardKey.arrowLeft): () => seekBy(-5),
-        const SingleActivator(LogicalKeyboardKey.arrowRight): () => seekBy(5),
         const SingleActivator(LogicalKeyboardKey.mediaRewind): () => seekBy(-10),
         const SingleActivator(LogicalKeyboardKey.mediaFastForward): () =>
             seekBy(10),

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -970,10 +970,16 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
   // TV-only: when the advanced settings panel is open the video docks left and
   // the panel slides in on the right (YouTube-style), instead of a bottom sheet.
   bool _tvSettingsOpen = false;
+  // Owned focus anchors for the split view so Left/Right cross deterministically
+  // (geometric directional focus was losing focus entirely).
+  final FocusNode _tvVideoFocus = FocusNode(debugLabel: 'tvVideoFrame');
+  final FocusNode _tvPanelFocus = FocusNode(debugLabel: 'tvPanelHeader');
 
   @override
   void dispose() {
     _revealControls.dispose();
+    _tvVideoFocus.dispose();
+    _tvPanelFocus.dispose();
     _watchStopwatch.stop();
     _currentPosition.removeListener(_updateRpcTimestamp);
     _subDelayController.removeListener(_onSubDelayChanged);
@@ -1772,8 +1778,13 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
       onBack: () => Navigator.pop(context),
       onRestart: () => _player.seek(Duration.zero),
       onSettings: () {
-        if (isTv && ref.read(tvAdvancedSettingsProvider)) {
+        // On TV the settings open as the docked side panel; phones/desktop keep
+        // the bottom-sheet menu.
+        if (isTv) {
           setState(() => _tvSettingsOpen = true);
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) _tvPanelFocus.requestFocus();
+          });
         } else {
           _videoSettingDraggableMenu(context);
         }
@@ -2422,7 +2433,9 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
               child: TvVideoFocusFrame(
                 accent: accent,
                 player: _player,
+                focusNode: _tvVideoFocus,
                 onSelect: () => _player.playOrPause(),
+                onExitRight: () => _tvPanelFocus.requestFocus(),
                 child: player,
               ),
             ),
@@ -2435,6 +2448,8 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             qualityOptions: _tvQualityOptions,
             subtitleOptions: _tvSubtitleOptions,
             audioOptions: _tvAudioOptions,
+            headerFocusNode: _tvPanelFocus,
+            onExitLeft: () => _tvVideoFocus.requestFocus(),
             onClose: () => setState(() => _tvSettingsOpen = false),
           ),
         ],

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -2278,7 +2278,59 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(body: _videoPlayer(context));
+    final body = _videoPlayer(context);
+    // Desktop already gets player keyboard shortcuts through media_kit's
+    // DesktopControllerWidget. On mobile / Android TV the controls have none,
+    // so wrap the player so a physical keyboard or TV remote can drive
+    // playback too. See #668 / #729.
+    return Scaffold(
+      body: isDesktop ? body : _wrapWithPlayerShortcuts(body),
+    );
+  }
+
+  /// Maps keyboard and TV-remote keys to player actions for non-desktop
+  /// builds. Only dedicated media keys + the usual mpv-style keys are bound
+  /// (no D-pad arrows beyond seek), so it stays additive and doesn't fight
+  /// touch input. Reuses the existing player + episode-navigation methods.
+  Widget _wrapWithPlayerShortcuts(Widget child) {
+    void seekBy(int seconds) {
+      _player.seek(_player.state.position + Duration(seconds: seconds));
+    }
+
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.space): () {
+          _player.playOrPause();
+        },
+        const SingleActivator(LogicalKeyboardKey.mediaPlayPause): () {
+          _player.playOrPause();
+        },
+        const SingleActivator(LogicalKeyboardKey.mediaPlay): () {
+          _player.play();
+        },
+        const SingleActivator(LogicalKeyboardKey.mediaPause): () {
+          _player.pause();
+        },
+        const SingleActivator(LogicalKeyboardKey.keyJ): () => seekBy(-10),
+        const SingleActivator(LogicalKeyboardKey.keyL): () => seekBy(10),
+        const SingleActivator(LogicalKeyboardKey.arrowLeft): () => seekBy(-5),
+        const SingleActivator(LogicalKeyboardKey.arrowRight): () => seekBy(5),
+        const SingleActivator(LogicalKeyboardKey.mediaRewind): () => seekBy(-10),
+        const SingleActivator(LogicalKeyboardKey.mediaFastForward): () =>
+            seekBy(10),
+        const SingleActivator(LogicalKeyboardKey.mediaTrackNext): () {
+          if (hasNextEpisode && mounted) {
+            pushToNewEpisode(context, _streamController.getNextEpisode());
+          }
+        },
+        const SingleActivator(LogicalKeyboardKey.mediaTrackPrevious): () {
+          if (_streamController.hasPreviousEpisode && mounted) {
+            pushToNewEpisode(context, _streamController.getPrevEpisode());
+          }
+        },
+      },
+      child: Focus(autofocus: true, child: child),
+    );
   }
 }
 

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -1574,7 +1574,10 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
       revealControls: _revealControls,
       title: widget.episode.manga.value?.name ?? '',
       episodeLabel: widget.episode.name ?? '',
-      onBack: () => Navigator.maybePop(context),
+      // Direct pop, not maybePop: the on-screen back arrow always exits the
+      // player, bypassing the PopScope that makes the remote Back hide the
+      // panel first.
+      onBack: () => Navigator.pop(context),
       onRestart: () => _player.seek(Duration.zero),
       onSettings: () => _videoSettingDraggableMenu(context),
       hasNext: hasNextEpisode,
@@ -1583,6 +1586,8 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           : null,
       qualityListenable: _video,
       buildQualityOptions: _buildTvQualityOptions,
+      speedListenable: _playbackSpeed,
+      onSetSpeed: _setPlaybackSpeed,
     );
   }
 
@@ -2458,7 +2463,17 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           }
         },
       },
-      child: Focus(autofocus: true, onKeyEvent: _onPlayerKey, child: child),
+      child: MouseRegion(
+        // Desktop debugging: a mouse has no d-pad, so let hover and clicks
+        // reveal the auto-hiding controls (bumping the same notifier the remote
+        // does). No-op on a TV, which sends no pointer-hover events.
+        onEnter: (_) => _revealControls.value++,
+        onHover: (_) => _revealControls.value++,
+        child: Listener(
+          onPointerDown: (_) => _revealControls.value++,
+          child: Focus(autofocus: true, onKeyEvent: _onPlayerKey, child: child),
+        ),
+      ),
     );
   }
 

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -1468,6 +1468,194 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     );
   }
 
+  // d-pad-focusable option data for the TV settings panel — the same track
+  // switching the bottom-sheet widgets do, minus the Navigator.pop (the panel
+  // is not a route). Records: (label, selected, onTap).
+  List<({String label, bool selected, VoidCallback onTap})> _tvQualityOptions() {
+    List<VideoPrefs> videoQuality = _player.state.tracks.video
+        .where(
+          (element) => element.w != null && element.h != null && widget.isLocal,
+        )
+        .toList()
+        .map((e) => VideoPrefs(videoTrack: e, isLocal: true))
+        .toList();
+    if (widget.videos.isNotEmpty && !widget.isLocal) {
+      for (var video in widget.videos) {
+        videoQuality.add(
+          VideoPrefs(
+            videoTrack: VideoTrack(video.url, video.quality, video.quality),
+            headers: video.headers,
+            isLocal: false,
+          ),
+        );
+      }
+    }
+    return videoQuality.map((quality) {
+      final selected =
+          _video.value!.videoTrack!.title == quality.videoTrack!.title ||
+          widget.isLocal;
+      return (
+        label: widget.isLocal ? _firstVid.quality : quality.videoTrack!.title!,
+        selected: selected,
+        onTap: () {
+          if (_video.value?.videoTrack?.id == quality.videoTrack?.id) return;
+          _video.value = quality;
+          _player.stop();
+          if (quality.isLocal) {
+            if (widget.isLocal) {
+              _player.setVideoTrack(quality.videoTrack!);
+            } else {
+              _openMedia(quality);
+            }
+          } else {
+            _openMedia(quality);
+          }
+          _initSubtitleAndAudio = true;
+        },
+      );
+    }).toList();
+  }
+
+  List<({String label, bool selected, VoidCallback onTap})> _tvSubtitleOptions() {
+    List<VideoPrefs> videoSubtitle = _player.state.tracks.subtitle
+        .toList()
+        .map((e) => VideoPrefs(isLocal: true, subtitle: e))
+        .toList();
+    List<String> subs = [];
+    if (widget.videos.isNotEmpty) {
+      for (var video in widget.videos) {
+        for (var sub in video.subtitles ?? []) {
+          if (!subs.contains(sub.file)) {
+            final file = sub.file!;
+            final label = sub.label;
+            videoSubtitle.add(
+              VideoPrefs(
+                isLocal: widget.isLocal,
+                subtitle: (file.startsWith("http") || file.startsWith("file"))
+                    ? SubtitleTrack.uri(file, title: label, language: label)
+                    : SubtitleTrack.data(file, title: label, language: label),
+              ),
+            );
+            subs.add(sub.file!);
+          }
+        }
+      }
+    }
+    final subtitle = _player.state.track.subtitle;
+    videoSubtitle = videoSubtitle
+        .map((e) {
+          e.title =
+              e.subtitle?.title ??
+              e.subtitle?.language ??
+              e.subtitle?.channels ??
+              "";
+          return e;
+        })
+        .toList()
+        .where((element) => element.title!.isNotEmpty)
+        .toList();
+    videoSubtitle.sort((a, b) => a.title!.compareTo(b.title!));
+    videoSubtitle.insert(
+      0,
+      VideoPrefs(isLocal: false, subtitle: SubtitleTrack.no()),
+    );
+    final List<VideoPrefs> last = [];
+    for (var element in videoSubtitle) {
+      final key = element.title ??
+          element.subtitle?.title ??
+          element.subtitle?.language ??
+          element.subtitle?.channels ??
+          "None";
+      final contains = last.any((sub) =>
+          (sub.title ??
+              sub.subtitle?.title ??
+              sub.subtitle?.language ??
+              sub.subtitle?.channels ??
+              "None") ==
+          key);
+      if (!contains) last.add(element);
+    }
+    return last.toSet().toList().map((sub) {
+      final title = sub.title ??
+          sub.subtitle?.title ??
+          sub.subtitle?.language ??
+          sub.subtitle?.channels ??
+          "None";
+      final selected = (title ==
+              (subtitle.title ??
+                  subtitle.language ??
+                  subtitle.channels ??
+                  "None")) ||
+          (subtitle.id == "no" && title == "None");
+      return (
+        label: title == "None" ? "Off" : title,
+        selected: selected,
+        onTap: () {
+          try {
+            _player.setSubtitleTrack(sub.subtitle!);
+          } catch (_) {}
+        },
+      );
+    }).toList();
+  }
+
+  List<({String label, bool selected, VoidCallback onTap})> _tvAudioOptions() {
+    List<VideoPrefs> videoAudio = _player.state.tracks.audio
+        .toList()
+        .map((e) => VideoPrefs(isLocal: true, audio: e))
+        .toList();
+    List<String> audios = [];
+    if (widget.videos.isNotEmpty && !widget.isLocal) {
+      for (var video in widget.videos) {
+        for (var audio in video.audios ?? []) {
+          if (!audios.contains(audio.file)) {
+            videoAudio.add(
+              VideoPrefs(
+                isLocal: false,
+                audio: AudioTrack.uri(
+                  audio.file!,
+                  title: audio.label,
+                  language: audio.label,
+                ),
+              ),
+            );
+            audios.add(audio.file!);
+          }
+        }
+      }
+    }
+    final audio = _player.state.track.audio;
+    videoAudio = videoAudio
+        .map((e) {
+          e.title =
+              e.audio?.title ?? e.audio?.language ?? e.audio?.channels ?? "";
+          return e;
+        })
+        .toList()
+        .where((element) => element.title!.isNotEmpty)
+        .toList();
+    videoAudio.sort((a, b) => a.title!.compareTo(b.title!));
+    videoAudio.insert(0, VideoPrefs(isLocal: false, audio: AudioTrack.no()));
+    return videoAudio.toSet().toList().map((aud) {
+      final title = aud.title ??
+          aud.audio?.title ??
+          aud.audio?.language ??
+          aud.audio?.channels ??
+          "None";
+      final selected =
+          (aud.audio == audio) || (audio.id == "no" && title == "None");
+      return (
+        label: title == "None" ? "Off" : title,
+        selected: selected,
+        onTap: () {
+          try {
+            _player.setAudioTrack(aud.audio!);
+          } catch (_) {}
+        },
+      );
+    }).toList();
+  }
+
   Future<void> _setPlaybackSpeed(double speed) async {
     await _player.setRate(speed);
     _playbackSpeed.value = speed;
@@ -2244,9 +2432,9 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             speedListenable: _playbackSpeed,
             onSetSpeed: _setPlaybackSpeed,
             selectedShaderListenable: _selectedShader,
-            qualityWidget: _videoQualityWidget(context),
-            subtitleWidget: _videoSubtitle(context, (_) {}),
-            audioWidget: _videoAudios(context),
+            qualityOptions: _tvQualityOptions,
+            subtitleOptions: _tvSubtitleOptions,
+            audioOptions: _tvAudioOptions,
             onClose: () => setState(() => _tvSettingsOpen = false),
           ),
         ],

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -21,6 +21,7 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/video.dart' as vid;
 import 'package:mangayomi/modules/anime/providers/anime_player_controller_provider.dart';
+import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
 import 'package:mangayomi/modules/anime/widgets/aniskip_countdown_btn.dart';
 import 'package:mangayomi/modules/anime/widgets/desktop.dart';
 import 'package:mangayomi/modules/anime/widgets/play_or_pause_button.dart';
@@ -311,7 +312,7 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
 
   late final StreamSubscription<bool> _completed = _player.stream.completed
       .listen((val) {
-        if (hasNextEpisode && val) {
+        if (hasNextEpisode && val && ref.read(autoPlayNextEpisodeProvider)) {
           if (mounted) {
             pushToNewEpisode(context, _streamController.getNextEpisode());
           }
@@ -1896,6 +1897,23 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           ),
           Row(
             children: [
+              Consumer(
+                builder: (context, ref, _) {
+                  final autoPlay = ref.watch(autoPlayNextEpisodeProvider);
+                  return IconButton(
+                    tooltip: autoPlay
+                        ? 'Autoplay next episode: on'
+                        : 'Autoplay next episode: off',
+                    icon: Icon(
+                      Icons.playlist_play,
+                      color: autoPlay ? Colors.white : Colors.white38,
+                    ),
+                    onPressed: () => ref
+                        .read(autoPlayNextEpisodeProvider.notifier)
+                        .toggle(),
+                  );
+                },
+              ),
               if (_supportAlwaysOnTop())
                 IconButton(
                   icon: Icon(

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -853,7 +853,13 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     }
     if (!isDesktop) {
       final forceLandscape = ref.read(forceLandscapePlayerStateProvider);
-      if (forceLandscape) {
+      // Preserve the player orientation across episode changes. Playing the next
+      // episode pushes a fresh player, and the old one's dispose() resets the
+      // orientation to portrait. So if the viewer is still in fullscreen — from
+      // the force-landscape setting or a manual toggle that persists across
+      // episodes (fullscreenProvider is global) — re-apply landscape here rather
+      // than stranding them in portrait with the fullscreen button still active.
+      if (forceLandscape || ref.read(fullscreenProvider)) {
         _setLandscapeMode(true);
       }
     }

--- a/lib/modules/anime/providers/auto_play_next_provider.dart
+++ b/lib/modules/anime/providers/auto_play_next_provider.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+/// Hive box + key holding the "autoplay next episode" preference.
+///
+/// Stored in Hive (not the Isar Settings collection) so the toggle persists
+/// without touching the generated Isar schema. The box is opened once at
+/// startup in `_postLaunchInit`; see [openPlayerPrefsBox].
+const _playerPrefsBox = 'player_prefs';
+const _autoPlayNextKey = 'auto_play_next_episode';
+
+/// Opens the player-preferences box. Called once during app startup so the
+/// value can be read synchronously by [AutoPlayNextEpisode.build].
+Future<void> openPlayerPrefsBox() async {
+  if (!Hive.isBoxOpen(_playerPrefsBox)) {
+    await Hive.openBox(_playerPrefsBox);
+  }
+}
+
+/// Whether the player should automatically start the next episode when the
+/// current one finishes. Defaults to `true` (the previous always-on behavior).
+/// Toggled from a button in the player and persisted across sessions.
+final autoPlayNextEpisodeProvider =
+    NotifierProvider<AutoPlayNextEpisode, bool>(AutoPlayNextEpisode.new);
+
+class AutoPlayNextEpisode extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_playerPrefsBox)) {
+      return Hive.box(_playerPrefsBox).get(_autoPlayNextKey, defaultValue: true)
+          as bool;
+    }
+    return true;
+  }
+
+  void toggle() => set(!state);
+
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_playerPrefsBox)) {
+      Hive.box(_playerPrefsBox).put(_autoPlayNextKey, value);
+    }
+  }
+}

--- a/lib/modules/anime/providers/auto_play_next_provider.dart
+++ b/lib/modules/anime/providers/auto_play_next_provider.dart
@@ -27,8 +27,10 @@ class AutoPlayNextEpisode extends Notifier<bool> {
   @override
   bool build() {
     if (Hive.isBoxOpen(_playerPrefsBox)) {
-      return Hive.box(_playerPrefsBox).get(_autoPlayNextKey, defaultValue: true)
-          as bool;
+      // Read defensively: a missing or non-bool value (corrupt / hand-edited
+      // box) falls back to the default rather than throwing during build.
+      final value = Hive.box(_playerPrefsBox).get(_autoPlayNextKey);
+      if (value is bool) return value;
     }
     return true;
   }

--- a/lib/modules/anime/widgets/desktop.dart
+++ b/lib/modules/anime/widgets/desktop.dart
@@ -26,6 +26,9 @@ class DesktopControllerWidget extends ConsumerStatefulWidget {
   final int defaultSkipIntroLength;
   final void Function(bool) desktopFullScreenPlayer;
   final ValueNotifier<List<(String, int)>> chapterMarks;
+  // Bumped by the player on each d-pad key so the desktop controls can reveal on
+  // a TV remote — they otherwise only appear on mouse hover. Null off-TV.
+  final ValueNotifier<int>? revealControls;
   const DesktopControllerWidget({
     super.key,
     required this.videoController,
@@ -39,6 +42,7 @@ class DesktopControllerWidget extends ConsumerStatefulWidget {
     required this.defaultSkipIntroLength,
     required this.desktopFullScreenPlayer,
     required this.chapterMarks,
+    this.revealControls,
   });
 
   @override
@@ -67,6 +71,18 @@ class _DesktopControllerWidgetState
   final List<StreamSubscription> subscriptions = [];
   DateTime last = DateTime.now();
   Timer? _tapTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    // Reveal on a d-pad key (TV remote) — the desktop controls otherwise only
+    // appear on mouse hover, which a remote can't trigger.
+    widget.revealControls?.addListener(_onRevealRequest);
+  }
+
+  void _onRevealRequest() {
+    if (mounted) onEnter();
+  }
 
   @override
   void setState(VoidCallback fn) {
@@ -99,6 +115,7 @@ class _DesktopControllerWidgetState
 
   @override
   void dispose() {
+    widget.revealControls?.removeListener(_onRevealRequest);
     for (final subscription in subscriptions) {
       subscription.cancel();
     }

--- a/lib/modules/anime/widgets/mobile.dart
+++ b/lib/modules/anime/widgets/mobile.dart
@@ -25,6 +25,8 @@ class MobileControllerWidget extends ConsumerStatefulWidget {
   final GlobalKey<VideoState> videoStatekey;
   final Widget bottomButtonBarWidget;
   final ValueNotifier<List<(String, int)>> chapterMarks;
+  // Bumped by the player on each d-pad key so the controls reveal on a TV remote.
+  final ValueNotifier<int> revealControls;
   const MobileControllerWidget({
     super.key,
     required this.videoController,
@@ -34,6 +36,7 @@ class MobileControllerWidget extends ConsumerStatefulWidget {
     required this.videoStatekey,
     required this.doubleSpeed,
     required this.chapterMarks,
+    required this.revealControls,
   });
 
   @override
@@ -45,6 +48,14 @@ class _MobileControllerWidgetState
     extends ConsumerState<MobileControllerWidget> {
   bool mount = true;
   bool visible = true;
+  // Wraps the control buttons; requestFocus()'d on reveal so the d-pad lands on
+  // a real button (see _onRevealRequest).
+  final FocusScopeNode _controlsScope = FocusScopeNode(
+    debugLabel: 'playerControls',
+  );
+  // The center play/pause — focused first on reveal so the d-pad lands on the
+  // main control rather than the top-bar back button.
+  final FocusNode _playPauseFocus = FocusNode(debugLabel: 'playerPlayPause');
   Duration controlsTransitionDuration = const Duration(milliseconds: 300);
   Color backdropColor = const Color(0x66000000);
   Timer? _timer;
@@ -125,8 +136,40 @@ class _MobileControllerWidgetState
     }
   }
 
+  // Called by the player on each d-pad key: reveal the controls if hidden and
+  // keep them on-screen while the user navigates the buttons with the remote.
+  void _onRevealRequest() {
+    if (!mounted) return;
+    if (!visible) {
+      setState(() {
+        mount = true;
+        visible = true;
+      });
+    }
+    _restartHideTimer();
+    // Move focus onto the controls only when it isn't already there. A
+    // FocusScope delegates requestFocus to its first focusable descendant, so
+    // this reliably lands the d-pad on a real button — unlike directional
+    // traversal from the full-screen player Focus, which never landed anywhere.
+    // Once focus is inside, subsequent keys navigate the buttons freely.
+    if (!_controlsScope.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        // Prefer the center play/pause; fall back to the scope's first button.
+        if (_playPauseFocus.canRequestFocus) {
+          _playPauseFocus.requestFocus();
+        } else {
+          _controlsScope.requestFocus();
+        }
+      });
+    }
+  }
+
   @override
   void dispose() {
+    widget.revealControls.removeListener(_onRevealRequest);
+    _controlsScope.dispose();
+    _playPauseFocus.dispose();
     for (final subscription in subscriptions) {
       subscription.cancel();
     }
@@ -172,6 +215,19 @@ class _MobileControllerWidgetState
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
       _timer?.cancel();
     }
+  }
+
+
+  void _restartHideTimer() {
+    _timer?.cancel();
+    _timer = Timer(controlsHoverDuration, () {
+      if (mounted) {
+        setState(() {
+          visible = false;
+        });
+        SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
+      }
+    });
   }
 
   void onDoubleTapSeekBackward() {
@@ -234,6 +290,7 @@ class _MobileControllerWidgetState
   @override
   void initState() {
     super.initState();
+    widget.revealControls.addListener(_onRevealRequest);
     _volumeController = VolumeController.instance;
 
     Future.microtask(() async {
@@ -309,8 +366,8 @@ class _MobileControllerWidgetState
                   ),
                 ),
         ),
-        Focus(
-          autofocus: true,
+        FocusScope(
+          node: _controlsScope,
           child: Stack(
             clipBehavior: Clip.none,
             alignment: Alignment.center,
@@ -429,12 +486,23 @@ class _MobileControllerWidgetState
                                     : 1.0,
                                 duration: controlsTransitionDuration,
                                 child: Center(
-                                  child: Row(
-                                    children: mobilePrimaryButtonBar(
-                                      context,
-                                      widget.videoStatekey,
-                                      widget.streamController,
-                                      widget.videoController,
+                                  // Brighter focus highlight on the main controls
+                                  // so the focused button stands out against the
+                                  // dark backdrop on a TV.
+                                  child: Theme(
+                                    data: Theme.of(context).copyWith(
+                                      focusColor: Colors.white.withValues(
+                                        alpha: 0.45,
+                                      ),
+                                    ),
+                                    child: Row(
+                                      children: mobilePrimaryButtonBar(
+                                        context,
+                                        widget.videoStatekey,
+                                        widget.streamController,
+                                        widget.videoController,
+                                        playPauseFocus: _playPauseFocus,
+                                      ),
                                     ),
                                   ),
                                 ),
@@ -890,8 +958,9 @@ List<Widget> mobilePrimaryButtonBar(
   BuildContext context,
   GlobalKey<VideoState> key,
   AnimeStreamController streamController,
-  VideoController controller,
-) {
+  VideoController controller, {
+  FocusNode? playPauseFocus,
+}) {
   bool hasPrevEpisode =
       streamController.getEpisodeIndex().$1 + 1 !=
       streamController.getEpisodesLength(streamController.getEpisodeIndex().$2);
@@ -918,7 +987,7 @@ List<Widget> mobilePrimaryButtonBar(
       ),
     ),
     const Spacer(),
-    CustomPlayOrPauseButton(controller: controller),
+    CustomPlayOrPauseButton(controller: controller, focusNode: playPauseFocus),
     const Spacer(),
     IconButton(
       onPressed: hasNextEpisode

--- a/lib/modules/anime/widgets/play_or_pause_button.dart
+++ b/lib/modules/anime/widgets/play_or_pause_button.dart
@@ -8,8 +8,13 @@ import 'package:media_kit_video/media_kit_video.dart';
 /// A material design play/pause button.
 class CustomPlayOrPauseButton extends StatefulWidget {
   final VideoController controller;
+  final FocusNode? focusNode;
 
-  const CustomPlayOrPauseButton({super.key, required this.controller});
+  const CustomPlayOrPauseButton({
+    super.key,
+    required this.controller,
+    this.focusNode,
+  });
 
   @override
   CustomPlayOrPauseButtonState createState() => CustomPlayOrPauseButtonState();
@@ -56,6 +61,7 @@ class CustomPlayOrPauseButtonState extends State<CustomPlayOrPauseButton>
   @override
   Widget build(BuildContext context) {
     return IconButton(
+      focusNode: widget.focusNode,
       onPressed: widget.controller.player.playOrPause,
       iconSize: iconSize,
       color: Colors.white,

--- a/lib/modules/anime/widgets/tv_player_controls.dart
+++ b/lib/modules/anime/widgets/tv_player_controls.dart
@@ -1,0 +1,870 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
+import 'package:media_kit/media_kit.dart';
+
+/// A dedicated, Netflix-style controls overlay for the anime player on TV.
+///
+/// Only the essentials are on screen — play/pause, prev/next episode, a seek
+/// bar with times, and audio/subtitle access — everything else lives behind the
+/// gear. Built for the d-pad: theme-coloured focus highlight on every control,
+/// the seek bar seeks a small fixed amount on Left/Right and lets Up/Down move
+/// focus away, and the reveal/auto-hide is driven by [revealControls] (bumped by
+/// the player on each key).
+class TvPlayerControls extends StatefulWidget {
+  const TvPlayerControls({
+    super.key,
+    required this.player,
+    required this.revealControls,
+    required this.title,
+    required this.episodeLabel,
+    required this.onBack,
+    required this.onRestart,
+    required this.onSettings,
+    required this.hasNext,
+    required this.onNext,
+    required this.qualityListenable,
+    required this.buildQualityOptions,
+  });
+
+  final Player player;
+  final ValueNotifier<int> revealControls;
+  final String title;
+  final String episodeLabel;
+  final VoidCallback onBack;
+  final VoidCallback onRestart;
+  final VoidCallback onSettings;
+  final bool hasNext;
+  final VoidCallback? onNext;
+  // Quality = the source video list (e.g. "1080p Sub"/"1080p Dub") — the real
+  // dub/sub control here. Rebuilt when [qualityListenable] fires.
+  final Listenable qualityListenable;
+  final List<TvTrackOption> Function() buildQualityOptions;
+
+  @override
+  State<TvPlayerControls> createState() => _TvPlayerControlsState();
+}
+
+class _TvPlayerControlsState extends State<TvPlayerControls> {
+  bool _visible = true;
+  Timer? _hideTimer;
+  final FocusScopeNode _scope = FocusScopeNode(debugLabel: 'tvPlayer');
+  final FocusNode _playFocus = FocusNode(debugLabel: 'tvPlayerPlayPause');
+  static const _hideAfter = Duration(seconds: 4);
+
+  @override
+  void initState() {
+    super.initState();
+    widget.revealControls.addListener(_reveal);
+    _startHideTimer();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _playFocus.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.revealControls.removeListener(_reveal);
+    _hideTimer?.cancel();
+    _scope.dispose();
+    _playFocus.dispose();
+    super.dispose();
+  }
+
+  void _reveal() {
+    if (!mounted) return;
+    if (!_visible) setState(() => _visible = true);
+    _startHideTimer();
+    if (!_scope.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        (_playFocus.canRequestFocus ? _playFocus : _scope).requestFocus();
+      });
+    }
+  }
+
+  void _startHideTimer() {
+    _hideTimer?.cancel();
+    _hideTimer = Timer(_hideAfter, () {
+      if (mounted) setState(() => _visible = false);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.primary;
+    // TV overscan-safe margins (~5% per side, Netflix-generous). Only the
+    // interactive controls/title are inset — the scrim stays full-bleed, per
+    // Android TV layout guidance.
+    final size = MediaQuery.of(context).size;
+    final safeH = size.width * 0.08;
+    final safeV = size.height * 0.05;
+    return FocusScope(
+      node: _scope,
+      // Only build the controls (and their per-frame StreamBuilders) while
+      // visible. Otherwise the seek/time streams rebuild ~4x/sec during
+      // playback and jank the Fire TV — hidden means nothing to render.
+      child: !_visible
+          ? const SizedBox.expand()
+          : Stack(
+              children: [
+              // Scrim so white controls read over any frame.
+              Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        Colors.black.withValues(alpha: 0.55),
+                        Colors.black.withValues(alpha: 0.15),
+                        Colors.black.withValues(alpha: 0.65),
+                      ],
+                      stops: const [0.0, 0.45, 1.0],
+                    ),
+                  ),
+                ),
+              ),
+              // Top-left: back / restart / autoplay (gear lives by the pills).
+              Positioned(
+                top: safeV,
+                left: safeH,
+                child: Row(
+                  children: [
+                    _TvFocusable(
+                      accent: accent,
+                      onPressed: widget.onBack,
+                      child: const Icon(Icons.arrow_back, color: Colors.white),
+                    ),
+                    const SizedBox(width: 8),
+                    _TvFocusable(
+                      accent: accent,
+                      onPressed: widget.onRestart,
+                      child: const Icon(
+                        Icons.replay_outlined,
+                        color: Colors.white,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    // Autoplay-next — YouTube-style labelled switch.
+                    Consumer(
+                      builder: (context, ref, _) {
+                        final on = ref.watch(autoPlayNextEpisodeProvider);
+                        return _AutoplayToggle(
+                          accent: accent,
+                          on: on,
+                          onToggle: () => ref
+                              .read(autoPlayNextEpisodeProvider.notifier)
+                              .toggle(),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              // Top-right: title + episode.
+              Positioned(
+                top: safeV,
+                right: safeH,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    if (widget.title.isNotEmpty)
+                      Text(
+                        widget.title,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    if (widget.episodeLabel.isNotEmpty)
+                      Text(
+                        widget.episodeLabel,
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 14,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              // Bottom: controls + seek + tracks.
+              Positioned(
+                left: safeH,
+                right: safeH,
+                bottom: safeV,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    // Play/pause inline on the left of the seek line. Default
+                    // focus + highlighted; OK on the seek bar also toggles it.
+                    Row(
+                      children: [
+                        _PlayPauseButton(
+                          player: widget.player,
+                          accent: accent,
+                          focusNode: _playFocus,
+                        ),
+                        const SizedBox(width: 14),
+                        _PositionText(player: widget.player),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: _TvSeekBar(
+                            player: widget.player,
+                            accent: accent,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        _RemainingText(player: widget.player),
+                        // Manual skip to the next episode (autoplay still
+                        // auto-advances at the end); shown only if there is one.
+                        if (widget.hasNext) ...[
+                          const SizedBox(width: 8),
+                          _TvFocusable(
+                            accent: accent,
+                            onPressed: widget.onNext,
+                            // Match the play/pause size (34) so the two
+                            // transport controls frame the seek bar evenly.
+                            child: const Icon(
+                              Icons.skip_next,
+                              color: Colors.white,
+                              size: 34,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 14),
+                    // Quality | Subtitles | Audio pills (current one checked).
+                    _PillBar(
+                      player: widget.player,
+                      accent: accent,
+                      qualityListenable: widget.qualityListenable,
+                      buildQualityOptions: widget.buildQualityOptions,
+                      onSettings: widget.onSettings,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+    );
+  }
+}
+
+bool _isSelect(LogicalKeyboardKey k) =>
+    k == LogicalKeyboardKey.select ||
+    k == LogicalKeyboardKey.enter ||
+    k == LogicalKeyboardKey.numpadEnter ||
+    k == LogicalKeyboardKey.gameButtonA ||
+    k == LogicalKeyboardKey.space;
+
+/// A focusable control that shows a solid theme-accent background when focused
+/// (clearly visible over the dark backdrop) and fires [onPressed] on select.
+class _TvFocusable extends StatefulWidget {
+  const _TvFocusable({
+    required this.accent,
+    required this.child,
+    required this.onPressed,
+    this.focusNode,
+    this.autofocus = false,
+  });
+
+  final Color accent;
+  final Widget child;
+  final VoidCallback? onPressed;
+  final FocusNode? focusNode;
+  final bool autofocus;
+
+  @override
+  State<_TvFocusable> createState() => _TvFocusableState();
+}
+
+class _TvFocusableState extends State<_TvFocusable> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = widget.onPressed != null;
+    return Focus(
+      focusNode: widget.focusNode,
+      autofocus: widget.autofocus,
+      canRequestFocus: enabled,
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey) && enabled) {
+          widget.onPressed!();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onPressed,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: _focused
+                ? widget.accent
+                : Colors.black.withValues(alpha: 0.35),
+          ),
+          child: Opacity(opacity: enabled ? 1.0 : 0.4, child: widget.child),
+        ),
+      ),
+    );
+  }
+}
+
+/// Focusable play/pause button — highlighted when focused, and the default
+/// focus on reveal. OK on the seek bar also toggles it (Netflix convenience).
+class _PlayPauseButton extends StatelessWidget {
+  const _PlayPauseButton({
+    required this.player,
+    required this.accent,
+    required this.focusNode,
+  });
+
+  final Player player;
+  final Color accent;
+  final FocusNode focusNode;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<bool>(
+      stream: player.stream.playing,
+      initialData: player.state.playing,
+      builder: (context, snapshot) {
+        final playing = snapshot.data ?? false;
+        return _TvFocusable(
+          accent: accent,
+          focusNode: focusNode,
+          autofocus: true,
+          onPressed: player.playOrPause,
+          child: Icon(
+            playing ? Icons.pause : Icons.play_arrow,
+            color: Colors.white,
+            size: 34,
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// A selectable option for the Quality group (source-provided video list).
+class TvTrackOption {
+  const TvTrackOption({
+    required this.label,
+    required this.selected,
+    required this.onSelect,
+  });
+  final String label;
+  final bool selected;
+  final VoidCallback onSelect;
+}
+
+/// The bottom pill bar: `Quality | Subtitles | Audio`, centered, current option
+/// in each group checked. Quality is the real dub/sub control here (it re-opens
+/// the stream at the chosen source video), so it comes first.
+class _PillBar extends StatelessWidget {
+  const _PillBar({
+    required this.player,
+    required this.accent,
+    required this.qualityListenable,
+    required this.buildQualityOptions,
+    required this.onSettings,
+  });
+
+  final Player player;
+  final Color accent;
+  final Listenable qualityListenable;
+  final List<TvTrackOption> Function() buildQualityOptions;
+  final VoidCallback onSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: qualityListenable,
+      builder: (context, _) {
+        final quality = buildQualityOptions();
+        return StreamBuilder<Tracks>(
+          stream: player.stream.tracks,
+          initialData: player.state.tracks,
+          builder: (context, tracksSnap) {
+            final tracks = tracksSnap.data ?? player.state.tracks;
+            return StreamBuilder<Track>(
+              stream: player.stream.track,
+              initialData: player.state.track,
+              builder: (context, trackSnap) {
+                final current = trackSnap.data ?? player.state.track;
+                // Real subtitle tracks only (no "auto"/"no" placeholders).
+                final subs = tracks.subtitle
+                    .where((t) => t.id != 'auto' && t.id != 'no')
+                    .toList();
+                // A "sub" quality already bakes subtitles into the stream, so
+                // hide the subtitle group when one is selected.
+                final subQualitySelected = quality.any(
+                  (q) => q.selected && q.label.toLowerCase().contains('sub'),
+                );
+
+                final groups = <List<Widget>>[];
+
+                // Quality group — the real dub/sub control.
+                if (quality.isNotEmpty) {
+                  groups.add([
+                    for (final q in quality)
+                      _TrackPill(
+                        accent: accent,
+                        icon: Icons.high_quality_outlined,
+                        label: q.label,
+                        selected: q.selected,
+                        onTap: q.onSelect,
+                      ),
+                  ]);
+                }
+
+                // Subtitle group — real tracks only, toggleable (re-clicking the
+                // selected one turns subtitles off). No separate "off" pill, and
+                // hidden entirely for sub-quality streams.
+                if (!subQualitySelected && subs.isNotEmpty) {
+                  groups.add([
+                    for (final s in subs)
+                      _TrackPill(
+                        accent: accent,
+                        icon: Icons.subtitles_outlined,
+                        label: _trackLabel(s.title, s.language, s.id),
+                        selected: s.id == current.subtitle.id,
+                        onTap: () => player.setSubtitleTrack(
+                          s.id == current.subtitle.id
+                              ? SubtitleTrack.no()
+                              : s,
+                        ),
+                      ),
+                  ]);
+                }
+
+                // Join groups with a "|" divider.
+                final children = <Widget>[];
+                for (var i = 0; i < groups.length; i++) {
+                  if (i > 0) children.add(const _PillDivider());
+                  children.addAll(groups[i]);
+                }
+                // Gear pill at the end of the row (moved here from the top bar),
+                // sized to match the track pills.
+                if (children.isNotEmpty) children.add(const _PillDivider());
+                children.add(
+                  _TrackPill(
+                    accent: accent,
+                    icon: Icons.settings,
+                    label: 'Settings',
+                    selected: false,
+                    onTap: onSettings,
+                  ),
+                );
+                return Wrap(
+                  alignment: WrapAlignment.center,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: children,
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+/// A thin vertical "|" separator between pill groups.
+class _PillDivider extends StatelessWidget {
+  const _PillDivider();
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1,
+      height: 22,
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      color: Colors.white.withValues(alpha: 0.3),
+    );
+  }
+}
+
+/// A compact YouTube-style "Autoplay" labelled switch, focusable for the d-pad.
+class _AutoplayToggle extends StatefulWidget {
+  const _AutoplayToggle({
+    required this.accent,
+    required this.on,
+    required this.onToggle,
+  });
+
+  final Color accent;
+  final bool on;
+  final VoidCallback onToggle;
+
+  @override
+  State<_AutoplayToggle> createState() => _AutoplayToggleState();
+}
+
+class _AutoplayToggleState extends State<_AutoplayToggle> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
+          widget.onToggle();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onToggle,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          padding: const EdgeInsets.all(6),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            // Theme tint on focus (like the settings toggles), not an outline.
+            color: _focused
+                ? widget.accent.withValues(alpha: 0.25)
+                : Colors.transparent,
+          ),
+          child: AutoplaySwitch(on: widget.on, accent: widget.accent),
+        ),
+      ),
+    );
+  }
+
+}
+
+/// A drawn play/pause autoplay toggle (no asset): a pill track with a circular
+/// black knob that slides right + shows ▶ when on, left + shows ⏸ when off —
+/// matching the reference toggle style.
+class AutoplaySwitch extends StatelessWidget {
+  const AutoplaySwitch({required this.on, required this.accent});
+
+  final bool on;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    const w = 52.0;
+    const h = 28.0;
+    const trackH = 22.0;
+    const knob = 28.0;
+    return SizedBox(
+      width: w,
+      height: h,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          AnimatedContainer(
+            duration: const Duration(milliseconds: 180),
+            width: w - 4,
+            height: trackH,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(trackH / 2),
+              color: on
+                  ? accent.withValues(alpha: 0.5)
+                  : Colors.white.withValues(alpha: 0.22),
+            ),
+          ),
+          AnimatedAlign(
+            duration: const Duration(milliseconds: 180),
+            curve: Curves.easeOut,
+            alignment: on ? Alignment.centerRight : Alignment.centerLeft,
+            child: Container(
+              width: knob,
+              height: knob,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.black,
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.4),
+                    blurRadius: 3,
+                    offset: const Offset(0, 1),
+                  ),
+                ],
+              ),
+              child: Icon(
+                on ? Icons.play_arrow : Icons.pause,
+                color: Colors.white,
+                size: 16,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _trackLabel(String? title, String? language, String id) {
+  final t = (title ?? '').trim();
+  if (t.isNotEmpty) return t;
+  final l = (language ?? '').trim();
+  if (l.isNotEmpty) return l;
+  return id;
+}
+
+/// A small focusable track pill: accent when focused, faded accent when it's the
+/// current track (with a check), else a translucent fill.
+class _TrackPill extends StatefulWidget {
+  const _TrackPill({
+    required this.accent,
+    required this.icon,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final Color accent;
+  final IconData icon;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  State<_TrackPill> createState() => _TrackPillState();
+}
+
+class _TrackPillState extends State<_TrackPill> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = _focused
+        ? widget.accent
+        : widget.selected
+        ? widget.accent.withValues(alpha: 0.4)
+        : Colors.white.withValues(alpha: 0.15);
+    return Focus(
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
+          widget.onTap();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(16),
+            color: bg,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                widget.selected ? Icons.check : widget.icon,
+                color: Colors.white,
+                size: 14,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                widget.label,
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A focusable seek bar: Left/Right seek a small fixed amount; Up/Down escape.
+class _TvSeekBar extends StatefulWidget {
+  const _TvSeekBar({
+    required this.player,
+    required this.accent,
+    this.focusNode,
+  });
+
+  final Player player;
+  final Color accent;
+  final FocusNode? focusNode;
+
+  @override
+  State<_TvSeekBar> createState() => _TvSeekBarState();
+}
+
+class _TvSeekBarState extends State<_TvSeekBar> {
+  bool _focused = false;
+  static const _step = Duration(seconds: 10);
+
+  void _seek(Duration delta) {
+    var target = widget.player.state.position + delta;
+    if (target < Duration.zero) target = Duration.zero;
+    final dur = widget.player.state.duration;
+    if (dur > Duration.zero && target > dur) target = dur;
+    widget.player.seek(target);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: widget.focusNode,
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent || event is KeyRepeatEvent) {
+          final k = event.logicalKey;
+          if (k == LogicalKeyboardKey.arrowLeft) {
+            _seek(-_step);
+            return KeyEventResult.handled;
+          }
+          if (k == LogicalKeyboardKey.arrowRight) {
+            _seek(_step);
+            return KeyEventResult.handled;
+          }
+          // OK/Select toggles play/pause (Netflix model — no separate button).
+          if (event is KeyDownEvent && _isSelect(k)) {
+            widget.player.playOrPause();
+            return KeyEventResult.handled;
+          }
+          // Up / Down fall through so focus can leave the bar.
+        }
+        return KeyEventResult.ignored;
+      },
+      child: StreamBuilder<Duration>(
+        stream: widget.player.stream.position,
+        initialData: widget.player.state.position,
+        builder: (context, snapshot) {
+          final pos = snapshot.data ?? Duration.zero;
+          final dur = widget.player.state.duration;
+          final frac = dur.inMilliseconds > 0
+              ? (pos.inMilliseconds / dur.inMilliseconds).clamp(0.0, 1.0)
+              : 0.0;
+          final barH = _focused ? 6.0 : 4.0;
+          const knob = 16.0;
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 6),
+            child: SizedBox(
+              height: 16,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final w = constraints.maxWidth;
+                  return Stack(
+                    children: [
+                      // Track + progress, vertically centred.
+                      Align(
+                        alignment: Alignment.center,
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(barH / 2),
+                          child: SizedBox(
+                            height: barH,
+                            width: w,
+                            child: LinearProgressIndicator(
+                              value: frac,
+                              backgroundColor: Colors.white24,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                widget.accent,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      // Scrubber handle at the current position when focused —
+                      // the focus affordance instead of an outline.
+                      if (_focused)
+                        Positioned(
+                          left: (frac * (w - knob)).clamp(0.0, w - knob),
+                          top: (16 - knob) / 2,
+                          child: Container(
+                            width: knob,
+                            height: knob,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Colors.white,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withValues(alpha: 0.4),
+                                  blurRadius: 3,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+String _fmt(Duration d) {
+  final h = d.inHours;
+  final m = d.inMinutes.remainder(60);
+  final s = d.inSeconds.remainder(60);
+  final mm = m.toString().padLeft(2, '0');
+  final ss = s.toString().padLeft(2, '0');
+  return h > 0 ? '$h:$mm:$ss' : '$mm:$ss';
+}
+
+// Monospace + tabular figures so the timestamps read cleanly and don't jitter
+// as the digits change.
+TextStyle _timeStyle(Color color) => TextStyle(
+  color: color,
+  fontSize: 15,
+  fontFamily: 'monospace',
+  fontWeight: FontWeight.w600,
+  letterSpacing: 0.3,
+  fontFeatures: const [FontFeature.tabularFigures()],
+);
+
+class _PositionText extends StatelessWidget {
+  const _PositionText({required this.player});
+  final Player player;
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<Duration>(
+      stream: player.stream.position,
+      initialData: player.state.position,
+      builder: (context, snapshot) => Text(
+        _fmt(snapshot.data ?? Duration.zero),
+        style: _timeStyle(Colors.white),
+      ),
+    );
+  }
+}
+
+/// Right-side timestamp counts DOWN — time remaining (e.g. "-45:32"), like
+/// Netflix.
+class _RemainingText extends StatelessWidget {
+  const _RemainingText({required this.player});
+  final Player player;
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<Duration>(
+      stream: player.stream.position,
+      initialData: player.state.position,
+      builder: (context, snapshot) {
+        final pos = snapshot.data ?? Duration.zero;
+        final dur = player.state.duration;
+        var remaining = dur - pos;
+        if (remaining < Duration.zero) remaining = Duration.zero;
+        return Text('-${_fmt(remaining)}', style: _timeStyle(Colors.white70));
+      },
+    );
+  }
+}

--- a/lib/modules/anime/widgets/tv_player_controls.dart
+++ b/lib/modules/anime/widgets/tv_player_controls.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -28,6 +29,8 @@ class TvPlayerControls extends StatefulWidget {
     required this.onNext,
     required this.qualityListenable,
     required this.buildQualityOptions,
+    required this.speedListenable,
+    required this.onSetSpeed,
   });
 
   final Player player;
@@ -43,6 +46,10 @@ class TvPlayerControls extends StatefulWidget {
   // dub/sub control here. Rebuilt when [qualityListenable] fires.
   final Listenable qualityListenable;
   final List<TvTrackOption> Function() buildQualityOptions;
+  // Playback speed: routed through the parent so its own speed notifier (used by
+  // the hold-to-2x gesture) stays in sync rather than calling setRate directly.
+  final ValueListenable<double> speedListenable;
+  final ValueChanged<double> onSetSpeed;
 
   @override
   State<TvPlayerControls> createState() => _TvPlayerControlsState();
@@ -53,6 +60,11 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
   Timer? _hideTimer;
   final FocusScopeNode _scope = FocusScopeNode(debugLabel: 'tvPlayer');
   final FocusNode _playFocus = FocusNode(debugLabel: 'tvPlayerPlayPause');
+  // Always in the tree, even while hidden (when the controls collapse to an
+  // empty box and leave no focusable node). Focus parks here on hide so a key
+  // press can still wake the panel — otherwise, on a keyboard, once it hides
+  // there's nothing focused to receive the wake key.
+  final FocusNode _rootFocus = FocusNode(debugLabel: 'tvPlayerRoot');
   static const _hideAfter = Duration(seconds: 4);
 
   @override
@@ -71,14 +83,24 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
     _hideTimer?.cancel();
     _scope.dispose();
     _playFocus.dispose();
+    _rootFocus.dispose();
     super.dispose();
   }
 
+  // True while the player is the topmost route. When a dialog (speed / settings)
+  // is open on top, the panel must not hide or touch focus — doing so steals
+  // focus out of the dialog and back to the play button behind it.
+  bool get _isTopRoute => ModalRoute.of(context)?.isCurrent ?? true;
+
   void _reveal() {
     if (!mounted) return;
-    if (!_visible) setState(() => _visible = true);
+    final wasHidden = !_visible;
+    if (wasHidden) setState(() => _visible = true);
+    // Always extend the hide timer (so a moving mouse keeps controls up), but
+    // only grab focus on the hidden→visible edge — otherwise a stream of mouse
+    // hover events would re-request focus every frame.
     _startHideTimer();
-    if (!_scope.hasFocus) {
+    if (wasHidden && !_scope.hasFocus && _isTopRoute) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         (_playFocus.canRequestFocus ? _playFocus : _scope).requestFocus();
@@ -88,9 +110,27 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
 
   void _startHideTimer() {
     _hideTimer?.cancel();
-    _hideTimer = Timer(_hideAfter, () {
-      if (mounted) setState(() => _visible = false);
-    });
+    _hideTimer = Timer(_hideAfter, _onHideTimer);
+  }
+
+  void _onHideTimer() {
+    if (!mounted) return;
+    // A dialog is open on top — keep the panel and don't touch focus; re-arm so
+    // it hides once the player is back on top.
+    if (!_isTopRoute) {
+      _startHideTimer();
+      return;
+    }
+    _hideNow();
+  }
+
+  // Hide the control panel and park focus on the root node so a key press can
+  // still wake it (Back also dismisses the panel before leaving the player).
+  void _hideNow() {
+    _hideTimer?.cancel();
+    if (!mounted || !_visible) return;
+    setState(() => _visible = false);
+    _rootFocus.requestFocus();
   }
 
   @override
@@ -102,8 +142,40 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
     final size = MediaQuery.of(context).size;
     final safeH = size.width * 0.08;
     final safeV = size.height * 0.05;
-    return FocusScope(
-      node: _scope,
+    // Back dismisses the visible control panel before it leaves the player:
+    // block the pop while the panel shows and hide it instead; a second Back
+    // (panel already hidden) exits normally. The on-screen back arrow still
+    // exits outright — it pops directly, bypassing this.
+    return PopScope(
+      canPop: !_visible,
+      onPopInvokedWithResult: (didPop, result) {
+        if (!didPop && _visible) _hideNow();
+      },
+      child: Focus(
+        focusNode: _rootFocus,
+        // While the panel is hidden this node holds focus; any d-pad / select
+        // key wakes the panel (and is consumed so it doesn't also act). While
+        // visible it defers to the focused control. Back is left alone so it
+        // still exits.
+        onKeyEvent: (node, event) {
+          if (_visible) return KeyEventResult.ignored;
+          if (event is KeyDownEvent || event is KeyRepeatEvent) {
+            final k = event.logicalKey;
+            final wake =
+                k == LogicalKeyboardKey.arrowUp ||
+                k == LogicalKeyboardKey.arrowDown ||
+                k == LogicalKeyboardKey.arrowLeft ||
+                k == LogicalKeyboardKey.arrowRight ||
+                _isSelect(k);
+            if (wake) {
+              _reveal();
+              return KeyEventResult.handled;
+            }
+          }
+          return KeyEventResult.ignored;
+        },
+        child: FocusScope(
+          node: _scope,
       // Only build the controls (and their per-frame StreamBuilders) while
       // visible. Otherwise the seek/time streams rebuild ~4x/sec during
       // playback and jank the Fire TV — hidden means nothing to render.
@@ -239,20 +311,24 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
                         ],
                       ],
                     ),
-                    const SizedBox(height: 14),
-                    // Quality | Subtitles | Audio pills (current one checked).
+                    const SizedBox(height: 4),
+                    // Quality | Subtitles | Speed | Settings pills.
                     _PillBar(
                       player: widget.player,
                       accent: accent,
                       qualityListenable: widget.qualityListenable,
                       buildQualityOptions: widget.buildQualityOptions,
                       onSettings: widget.onSettings,
+                      speedListenable: widget.speedListenable,
+                      onSetSpeed: widget.onSetSpeed,
                     ),
                   ],
                 ),
               ),
             ],
           ),
+        ),
+      ),
     );
   }
 }
@@ -379,6 +455,8 @@ class _PillBar extends StatelessWidget {
     required this.qualityListenable,
     required this.buildQualityOptions,
     required this.onSettings,
+    required this.speedListenable,
+    required this.onSetSpeed,
   });
 
   final Player player;
@@ -386,6 +464,8 @@ class _PillBar extends StatelessWidget {
   final Listenable qualityListenable;
   final List<TvTrackOption> Function() buildQualityOptions;
   final VoidCallback onSettings;
+  final ValueListenable<double> speedListenable;
+  final ValueChanged<double> onSetSpeed;
 
   @override
   Widget build(BuildContext context) {
@@ -455,9 +535,17 @@ class _PillBar extends StatelessWidget {
                   if (i > 0) children.add(const _PillDivider());
                   children.addAll(groups[i]);
                 }
-                // Gear pill at the end of the row (moved here from the top bar),
-                // sized to match the track pills.
+                // Speed group, then the gear, both sized to match the track
+                // pills.
                 if (children.isNotEmpty) children.add(const _PillDivider());
+                children.add(
+                  _SpeedPill(
+                    accent: accent,
+                    speedListenable: speedListenable,
+                    onSetSpeed: onSetSpeed,
+                  ),
+                );
+                children.add(const _PillDivider());
                 children.add(
                   _TrackPill(
                     accent: accent,
@@ -479,6 +567,196 @@ class _PillBar extends StatelessWidget {
           },
         );
       },
+    );
+  }
+}
+
+/// Playback-speed pill: shows the current rate, opens a d-pad-focusable list of
+/// presets. Highlighted (like a selected track) whenever it isn't 1×.
+class _SpeedPill extends StatelessWidget {
+  const _SpeedPill({
+    required this.accent,
+    required this.speedListenable,
+    required this.onSetSpeed,
+  });
+
+  final Color accent;
+  final ValueListenable<double> speedListenable;
+  final ValueChanged<double> onSetSpeed;
+
+  static const _presets = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+
+  static String _fmt(double r) {
+    final s = r == r.roundToDouble() ? r.toStringAsFixed(0) : r.toString();
+    return '$s×';
+  }
+
+  void _showMenu(BuildContext context, double current) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => _SpeedMenu(
+        accent: accent,
+        presets: _presets,
+        current: current,
+        onPick: onSetSpeed,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<double>(
+      valueListenable: speedListenable,
+      builder: (context, rate, _) => _TrackPill(
+        accent: accent,
+        icon: Icons.speed,
+        label: _fmt(rate),
+        selected: (rate - 1.0).abs() > 0.001,
+        onTap: () => _showMenu(context, rate),
+      ),
+    );
+  }
+}
+
+/// The playback-speed picker. Owns its focus containment: Up/Down move within
+/// the list and are *always* consumed (clamped at the ends), so d-pad focus
+/// can't escape past the edges to the controls behind the still-open dialog —
+/// which was letting the speed pill re-open a second dialog on top of this one.
+class _SpeedMenu extends StatefulWidget {
+  const _SpeedMenu({
+    required this.accent,
+    required this.presets,
+    required this.current,
+    required this.onPick,
+  });
+
+  final Color accent;
+  final List<double> presets;
+  final double current;
+  final ValueChanged<double> onPick;
+
+  @override
+  State<_SpeedMenu> createState() => _SpeedMenuState();
+}
+
+class _SpeedMenuState extends State<_SpeedMenu> {
+  late final List<FocusNode> _nodes = List.generate(
+    widget.presets.length,
+    (_) => FocusNode(),
+  );
+  late int _index;
+
+  @override
+  void initState() {
+    super.initState();
+    final sel = widget.presets.indexWhere(
+      (s) => (s - widget.current).abs() < 0.001,
+    );
+    _index = sel >= 0 ? sel : widget.presets.length ~/ 2;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _nodes[_index].requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    for (final n in _nodes) {
+      n.dispose();
+    }
+    super.dispose();
+  }
+
+  void _move(int delta) {
+    final next = (_index + delta).clamp(0, _nodes.length - 1);
+    if (next != _index) {
+      setState(() => _index = next);
+      _nodes[next].requestFocus();
+    }
+  }
+
+  void _pick(int i) {
+    widget.onPick(widget.presets[i]);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Playback speed'),
+      contentPadding: const EdgeInsets.symmetric(vertical: 8),
+      content: SizedBox(
+        width: 300,
+        child: FocusTraversalGroup(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (var i = 0; i < widget.presets.length; i++)
+                Focus(
+                  focusNode: _nodes[i],
+                  onKeyEvent: (node, event) {
+                    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+                      return KeyEventResult.ignored;
+                    }
+                    final k = event.logicalKey;
+                    if (k == LogicalKeyboardKey.arrowDown) {
+                      _move(1);
+                      return KeyEventResult.handled;
+                    }
+                    if (k == LogicalKeyboardKey.arrowUp) {
+                      _move(-1);
+                      return KeyEventResult.handled;
+                    }
+                    // Swallow Left/Right too, so neither can escape sideways.
+                    if (k == LogicalKeyboardKey.arrowLeft ||
+                        k == LogicalKeyboardKey.arrowRight) {
+                      return KeyEventResult.handled;
+                    }
+                    if (event is KeyDownEvent && _isSelect(k)) {
+                      _pick(i);
+                      return KeyEventResult.handled;
+                    }
+                    return KeyEventResult.ignored;
+                  },
+                  child: Padding(
+                    // Inset so the highlight is a rounded pill inside the
+                    // dialog — a full-bleed square looked broken on the last
+                    // row against the dialog's rounded corner.
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 2,
+                    ),
+                    child: InkWell(
+                      onTap: () => _pick(i),
+                      borderRadius: BorderRadius.circular(10),
+                      child: Ink(
+                        decoration: BoxDecoration(
+                          color: i == _index
+                              ? widget.accent.withValues(alpha: 0.18)
+                              : null,
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 12,
+                        ),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: Text(_SpeedPill._fmt(widget.presets[i])),
+                            ),
+                            if ((widget.presets[i] - widget.current).abs() <
+                                0.001)
+                              Icon(Icons.check, color: widget.accent),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }
@@ -706,7 +984,43 @@ class _TvSeekBar extends StatefulWidget {
 
 class _TvSeekBarState extends State<_TvSeekBar> {
   bool _focused = false;
-  static const _step = Duration(seconds: 10);
+
+  // Own a node when the parent doesn't supply one, so a mouse click can focus
+  // the bar (and hand keyboard seeking over to it) on desktop.
+  FocusNode? _ownNode;
+  FocusNode get _node => widget.focusNode ?? (_ownNode ??= FocusNode());
+
+  @override
+  void dispose() {
+    _ownNode?.dispose();
+    super.dispose();
+  }
+
+  // Hold-to-accelerate: a held arrow fires key repeats, and each consecutive
+  // repeat in the same direction grows the seek step, so a long hold covers
+  // ground fast while a single tap still nudges ±10s. Reset on release or when
+  // the direction flips.
+  static const _baseStep = 10; // seconds
+  static const _maxStep = 90;
+  int _holdCount = 0;
+  LogicalKeyboardKey? _holdDir;
+
+  Duration _stepFor(LogicalKeyboardKey dir) {
+    if (_holdDir != dir) {
+      _holdDir = dir;
+      _holdCount = 0;
+    } else {
+      _holdCount++;
+    }
+    // +10s per 3 repeats held: 10 → 20 → 30 … capped.
+    final secs = (_baseStep + (_holdCount ~/ 3) * 10).clamp(_baseStep, _maxStep);
+    return Duration(seconds: secs);
+  }
+
+  void _endHold() {
+    _holdDir = null;
+    _holdCount = 0;
+  }
 
   void _seek(Duration delta) {
     var target = widget.player.state.position + delta;
@@ -716,20 +1030,41 @@ class _TvSeekBarState extends State<_TvSeekBar> {
     widget.player.seek(target);
   }
 
+  // Mouse tap / drag on the bar seeks to that fraction of the duration.
+  void _seekToFraction(double frac) {
+    final dur = widget.player.state.duration;
+    if (dur <= Duration.zero) return;
+    if (!_node.hasFocus) _node.requestFocus();
+    widget.player.seek(dur * frac.clamp(0.0, 1.0));
+  }
+
   @override
   Widget build(BuildContext context) {
     return Focus(
-      focusNode: widget.focusNode,
-      onFocusChange: (f) => setState(() => _focused = f),
+      focusNode: _node,
+      onFocusChange: (f) {
+        setState(() => _focused = f);
+        if (!f) _endHold();
+      },
       onKeyEvent: (node, event) {
-        if (event is KeyDownEvent || event is KeyRepeatEvent) {
-          final k = event.logicalKey;
-          if (k == LogicalKeyboardKey.arrowLeft) {
-            _seek(-_step);
+        final k = event.logicalKey;
+        final isLeft = k == LogicalKeyboardKey.arrowLeft;
+        final isRight = k == LogicalKeyboardKey.arrowRight;
+        // Releasing an arrow ends the hold ramp.
+        if (event is KeyUpEvent) {
+          if (isLeft || isRight) {
+            _endHold();
             return KeyEventResult.handled;
           }
-          if (k == LogicalKeyboardKey.arrowRight) {
-            _seek(_step);
+          return KeyEventResult.ignored;
+        }
+        if (event is KeyDownEvent || event is KeyRepeatEvent) {
+          if (isLeft) {
+            _seek(-_stepFor(k));
+            return KeyEventResult.handled;
+          }
+          if (isRight) {
+            _seek(_stepFor(k));
             return KeyEventResult.handled;
           }
           // OK/Select toggles play/pause (Netflix model — no separate button).
@@ -759,7 +1094,14 @@ class _TvSeekBarState extends State<_TvSeekBar> {
               child: LayoutBuilder(
                 builder: (context, constraints) {
                   final w = constraints.maxWidth;
-                  return Stack(
+                  return GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTapDown: (d) => _seekToFraction(d.localPosition.dx / w),
+                    onHorizontalDragStart: (d) =>
+                        _seekToFraction(d.localPosition.dx / w),
+                    onHorizontalDragUpdate: (d) =>
+                        _seekToFraction(d.localPosition.dx / w),
+                    child: Stack(
                     children: [
                       // Track + progress, vertically centred.
                       Align(
@@ -801,6 +1143,7 @@ class _TvSeekBarState extends State<_TvSeekBar> {
                           ),
                         ),
                     ],
+                    ),
                   );
                 },
               ),

--- a/lib/modules/anime/widgets/tv_player_settings_panel.dart
+++ b/lib/modules/anime/widgets/tv_player_settings_panel.dart
@@ -26,6 +26,8 @@ class TvPlayerSettingsPanel extends ConsumerStatefulWidget {
     required this.qualityOptions,
     required this.subtitleOptions,
     required this.audioOptions,
+    required this.headerFocusNode,
+    required this.onExitLeft,
     required this.onClose,
   });
 
@@ -36,6 +38,12 @@ class TvPlayerSettingsPanel extends ConsumerStatefulWidget {
   final List<TvTrackOptionData> Function() qualityOptions;
   final List<TvTrackOptionData> Function() subtitleOptions;
   final List<TvTrackOptionData> Function() audioOptions;
+  // The header's focus node is owned by the player so it can be re-focused every
+  // time the panel opens (autofocus only fires once per scope).
+  final FocusNode headerFocusNode;
+  // Left out of the panel goes to the video — an explicit hand-off, because
+  // geometric directional focus across the split was losing focus entirely.
+  final VoidCallback onExitLeft;
   final VoidCallback onClose;
 
   @override
@@ -104,22 +112,36 @@ class _TvPlayerSettingsPanelState extends ConsumerState<TvPlayerSettingsPanel> {
       onPopInvokedWithResult: (didPop, _) {
         if (!didPop) _handleBack();
       },
-      child: FocusTraversalGroup(
-        child: Container(
-          width: width,
-          color: Theme.of(context).colorScheme.surface,
-          child: SafeArea(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _header(context),
-                const Divider(height: 1),
-                Expanded(
-                  child: _open == null
-                      ? _categoryList(context, accent)
-                      : _page(context, accent, _open!),
-                ),
-              ],
+      // Intercept Left before the default directional traversal (onKeyEvent
+      // runs ahead of Shortcuts/Actions) and hand focus to the video explicitly.
+      child: Focus(
+        canRequestFocus: false,
+        skipTraversal: true,
+        onKeyEvent: (node, event) {
+          if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+              event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+            widget.onExitLeft();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: FocusTraversalGroup(
+          child: Container(
+            width: width,
+            color: Theme.of(context).colorScheme.surface,
+            child: SafeArea(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _header(context),
+                  const Divider(height: 1),
+                  Expanded(
+                    child: _open == null
+                        ? _categoryList(context, accent)
+                        : _page(context, accent, _open!),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -134,7 +156,7 @@ class _TvPlayerSettingsPanelState extends ConsumerState<TvPlayerSettingsPanel> {
       child: Row(
         children: [
           IconButton(
-            autofocus: true,
+            focusNode: widget.headerFocusNode,
             onPressed: _handleBack,
             icon: Icon(_open == null ? Icons.close : Icons.arrow_back),
           ),
@@ -427,12 +449,17 @@ class TvVideoFocusFrame extends StatefulWidget {
     super.key,
     required this.accent,
     required this.player,
+    required this.focusNode,
     required this.onSelect,
+    required this.onExitRight,
     required this.child,
   });
   final Color accent;
   final Player player;
+  final FocusNode focusNode;
   final VoidCallback onSelect;
+  // Right off the video hands focus back into the settings panel.
+  final VoidCallback onExitRight;
   final Widget child;
 
   @override
@@ -445,8 +472,15 @@ class _TvVideoFocusFrameState extends State<TvVideoFocusFrame> {
   @override
   Widget build(BuildContext context) {
     return Focus(
+      focusNode: widget.focusNode,
       onFocusChange: (f) => setState(() => _focused = f),
       onKeyEvent: (node, event) {
+        if (event is KeyDownEvent || event is KeyRepeatEvent) {
+          if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+            widget.onExitRight();
+            return KeyEventResult.handled;
+          }
+        }
         if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
           widget.onSelect();
           return KeyEventResult.handled;

--- a/lib/modules/anime/widgets/tv_player_settings_panel.dart
+++ b/lib/modules/anime/widgets/tv_player_settings_panel.dart
@@ -11,6 +11,11 @@ import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 /// that category's page (Back returns). Surfaces the player's existing quality /
 /// subtitle / audio widgets plus speed, shaders, decoder and mpv stats — all
 /// d-pad-focusable.
+/// One selectable option in a track/quality list: its label, whether it's the
+/// current selection, and the action to switch to it (no route pop — the panel
+/// stays open).
+typedef TvTrackOptionData = ({String label, bool selected, VoidCallback onTap});
+
 class TvPlayerSettingsPanel extends ConsumerStatefulWidget {
   const TvPlayerSettingsPanel({
     super.key,
@@ -18,9 +23,9 @@ class TvPlayerSettingsPanel extends ConsumerStatefulWidget {
     required this.speedListenable,
     required this.onSetSpeed,
     required this.selectedShaderListenable,
-    required this.qualityWidget,
-    required this.subtitleWidget,
-    required this.audioWidget,
+    required this.qualityOptions,
+    required this.subtitleOptions,
+    required this.audioOptions,
     required this.onClose,
   });
 
@@ -28,9 +33,9 @@ class TvPlayerSettingsPanel extends ConsumerStatefulWidget {
   final ValueListenable<double> speedListenable;
   final ValueChanged<double> onSetSpeed;
   final ValueListenable<String> selectedShaderListenable;
-  final Widget qualityWidget;
-  final Widget subtitleWidget;
-  final Widget audioWidget;
+  final List<TvTrackOptionData> Function() qualityOptions;
+  final List<TvTrackOptionData> Function() subtitleOptions;
+  final List<TvTrackOptionData> Function() audioOptions;
   final VoidCallback onClose;
 
   @override
@@ -198,11 +203,11 @@ class _TvPlayerSettingsPanelState extends ConsumerState<TvPlayerSettingsPanel> {
           ),
         );
       case 'quality':
-        return SingleChildScrollView(child: widget.qualityWidget);
+        return _trackList(accent, widget.qualityOptions(), 'No other quality');
       case 'subtitles':
-        return SingleChildScrollView(child: widget.subtitleWidget);
+        return _trackList(accent, widget.subtitleOptions(), 'No subtitles');
       case 'audio':
-        return SingleChildScrollView(child: widget.audioWidget);
+        return _trackList(accent, widget.audioOptions(), 'No audio tracks');
       case 'shaders':
         return ValueListenableBuilder<String>(
           valueListenable: widget.selectedShaderListenable,
@@ -251,6 +256,28 @@ class _TvPlayerSettingsPanelState extends ConsumerState<TvPlayerSettingsPanel> {
       default:
         return const SizedBox.shrink();
     }
+  }
+
+  Widget _trackList(Color accent, List<TvTrackOptionData> options, String empty) {
+    if (options.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(empty, style: TextStyle(color: Theme.of(context).hintColor)),
+        ),
+      );
+    }
+    return ListView(
+      children: [
+        for (final o in options)
+          _OptionRow(
+            accent: accent,
+            label: o.label,
+            selected: o.selected,
+            onTap: o.onTap,
+          ),
+      ],
+    );
   }
 
   static String _fmtSpeed(double r) {

--- a/lib/modules/anime/widgets/tv_player_settings_panel.dart
+++ b/lib/modules/anime/widgets/tv_player_settings_panel.dart
@@ -93,7 +93,7 @@ class _TvPlayerSettingsPanelState extends ConsumerState<TvPlayerSettingsPanel> {
   Widget build(BuildContext context) {
     final accent = context.primaryColor;
     final size = MediaQuery.of(context).size;
-    final width = (size.width * 0.34).clamp(340.0, 460.0);
+    final width = (size.width * 0.26).clamp(300.0, 380.0);
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {
@@ -295,10 +295,12 @@ class _NavRowState extends State<_NavRow> {
       child: GestureDetector(
         onTap: widget.onTap,
         child: Container(
-          color: _focused
-              ? widget.accent.withValues(alpha: 0.18)
-              : Colors.transparent,
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 13),
+          decoration: BoxDecoration(
+            color: _focused ? widget.accent.withValues(alpha: 0.18) : null,
+            borderRadius: BorderRadius.circular(12),
+          ),
           child: Row(
             children: [
               Icon(widget.icon, size: 20, color: widget.accent),
@@ -352,10 +354,12 @@ class _OptionRowState extends State<_OptionRow> {
       child: GestureDetector(
         onTap: widget.onTap,
         child: Container(
-          color: _focused
-              ? widget.accent.withValues(alpha: 0.18)
-              : Colors.transparent,
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 13),
+          margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          decoration: BoxDecoration(
+            color: _focused ? widget.accent.withValues(alpha: 0.18) : null,
+            borderRadius: BorderRadius.circular(12),
+          ),
           child: Row(
             children: [
               Expanded(
@@ -389,15 +393,18 @@ bool _isSelect(LogicalKeyboardKey k) =>
 
 /// Wraps the docked video as a single focusable unit: a rounded accent ring
 /// when focused (reached by pressing Left out of the panel), and Select toggles
-/// play/pause so the video can be paused without leaving settings.
+/// play/pause. When focused it shows the current play/pause state in the centre
+/// so it's clear what Select will do (and that it changed).
 class TvVideoFocusFrame extends StatefulWidget {
   const TvVideoFocusFrame({
     super.key,
     required this.accent,
+    required this.player,
     required this.onSelect,
     required this.child,
   });
   final Color accent;
+  final Player player;
   final VoidCallback onSelect;
   final Widget child;
 
@@ -430,7 +437,36 @@ class _TvVideoFocusFrameState extends State<TvVideoFocusFrame> {
         ),
         child: ClipRRect(
           borderRadius: BorderRadius.circular(11),
-          child: widget.child,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              widget.child,
+              if (_focused)
+                Center(
+                  child: StreamBuilder<bool>(
+                    stream: widget.player.stream.playing,
+                    initialData: widget.player.state.playing,
+                    builder: (context, snap) {
+                      final playing = snap.data ?? true;
+                      return DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.5),
+                          shape: BoxShape.circle,
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.all(14),
+                          child: Icon(
+                            playing ? Icons.pause : Icons.play_arrow,
+                            color: Colors.white,
+                            size: 40,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/modules/anime/widgets/tv_player_settings_panel.dart
+++ b/lib/modules/anime/widgets/tv_player_settings_panel.dart
@@ -1,0 +1,438 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:mangayomi/modules/more/settings/player/providers/player_decoder_state_provider.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+
+/// The YouTube-style settings panel that docks on the right of the TV player.
+/// A navigable drill-down: a category list, and selecting one replaces it with
+/// that category's page (Back returns). Surfaces the player's existing quality /
+/// subtitle / audio widgets plus speed, shaders, decoder and mpv stats — all
+/// d-pad-focusable.
+class TvPlayerSettingsPanel extends ConsumerStatefulWidget {
+  const TvPlayerSettingsPanel({
+    super.key,
+    required this.player,
+    required this.speedListenable,
+    required this.onSetSpeed,
+    required this.selectedShaderListenable,
+    required this.qualityWidget,
+    required this.subtitleWidget,
+    required this.audioWidget,
+    required this.onClose,
+  });
+
+  final Player player;
+  final ValueListenable<double> speedListenable;
+  final ValueChanged<double> onSetSpeed;
+  final ValueListenable<String> selectedShaderListenable;
+  final Widget qualityWidget;
+  final Widget subtitleWidget;
+  final Widget audioWidget;
+  final VoidCallback onClose;
+
+  @override
+  ConsumerState<TvPlayerSettingsPanel> createState() =>
+      _TvPlayerSettingsPanelState();
+}
+
+class _TvPlayerSettingsPanelState extends ConsumerState<TvPlayerSettingsPanel> {
+  static const _speeds = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+  static const _shaders = [
+    ('Anime4K: Mode A (Fast)', 'set_anime_a'),
+    ('Anime4K: Mode B (Fast)', 'set_anime_b'),
+    ('Anime4K: Mode C (Fast)', 'set_anime_c'),
+    ('Anime4K: Mode A (HQ)', 'set_anime_hq_a'),
+    ('Anime4K: Mode B (HQ)', 'set_anime_hq_b'),
+    ('Anime4K: Mode C (HQ)', 'set_anime_hq_c'),
+    ('AMD FSR', 'set_fsr'),
+    ('Luma Upscaling', 'set_luma'),
+    ('Qualcomm Snapdragon GSR', 'set_snapdragon'),
+    ('NVIDIA Image Scaling', 'set_nvidia'),
+    ('Off (clear shaders)', 'clear_anime'),
+  ];
+  static const _decoders = [
+    ('auto', 'Auto (hardware)'),
+    ('auto-copy', 'Auto-copy'),
+    ('mediacodec', 'MediaCodec — HW (Android)'),
+    ('mediacodec-copy', 'MediaCodec — HW+ (Android)'),
+    ('videotoolbox', 'VideoToolbox (Apple)'),
+    ('videotoolbox-copy', 'VideoToolbox-copy (Apple)'),
+    ('d3d11va', 'D3D11VA (Windows)'),
+    ('nvdec', 'NVDEC (CUDA)'),
+    ('no', 'Software (no hardware)'),
+  ];
+  static const _stats = [
+    ('Toggle overlay', 'stats/display-stats-toggle'),
+    ('General', 'stats/display-page-1'),
+    ('Frame timings', 'stats/display-page-2'),
+    ('Input cache', 'stats/display-page-3'),
+    ('Active filters', 'stats/display-page-4'),
+    ('Log', 'stats/display-page-5'),
+  ];
+
+  // null = the category list; otherwise the open category's key.
+  String? _open;
+
+  NativePlayer get _native => widget.player.platform as NativePlayer;
+
+  void _drill(String key) => setState(() => _open = key);
+
+  bool _handleBack() {
+    if (_open != null) {
+      setState(() => _open = null);
+      return true;
+    }
+    widget.onClose();
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = context.primaryColor;
+    final size = MediaQuery.of(context).size;
+    final width = (size.width * 0.34).clamp(340.0, 460.0);
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) _handleBack();
+      },
+      child: FocusTraversalGroup(
+        child: Container(
+          width: width,
+          color: Theme.of(context).colorScheme.surface,
+          child: SafeArea(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _header(context),
+                const Divider(height: 1),
+                Expanded(
+                  child: _open == null
+                      ? _categoryList(context, accent)
+                      : _page(context, accent, _open!),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _header(BuildContext context) {
+    final title = _open == null ? 'Settings' : _titleFor(_open!);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(6, 8, 8, 4),
+      child: Row(
+        children: [
+          IconButton(
+            autofocus: true,
+            onPressed: _handleBack,
+            icon: Icon(_open == null ? Icons.close : Icons.arrow_back),
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              title,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _titleFor(String key) => switch (key) {
+    'playback' => 'Playback speed',
+    'quality' => 'Quality',
+    'subtitles' => 'Subtitles',
+    'audio' => 'Audio',
+    'shaders' => 'Shaders',
+    'decoder' => 'Decoder',
+    'stats' => 'Stats for nerds',
+    _ => 'Settings',
+  };
+
+  Widget _categoryList(BuildContext context, Color accent) {
+    final entries = <(String, IconData, String)>[
+      ('playback', Icons.speed, 'Playback speed'),
+      ('quality', Icons.high_quality_outlined, 'Quality'),
+      ('subtitles', Icons.subtitles_outlined, 'Subtitles'),
+      ('audio', Icons.audiotrack_outlined, 'Audio'),
+      ('shaders', Icons.auto_awesome_outlined, 'Shaders'),
+      ('decoder', Icons.memory_outlined, 'Decoder'),
+      ('stats', Icons.insights_outlined, 'Stats for nerds'),
+    ];
+    return ListView(
+      children: [
+        for (final e in entries)
+          _NavRow(
+            accent: accent,
+            icon: e.$2,
+            label: e.$3,
+            trailing: const Icon(Icons.chevron_right, size: 20),
+            onTap: () => _drill(e.$1),
+          ),
+      ],
+    );
+  }
+
+  Widget _page(BuildContext context, Color accent, String key) {
+    switch (key) {
+      case 'playback':
+        return ValueListenableBuilder<double>(
+          valueListenable: widget.speedListenable,
+          builder: (context, rate, _) => ListView(
+            children: [
+              for (final s in _speeds)
+                _OptionRow(
+                  accent: accent,
+                  label: _fmtSpeed(s),
+                  selected: (s - rate).abs() < 0.001,
+                  onTap: () => widget.onSetSpeed(s),
+                ),
+            ],
+          ),
+        );
+      case 'quality':
+        return SingleChildScrollView(child: widget.qualityWidget);
+      case 'subtitles':
+        return SingleChildScrollView(child: widget.subtitleWidget);
+      case 'audio':
+        return SingleChildScrollView(child: widget.audioWidget);
+      case 'shaders':
+        return ValueListenableBuilder<String>(
+          valueListenable: widget.selectedShaderListenable,
+          builder: (context, current, _) => ListView(
+            children: [
+              for (final sh in _shaders)
+                _OptionRow(
+                  accent: accent,
+                  label: sh.$1,
+                  selected: current == sh.$1,
+                  onTap: () =>
+                      _native.command(['script-message', sh.$2]),
+                ),
+            ],
+          ),
+        );
+      case 'decoder':
+        final currentHwdec = ref.watch(hwdecModeStateProvider());
+        return ListView(
+          children: [
+            for (final d in _decoders)
+              _OptionRow(
+                accent: accent,
+                label: d.$2,
+                selected: currentHwdec == d.$1,
+                onTap: () {
+                  ref.read(hwdecModeStateProvider().notifier).set(d.$1);
+                  // Live-switch mpv too, so it takes effect without a restart.
+                  _native.setProperty('hwdec', d.$1);
+                },
+              ),
+          ],
+        );
+      case 'stats':
+        return ListView(
+          children: [
+            for (final st in _stats)
+              _NavRow(
+                accent: accent,
+                icon: Icons.insights_outlined,
+                label: st.$1,
+                onTap: () => _native.command(['script-binding', st.$2]),
+              ),
+          ],
+        );
+      default:
+        return const SizedBox.shrink();
+    }
+  }
+
+  static String _fmtSpeed(double r) {
+    final s = r == r.roundToDouble() ? r.toStringAsFixed(0) : r.toString();
+    return '$s×';
+  }
+}
+
+/// A focusable navigation row (drills in or fires an action).
+class _NavRow extends StatefulWidget {
+  const _NavRow({
+    required this.accent,
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.trailing,
+  });
+  final Color accent;
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final Widget? trailing;
+
+  @override
+  State<_NavRow> createState() => _NavRowState();
+}
+
+class _NavRowState extends State<_NavRow> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
+          widget.onTap();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: Container(
+          color: _focused
+              ? widget.accent.withValues(alpha: 0.18)
+              : Colors.transparent,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          child: Row(
+            children: [
+              Icon(widget.icon, size: 20, color: widget.accent),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Text(
+                  widget.label,
+                  style: const TextStyle(fontSize: 15),
+                ),
+              ),
+              if (widget.trailing != null) widget.trailing!,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A focusable selectable option (a check marks the current one).
+class _OptionRow extends StatefulWidget {
+  const _OptionRow({
+    required this.accent,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+  final Color accent;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  State<_OptionRow> createState() => _OptionRowState();
+}
+
+class _OptionRowState extends State<_OptionRow> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
+          widget.onTap();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: Container(
+          color: _focused
+              ? widget.accent.withValues(alpha: 0.18)
+              : Colors.transparent,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 13),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  widget.label,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: widget.selected
+                        ? FontWeight.w700
+                        : FontWeight.normal,
+                    color: widget.selected ? widget.accent : null,
+                  ),
+                ),
+              ),
+              if (widget.selected)
+                Icon(Icons.check, size: 20, color: widget.accent),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+bool _isSelect(LogicalKeyboardKey k) =>
+    k == LogicalKeyboardKey.select ||
+    k == LogicalKeyboardKey.enter ||
+    k == LogicalKeyboardKey.numpadEnter ||
+    k == LogicalKeyboardKey.gameButtonA ||
+    k == LogicalKeyboardKey.space;
+
+/// Wraps the docked video as a single focusable unit: a rounded accent ring
+/// when focused (reached by pressing Left out of the panel), and Select toggles
+/// play/pause so the video can be paused without leaving settings.
+class TvVideoFocusFrame extends StatefulWidget {
+  const TvVideoFocusFrame({
+    super.key,
+    required this.accent,
+    required this.onSelect,
+    required this.child,
+  });
+  final Color accent;
+  final VoidCallback onSelect;
+  final Widget child;
+
+  @override
+  State<TvVideoFocusFrame> createState() => _TvVideoFocusFrameState();
+}
+
+class _TvVideoFocusFrameState extends State<TvVideoFocusFrame> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
+          widget.onSelect();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 130),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(
+            color: _focused ? widget.accent : Colors.transparent,
+            width: 3,
+          ),
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(11),
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/browse/browse_screen.dart
+++ b/lib/modules/browse/browse_screen.dart
@@ -10,6 +10,7 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/modules/browse/extension/extension_screen.dart';
 import 'package:mangayomi/modules/browse/sources/sources_screen.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/library/widgets/search_text_form_field.dart';
 import 'package:mangayomi/services/fetch_sources_list.dart';
 import 'package:mangayomi/utils/item_type_localization.dart';
@@ -33,22 +34,26 @@ class BrowseTab {
 class _BrowseScreenState extends ConsumerState<BrowseScreen>
     with TickerProviderStateMixin {
   late final hideItems = ref.read(hideItemsStateProvider);
+  // On the anime-only TV layout, hide manga & novel from Browse too (both
+  // sources and extensions) so only anime shows — matching the anime-only
+  // library. Defaults to isTv, user-overridable via the same provider. See #729.
+  late final _animeOnly = ref.read(animeOnlyTvModeProvider);
   final _textEditingController = TextEditingController();
   late TabController _tabBarController;
 
   late final List<BrowseTab> _tabList = [
-    if (!hideItems.contains("/MangaLibrary"))
+    if (!_animeOnly && !hideItems.contains("/MangaLibrary"))
       BrowseTab(ItemType.manga, BrowseTabKind.sources),
     if (!hideItems.contains("/AnimeLibrary"))
       BrowseTab(ItemType.anime, BrowseTabKind.sources),
-    if (!hideItems.contains("/NovelLibrary"))
+    if (!_animeOnly && !hideItems.contains("/NovelLibrary"))
       BrowseTab(ItemType.novel, BrowseTabKind.sources),
 
-    if (!hideItems.contains("/MangaLibrary"))
+    if (!_animeOnly && !hideItems.contains("/MangaLibrary"))
       BrowseTab(ItemType.manga, BrowseTabKind.extensions),
     if (!hideItems.contains("/AnimeLibrary"))
       BrowseTab(ItemType.anime, BrowseTabKind.extensions),
-    if (!hideItems.contains("/NovelLibrary"))
+    if (!_animeOnly && !hideItems.contains("/NovelLibrary"))
       BrowseTab(ItemType.novel, BrowseTabKind.extensions),
   ];
 
@@ -88,7 +93,7 @@ class _BrowseScreenState extends ConsumerState<BrowseScreen>
     final l10n = l10nLocalizations(context)!;
     return DefaultTabController(
       animationDuration: Duration.zero,
-      length: 6,
+      length: _tabList.length,
       child: Scaffold(
         appBar: AppBar(
           elevation: 0,

--- a/lib/modules/main_view/main_screen.dart
+++ b/lib/modules/main_view/main_screen.dart
@@ -18,6 +18,7 @@ import 'package:mangayomi/modules/more/settings/sync/providers/sync_providers.da
 import 'package:mangayomi/modules/widgets/loading_icon.dart';
 import 'package:mangayomi/services/fetch_item_sources.dart';
 import 'package:mangayomi/modules/main_view/providers/migration.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/about/providers/check_for_update.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/auto_backup.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -29,6 +30,11 @@ import 'package:mangayomi/modules/manga/detail/providers/state_providers.dart';
 import 'package:mangayomi/modules/more/providers/incognito_mode_state_provider.dart';
 
 final libLocationRegex = RegExp(r"^/(Manga|Anime|Novel)Library$");
+
+/// Nav destinations kept off the anime-only TV layout (the manga & novel
+/// libraries). True means "keep this destination".
+bool _isNotHiddenLibOnTv(String nav) =>
+    nav != "/MangaLibrary" && nav != "/NovelLibrary";
 
 class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({super.key, required this.child});
@@ -87,9 +93,12 @@ class _MainScreenState extends ConsumerState<MainScreen> {
         .autoSyncFrequency;
     final hiddenItems = ref.read(hideItemsStateProvider);
 
-    _defaultLocation = _navigationOrder
-        .where((e) => !hiddenItems.contains(e))
-        .first;
+    // On the anime-only TV layout, never land on a hidden manga/novel library.
+    final order = ref.read(animeOnlyTvModeProvider)
+        ? _navigationOrder.where(_isNotHiddenLibOnTv).toList()
+        : _navigationOrder;
+    final visible = order.where((e) => !hiddenItems.contains(e)).toList();
+    _defaultLocation = visible.isNotEmpty ? visible.first : "/AnimeLibrary";
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -209,6 +218,11 @@ class _MainScreenState extends ConsumerState<MainScreen> {
                   : navigationOrder
                         .where((nav) => !hideItems.contains(nav))
                         .toList();
+
+              // Anime-only TV layout: drop the manga & novel library tabs.
+              if (ref.watch(animeOnlyTvModeProvider)) {
+                dest = dest.where(_isNotHiddenLibOnTv).toList();
+              }
 
               if (mergeLibraryNavMobile && !context.isTablet && !isLibSwitch) {
                 dest = dest

--- a/lib/modules/main_view/providers/tv_mode_provider.dart
+++ b/lib/modules/main_view/providers/tv_mode_provider.dart
@@ -6,6 +6,7 @@ import 'package:mangayomi/utils/platform_utils.dart';
 /// A stored `bool` forces it on/off; absent means "auto" (follow [isTv]).
 const _boxName = 'tv_prefs';
 const _overrideKey = 'anime_only_override';
+const _playerStyleKey = 'tv_player_style';
 
 /// Opens the backing box. Called once at startup.
 Future<void> openTvPrefsBox() async {
@@ -37,6 +38,31 @@ class AnimeOnlyTvMode extends Notifier<bool> {
     state = value;
     if (Hive.isBoxOpen(_boxName)) {
       Hive.box(_boxName).put(_overrideKey, value);
+    }
+  }
+}
+
+/// Which controls to use for the anime player on TV: `true` = the dedicated
+/// Netflix-style TV player (default), `false` = the original desktop player.
+/// Only consulted when [isTv]; phones/desktops are unaffected.
+final tvPlayerStyleProvider = NotifierProvider<TvPlayerStyle, bool>(
+  TvPlayerStyle.new,
+);
+
+class TvPlayerStyle extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final v = Hive.box(_boxName).get(_playerStyleKey);
+      if (v is bool) return v;
+    }
+    return true; // default: TV player
+  }
+
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_playerStyleKey, value);
     }
   }
 }

--- a/lib/modules/main_view/providers/tv_mode_provider.dart
+++ b/lib/modules/main_view/providers/tv_mode_provider.dart
@@ -7,6 +7,7 @@ import 'package:mangayomi/utils/platform_utils.dart';
 const _boxName = 'tv_prefs';
 const _overrideKey = 'anime_only_override';
 const _playerStyleKey = 'tv_player_style';
+const _advancedSettingsKey = 'tv_advanced_settings';
 
 /// Opens the backing box. Called once at startup.
 Future<void> openTvPrefsBox() async {
@@ -63,6 +64,31 @@ class TvPlayerStyle extends Notifier<bool> {
     state = value;
     if (Hive.isBoxOpen(_boxName)) {
       Hive.box(_boxName).put(_playerStyleKey, value);
+    }
+  }
+}
+
+/// Whether the TV player opens its settings as a YouTube-style side panel (video
+/// docks left, an extensive settings panel slides in from the right) instead of
+/// the bottom-sheet menu. Off by default; only consulted on TV.
+final tvAdvancedSettingsProvider = NotifierProvider<TvAdvancedSettings, bool>(
+  TvAdvancedSettings.new,
+);
+
+class TvAdvancedSettings extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final v = Hive.box(_boxName).get(_advancedSettingsKey);
+      if (v is bool) return v;
+    }
+    return false;
+  }
+
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_advancedSettingsKey, value);
     }
   }
 }

--- a/lib/modules/main_view/providers/tv_mode_provider.dart
+++ b/lib/modules/main_view/providers/tv_mode_provider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
+
+/// Hive box + key for the user's explicit anime-only-layout override.
+/// A stored `bool` forces it on/off; absent means "auto" (follow [isTv]).
+const _boxName = 'tv_prefs';
+const _overrideKey = 'anime_only_override';
+
+/// Opens the backing box. Called once at startup.
+Future<void> openTvPrefsBox() async {
+  if (!Hive.isBoxOpen(_boxName)) {
+    await Hive.openBox(_boxName);
+  }
+}
+
+/// Whether to show the anime-only TV layout (manga + novel libraries hidden,
+/// anime-first). Defaults to [isTv] — i.e. on for Android TV, off everywhere
+/// else — and can be explicitly overridden by the user as an escape hatch, so
+/// a wrong detection can never strand someone with manga hidden.
+final animeOnlyTvModeProvider = NotifierProvider<AnimeOnlyTvMode, bool>(
+  AnimeOnlyTvMode.new,
+);
+
+class AnimeOnlyTvMode extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final override = Hive.box(_boxName).get(_overrideKey);
+      if (override is bool) return override;
+    }
+    return isTv;
+  }
+
+  /// Explicitly turns the anime-only layout on/off and persists the choice.
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_overrideKey, value);
+    }
+  }
+}

--- a/lib/modules/main_view/providers/tv_mode_provider.dart
+++ b/lib/modules/main_view/providers/tv_mode_provider.dart
@@ -7,7 +7,6 @@ import 'package:mangayomi/utils/platform_utils.dart';
 const _boxName = 'tv_prefs';
 const _overrideKey = 'anime_only_override';
 const _playerStyleKey = 'tv_player_style';
-const _advancedSettingsKey = 'tv_advanced_settings';
 
 /// Opens the backing box. Called once at startup.
 Future<void> openTvPrefsBox() async {
@@ -64,31 +63,6 @@ class TvPlayerStyle extends Notifier<bool> {
     state = value;
     if (Hive.isBoxOpen(_boxName)) {
       Hive.box(_boxName).put(_playerStyleKey, value);
-    }
-  }
-}
-
-/// Whether the TV player opens its settings as a YouTube-style side panel (video
-/// docks left, an extensive settings panel slides in from the right) instead of
-/// the bottom-sheet menu. Off by default; only consulted on TV.
-final tvAdvancedSettingsProvider = NotifierProvider<TvAdvancedSettings, bool>(
-  TvAdvancedSettings.new,
-);
-
-class TvAdvancedSettings extends Notifier<bool> {
-  @override
-  bool build() {
-    if (Hive.isBoxOpen(_boxName)) {
-      final v = Hive.box(_boxName).get(_advancedSettingsKey);
-      if (v is bool) return v;
-    }
-    return false;
-  }
-
-  void set(bool value) {
-    state = value;
-    if (Hive.isBoxOpen(_boxName)) {
-      Hive.box(_boxName).put(_advancedSettingsKey, value);
     }
   }
 }

--- a/lib/modules/more/settings/appearance/custom_navigation_settings.dart
+++ b/lib/modules/more/settings/appearance/custom_navigation_settings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/settings/appearance/appearance_screen.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -27,8 +28,18 @@ class _CustomNavigationSettingsState
         child: ReorderableListView.builder(
           header: Padding(
             padding: const EdgeInsets.symmetric(vertical: 10),
-            child: Stack(
+            child: Column(
               children: [
+                SwitchListTile(
+                  value: ref.watch(animeOnlyTvModeProvider),
+                  title: const Text('Anime-only TV layout'),
+                  subtitle: const Text(
+                    'Hide the manga & novel libraries (on by default on TV)',
+                  ),
+                  onChanged: (value) {
+                    ref.read(animeOnlyTvModeProvider.notifier).set(value);
+                  },
+                ),
                 SwitchListTile(
                   value: mergeLibraryNavMobile,
                   title: Text(context.l10n.merge_library_nav_mobile),

--- a/lib/modules/more/settings/player/player_overview_screen.dart
+++ b/lib/modules/more/settings/player/player_overview_screen.dart
@@ -35,23 +35,6 @@ class PlayerOverviewScreen extends StatelessWidget {
                   );
                 },
               ),
-            if (isTv)
-              Consumer(
-                builder: (context, ref, _) {
-                  final advanced = ref.watch(tvAdvancedSettingsProvider);
-                  return SwitchListTile(
-                    secondary: const Icon(Icons.tune),
-                    title: const Text('Advanced settings panel (beta)'),
-                    subtitle: const Text(
-                      'On: the gear docks the video left and opens an extensive '
-                      'settings panel on the right.  Off: the simple menu.',
-                    ),
-                    value: advanced,
-                    onChanged: (v) =>
-                        ref.read(tvAdvancedSettingsProvider.notifier).set(v),
-                  );
-                },
-              ),
             ListTileWidget(
               title: l10n.internal_player,
               subtitle: l10n.internal_player_info,

--- a/lib/modules/more/settings/player/player_overview_screen.dart
+++ b/lib/modules/more/settings/player/player_overview_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/widgets/list_tile_widget.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
 class PlayerOverviewScreen extends StatelessWidget {
   const PlayerOverviewScreen({super.key});
@@ -14,6 +17,24 @@ class PlayerOverviewScreen extends StatelessWidget {
       body: SingleChildScrollView(
         child: Column(
           children: [
+            // On TV, choose between the dedicated TV player and the original
+            // desktop player. Not shown on phones/desktops.
+            if (isTv)
+              Consumer(
+                builder: (context, ref, _) {
+                  final useTvPlayer = ref.watch(tvPlayerStyleProvider);
+                  return SwitchListTile(
+                    secondary: const Icon(Icons.smart_display_outlined),
+                    title: const Text('TV player (beta)'),
+                    subtitle: const Text(
+                      'On: dedicated TV player.  Off: original (desktop) player.',
+                    ),
+                    value: useTvPlayer,
+                    onChanged: (v) =>
+                        ref.read(tvPlayerStyleProvider.notifier).set(v),
+                  );
+                },
+              ),
             ListTileWidget(
               title: l10n.internal_player,
               subtitle: l10n.internal_player_info,

--- a/lib/modules/more/settings/player/player_overview_screen.dart
+++ b/lib/modules/more/settings/player/player_overview_screen.dart
@@ -35,6 +35,23 @@ class PlayerOverviewScreen extends StatelessWidget {
                   );
                 },
               ),
+            if (isTv)
+              Consumer(
+                builder: (context, ref, _) {
+                  final advanced = ref.watch(tvAdvancedSettingsProvider);
+                  return SwitchListTile(
+                    secondary: const Icon(Icons.tune),
+                    title: const Text('Advanced settings panel (beta)'),
+                    subtitle: const Text(
+                      'On: the gear docks the video left and opens an extensive '
+                      'settings panel on the right.  Off: the simple menu.',
+                    ),
+                    value: advanced,
+                    onChanged: (v) =>
+                        ref.read(tvAdvancedSettingsProvider.notifier).set(v),
+                  );
+                },
+              ),
             ListTileWidget(
               title: l10n.internal_player,
               subtitle: l10n.internal_player_info,

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 /// macOS, Linux or Windows
 final bool isDesktop =
@@ -9,3 +11,26 @@ final bool isMobile = Platform.isAndroid || Platform.isIOS;
 
 /// macOS or iOS
 final bool isApple = Platform.isMacOS || Platform.isIOS;
+
+/// Whether the app is running on an Android TV / leanback device.
+///
+/// Defaults to false and is hydrated once at startup by [initIsTv] (Android
+/// only); it stays false on every other platform. Nothing branches on this
+/// yet — it's the detection foundation for Android TV support (see #729).
+bool isTv = false;
+
+/// Asks the native side whether this is a TV / leanback device and caches the
+/// answer in [isTv]. No-op (and leaves [isTv] false) on non-Android platforms
+/// or if the channel isn't available. Safe to call once the engine is up.
+Future<void> initIsTv() async {
+  if (!Platform.isAndroid) return;
+  try {
+    const channel = MethodChannel('com.kodjodevf.mangayomi.device');
+    isTv = (await channel.invokeMethod<bool>('isTv')) ?? false;
+  } catch (_) {
+    isTv = false;
+  }
+  if (kDebugMode) {
+    debugPrint('[platform] isTv = $isTv');
+  }
+}


### PR DESCRIPTION
A purpose-built controls overlay for the anime player on **Android TV**, replacing the touch controls with a d-pad-first experience.

## What it does
- Big **play/pause + skip-next**; a seek bar with **position + counting-down remaining time**; **Quality | Subtitles** pills — Quality is the *source video list* (e.g. `1080-sub` / `1080-dub`), which is the real dub/sub control here; plus a **gear**, **autoplay toggle** and the title.
- Theme-accent focus on every control; d-pad seek (±10s) with **Up/Down to escape**; **OK / Select = play/pause**; overscan-safe margins.
- A **"TV player" vs original desktop player** choice in Player settings (`tvPlayerStyleProvider`); the desktop player now also **reveals its controls on a d-pad key**.

## Stacking
This is the top of the Android TV stack and depends on:
**#771** (isTv detection) · **#759** (autoplay) · **#768** (player remote shortcuts) · **#772** (anime-only layout + `tv_mode`) · **#784** (player orientation).

Until those merge, this PR's diff includes them; the redesign itself is the **top commit**. Once the foundation merges, it collapses to the player-only diff.

Part of #729. Verified on a physical Fire TV.
