### PR TITLE
feat(android-tv): make settings sliders usable with a d-pad (#729)

### DIFF
--- a/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
@@ -7,7 +7,11 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.embedding.android.FlutterFragmentActivity
 import androidx.core.content.FileProvider
+import android.app.UiModeManager
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.net.Uri
 import java.io.File
@@ -55,6 +59,33 @@ class MainActivity: FlutterFragmentActivity() {
                 }
             }
         }
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.kodjodevf.mangayomi.device",
+            StandardMethodCodec.INSTANCE
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "isTv" -> {
+                    result.success(isTvDevice())
+                }
+                else -> {
+                    result.notImplemented()
+                }
+            }
+        }
+    }
+
+    // Reports whether this is an Android TV / leanback device. Used by the
+    // Dart side to branch the UI on form factor (see #729). Kept conservative
+    // so a phone is never misdetected as a TV: a phone has neither the
+    // television UI mode nor the leanback feature.
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        if (uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true
+        }
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
     private fun installApk(filePath: String?) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -112,6 +112,9 @@ void main(List<String> args) async {
           );
         }
       }
+      // Detect Android TV once, before the UI builds, so form-factor branches
+      // can read `isTv`. No-op on other platforms. See #729.
+      await initIsTv();
       final storage = StorageProvider();
       await storage.requestPermission();
       Object? startupError;

--- a/lib/modules/more/data_and_storage/data_and_storage.dart
+++ b/lib/modules/more/data_and_storage/data_and_storage.dart
@@ -12,6 +12,8 @@ import 'package:mangayomi/modules/more/data_and_storage/providers/storage_usage.
 import 'package:mangayomi/modules/more/settings/downloads/providers/downloads_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/modules/widgets/tv_escapable_slider.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
 class DataAndStorage extends ConsumerWidget {
@@ -337,22 +339,31 @@ class DataAndStorage extends ConsumerWidget {
                       color: context.secondaryColor,
                     ),
                   ),
-                  Slider(
-                    min: 0,
-                    max: 9,
-                    divisions: 9,
-                    value: compression.toDouble(),
-                    label: compression.toString(),
-                    onChanged: (value) {
-                      ref
-                          .read(backupCompressionLevelProvider.notifier)
-                          .update(value.round());
-                    },
-                    onChangeEnd: (value) {
-                      ref
-                          .read(backupCompressionLevelProvider.notifier)
-                          .set(value.round());
-                    },
+                  TvEscapableSlider(
+                    enabled: isTv,
+                    onDecrease: () => ref
+                        .read(backupCompressionLevelProvider.notifier)
+                        .set((compression - 1).clamp(0, 9)),
+                    onIncrease: () => ref
+                        .read(backupCompressionLevelProvider.notifier)
+                        .set((compression + 1).clamp(0, 9)),
+                    child: Slider(
+                      min: 0,
+                      max: 9,
+                      divisions: 9,
+                      value: compression.toDouble(),
+                      label: compression.toString(),
+                      onChanged: (value) {
+                        ref
+                            .read(backupCompressionLevelProvider.notifier)
+                            .update(value.round());
+                      },
+                      onChangeEnd: (value) {
+                        ref
+                            .read(backupCompressionLevelProvider.notifier)
+                            .set(value.round());
+                      },
+                    ),
                   ),
                 ],
               ),

--- a/lib/modules/more/settings/appearance/widgets/blend_level_slider.dart
+++ b/lib/modules/more/settings/appearance/widgets/blend_level_slider.dart
@@ -2,7 +2,9 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/blend_level_state_provider.dart';
+import 'package:mangayomi/modules/widgets/tv_escapable_slider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
 class BlendLevelSlider extends ConsumerWidget {
   const BlendLevelSlider({super.key});
@@ -21,16 +23,25 @@ class BlendLevelSlider extends ConsumerWidget {
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
         ),
-        Slider(
-          min: 0.0,
-          max: 40.0,
-          divisions: max(39, 1),
-          value: blendLevel,
-          onChanged: (value) =>
-              ref.read(blendLevelStateProvider.notifier).setBlendLevel(value),
-          onChangeEnd: (value) => ref
+        TvEscapableSlider(
+          enabled: isTv,
+          onDecrease: () => ref
               .read(blendLevelStateProvider.notifier)
-              .setBlendLevel(value, end: true),
+              .setBlendLevel((blendLevel - 1).clamp(0.0, 40.0), end: true),
+          onIncrease: () => ref
+              .read(blendLevelStateProvider.notifier)
+              .setBlendLevel((blendLevel + 1).clamp(0.0, 40.0), end: true),
+          child: Slider(
+            min: 0.0,
+            max: 40.0,
+            divisions: max(39, 1),
+            value: blendLevel,
+            onChanged: (value) =>
+                ref.read(blendLevelStateProvider.notifier).setBlendLevel(value),
+            onChangeEnd: (value) => ref
+                .read(blendLevelStateProvider.notifier)
+                .setBlendLevel(value, end: true),
+          ),
         ),
       ],
     );

--- a/lib/modules/widgets/tv_escapable_slider.dart
+++ b/lib/modules/widgets/tv_escapable_slider.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Makes a Material [Slider] usable with a TV remote.
+///
+/// A Material Slider grabs *all four* arrow keys to change its value, so on a
+/// d-pad you can focus it but never move away — it's a trap. This wrapper owns
+/// the focus instead: Left/Right adjust the value (via [onDecrease]/[onIncrease])
+/// and Up/Down/Select fall through so focus can leave. The inner slider is
+/// excluded from focus so it can't swallow the keys. Off-TV ([enabled] false)
+/// it's a transparent pass-through, keeping normal touch/mouse behaviour.
+class TvEscapableSlider extends StatelessWidget {
+  const TvEscapableSlider({
+    super.key,
+    required this.child,
+    required this.onDecrease,
+    required this.onIncrease,
+    required this.enabled,
+  });
+
+  final Widget child;
+  final VoidCallback onDecrease;
+  final VoidCallback onIncrease;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!enabled) return child;
+    return Focus(
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent || event is KeyRepeatEvent) {
+          final k = event.logicalKey;
+          if (k == LogicalKeyboardKey.arrowLeft) {
+            onDecrease();
+            return KeyEventResult.handled;
+          }
+          if (k == LogicalKeyboardKey.arrowRight) {
+            onIncrease();
+            return KeyEventResult.handled;
+          }
+        }
+        // Up / Down / Select fall through so focus can leave the slider.
+        return KeyEventResult.ignored;
+      },
+      child: ExcludeFocus(child: child),
+    );
+  }
+}

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 /// macOS, Linux or Windows
 final bool isDesktop =
@@ -9,3 +11,26 @@ final bool isMobile = Platform.isAndroid || Platform.isIOS;
 
 /// macOS or iOS
 final bool isApple = Platform.isMacOS || Platform.isIOS;
+
+/// Whether the app is running on an Android TV / leanback device.
+///
+/// Defaults to false and is hydrated once at startup by [initIsTv] (Android
+/// only); it stays false on every other platform. Nothing branches on this
+/// yet — it's the detection foundation for Android TV support (see #729).
+bool isTv = false;
+
+/// Asks the native side whether this is a TV / leanback device and caches the
+/// answer in [isTv]. No-op (and leaves [isTv] false) on non-Android platforms
+/// or if the channel isn't available. Safe to call once the engine is up.
+Future<void> initIsTv() async {
+  if (!Platform.isAndroid) return;
+  try {
+    const channel = MethodChannel('com.kodjodevf.mangayomi.device');
+    isTv = (await channel.invokeMethod<bool>('isTv')) ?? false;
+  } catch (_) {
+    isTv = false;
+  }
+  if (kDebugMode) {
+    debugPrint('[platform] isTv = $isTv');
+  }
+}


### PR DESCRIPTION
A Material `Slider` grabs **all four** arrow keys to change its value, so on a TV remote you can focus it but never move away — it's a trap. This adds a small reusable wrapper and applies it where sliders live in settings.

## Changes
- **`TvEscapableSlider`** — Left/Right adjust the value (via `onDecrease`/`onIncrease`), Up/Down and Select fall through so focus can leave; the inner slider is excluded from focus so it can't swallow the keys. Off-TV it's a transparent pass-through (normal touch/mouse behaviour).
- Applied to the **appearance blend-level** and **backup-compression** sliders.

Only the anime-only-reachable settings sliders are covered here; more can adopt the same wrapper later.

Stacks on **#771** (isTv detection). Part of #729. Verified on a physical Fire TV.
