### PR TITLE
feat(android-tv): d-pad-navigable library grid (#729)

### DIFF
--- a/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
@@ -7,7 +7,11 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.embedding.android.FlutterFragmentActivity
 import androidx.core.content.FileProvider
+import android.app.UiModeManager
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.net.Uri
 import java.io.File
@@ -55,6 +59,33 @@ class MainActivity: FlutterFragmentActivity() {
                 }
             }
         }
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.kodjodevf.mangayomi.device",
+            StandardMethodCodec.INSTANCE
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "isTv" -> {
+                    result.success(isTvDevice())
+                }
+                else -> {
+                    result.notImplemented()
+                }
+            }
+        }
+    }
+
+    // Reports whether this is an Android TV / leanback device. Used by the
+    // Dart side to branch the UI on form factor (see #729). Kept conservative
+    // so a phone is never misdetected as a TV: a phone has neither the
+    // television UI mode nor the leanback feature.
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        if (uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true
+        }
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
     private fun installApk(filePath: String?) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -112,6 +112,9 @@ void main(List<String> args) async {
           );
         }
       }
+      // Detect Android TV once, before the UI builds, so form-factor branches
+      // can read `isTv`. No-op on other platforms. See #729.
+      await initIsTv();
       final storage = StorageProvider();
       await storage.requestPermission();
       Object? startupError;

--- a/lib/modules/library/library_screen.dart
+++ b/lib/modules/library/library_screen.dart
@@ -366,27 +366,36 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
               setState(() => _ignoreFiltersOnSearch = val),
           vsync: this,
         ),
-        body: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildCategoryTabs(
-              entr: entr,
-              withoutCategory: withoutCategory,
-              showNumbersOfItems: showNumbersOfItems,
-              badgeForCategory: badgeForCategory,
-            ),
-            Flexible(
-              child: TabBarView(
-                controller: tabBarController,
-                children: _buildCategoryBodies(
-                  entr: entr,
-                  withoutCategory: withoutCategory,
-                  bodyForCategory: bodyForCategory,
-                ),
+        // A single category doesn't need the tab bar + TabBarView. The
+        // TabBarView (a PageView) blocks directional d-pad focus from crossing
+        // into/out of the grid — which is why the anime tab couldn't reach the
+        // grid while Browse (a direct grid) works. So for one category, render
+        // the grid directly like Browse; keep the tabs only for 2+ categories.
+        body: tabCount <= 1
+            ? (withoutCategory.isEmpty && entr.isNotEmpty
+                  ? bodyForCategory(categoryId: entr.first.id!)
+                  : bodyForCategory())
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildCategoryTabs(
+                    entr: entr,
+                    withoutCategory: withoutCategory,
+                    showNumbersOfItems: showNumbersOfItems,
+                    badgeForCategory: badgeForCategory,
+                  ),
+                  Flexible(
+                    child: TabBarView(
+                      controller: tabBarController,
+                      children: _buildCategoryBodies(
+                        entr: entr,
+                        withoutCategory: withoutCategory,
+                        bodyForCategory: bodyForCategory,
+                      ),
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -5,6 +5,7 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/library/widgets/continue_reader_button.dart';
 import 'package:mangayomi/modules/manga/detail/providers/state_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/modules/library/widgets/library_entry_utils.dart';
 import 'package:mangayomi/modules/widgets/bottom_text_widget.dart';
 import 'package:mangayomi/modules/widgets/cover_view_widget.dart';
@@ -16,6 +17,7 @@ class LibraryGridViewWidget extends StatefulWidget {
   final Set<int> mangaIdsList;
   final List<Manga> entriesManga;
   final bool language;
+  final bool sourceBadge;
   final bool downloadedChapter;
   final bool continueReaderBtn;
   final bool localSource;
@@ -26,6 +28,7 @@ class LibraryGridViewWidget extends StatefulWidget {
     required this.isCoverOnlyGrid,
     this.isComfortableGrid = false,
     required this.language,
+    this.sourceBadge = false,
     required this.downloadedChapter,
     required this.continueReaderBtn,
     required this.mangaIdsList,
@@ -57,6 +60,9 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
             return Padding(
               padding: const EdgeInsets.all(2),
               child: CoverViewWidget(
+                // On TV, make the first cover the content's focus target so the
+                // d-pad reliably lands on the grid (not the app bar).
+                autofocus: isTv && index == 0,
                 isLongPressed: widget.mangaIdsList.contains(entry.id),
                 isComfortableGrid: widget.isComfortableGrid,
                 bottomTextWidget: BottomTextWidget(
@@ -122,7 +128,7 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                       ),
 
                       // ── Top-right: Language ──
-                      if (widget.language && entry.lang!.isNotEmpty)
+                      if (widget.language && (entry.lang?.isNotEmpty ?? false))
                         Positioned(
                           top: 0,
                           right: 0,
@@ -153,6 +159,35 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                       child: Padding(
                         padding: const EdgeInsets.all(9),
                         child: ContinueReaderButton(entry: entry),
+                      ),
+                    ),
+
+                  // ── Bottom-left: Source ──
+                  if (widget.sourceBadge && (entry.source ?? '').isNotEmpty)
+                    Positioned(
+                      bottom: 0,
+                      left: 0,
+                      child: Padding(
+                        padding: const EdgeInsets.all(5),
+                        child: Container(
+                          constraints: const BoxConstraints(maxWidth: 96),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 4,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: context.themeData.cardColor,
+                            borderRadius: const BorderRadius.only(
+                              topRight: Radius.circular(3),
+                            ),
+                          ),
+                          child: Text(
+                            entry.source!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(fontSize: 10),
+                          ),
+                        ),
                       ),
                     ),
                 ],

--- a/lib/modules/widgets/cover_view_widget.dart
+++ b/lib/modules/widgets/cover_view_widget.dart
@@ -10,6 +10,9 @@ class CoverViewWidget extends StatefulWidget {
   final VoidCallback onTap;
   final VoidCallback? onLongPress;
   final VoidCallback? onSecondaryTap;
+  // On TV, the first cover autofocuses so the grid becomes the content scope's
+  // focus target (otherwise d-pad focus never reaches it).
+  final bool autofocus;
   const CoverViewWidget({
     super.key,
     required this.children,
@@ -20,6 +23,7 @@ class CoverViewWidget extends StatefulWidget {
     this.onLongPress,
     this.isLongPressed,
     this.onSecondaryTap,
+    this.autofocus = false,
   });
 
   @override
@@ -90,6 +94,7 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
                 color: Colors.transparent,
                 clipBehavior: Clip.antiAlias,
                 child: InkWell(
+                  autofocus: widget.autofocus,
                   onTap: widget.onTap,
                   onLongPress: widget.onLongPress,
                   onSecondaryTap: widget.onSecondaryTap,

--- a/lib/modules/widgets/cover_view_widget.dart
+++ b/lib/modules/widgets/cover_view_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 
-class CoverViewWidget extends StatelessWidget {
+class CoverViewWidget extends StatefulWidget {
   final List<Widget> children;
   final bool? isLongPressed;
   final ImageProvider? image;
@@ -23,38 +23,74 @@ class CoverViewWidget extends StatelessWidget {
   });
 
   @override
+  State<CoverViewWidget> createState() => _CoverViewWidgetState();
+}
+
+class _CoverViewWidgetState extends State<CoverViewWidget> {
+  // Whether the card should draw a focus ring. Only set when focus arrives via
+  // keyboard / d-pad navigation (FocusHighlightMode.traditional), so touch
+  // input on phones/tablets never shows a ring. Gives d-pad/remote users on
+  // Android TV — and keyboard users anywhere — a clearly visible focus target.
+  bool _focused = false;
+
+  void _onFocusChange(bool hasFocus) {
+    final show =
+        hasFocus &&
+        FocusManager.instance.highlightMode == FocusHighlightMode.traditional;
+    if (mounted && show != _focused) {
+      setState(() => _focused = show);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(5),
       child: Column(
         children: [
           Expanded(
-            child: Material(
-              borderRadius: BorderRadius.circular(5),
-              color: Colors.transparent,
-              clipBehavior: Clip.antiAlias,
-              child: InkWell(
-                onTap: onTap,
-                onLongPress: onLongPress,
-                onSecondaryTap: onSecondaryTap,
-                child: Container(
-                  color: isLongPressed != null && isLongPressed!
-                      ? context.primaryColor.withValues(alpha: 0.4)
-                      : Colors.transparent,
-                  child: image == null
-                      ? isComfortableGrid
-                            ? Column(children: [...children, bottomTextWidget!])
-                            : Stack(children: children)
-                      : Ink.image(
-                          fit: BoxFit.cover,
-                          image: image!,
-                          child: Stack(children: children),
-                        ),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 120),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(7),
+                border: Border.all(
+                  color: _focused ? context.primaryColor : Colors.transparent,
+                  width: 3,
+                ),
+              ),
+              child: Material(
+                borderRadius: BorderRadius.circular(5),
+                color: Colors.transparent,
+                clipBehavior: Clip.antiAlias,
+                child: InkWell(
+                  onTap: widget.onTap,
+                  onLongPress: widget.onLongPress,
+                  onSecondaryTap: widget.onSecondaryTap,
+                  onFocusChange: _onFocusChange,
+                  child: Container(
+                    color: widget.isLongPressed != null && widget.isLongPressed!
+                        ? context.primaryColor.withValues(alpha: 0.4)
+                        : Colors.transparent,
+                    child: widget.image == null
+                        ? widget.isComfortableGrid
+                              ? Column(
+                                  children: [
+                                    ...widget.children,
+                                    widget.bottomTextWidget!,
+                                  ],
+                                )
+                              : Stack(children: widget.children)
+                        : Ink.image(
+                            fit: BoxFit.cover,
+                            image: widget.image!,
+                            child: Stack(children: widget.children),
+                          ),
+                  ),
                 ),
               ),
             ),
           ),
-          if (isComfortableGrid) bottomTextWidget!,
+          if (widget.isComfortableGrid) widget.bottomTextWidget!,
         ],
       ),
     );

--- a/lib/modules/widgets/cover_view_widget.dart
+++ b/lib/modules/widgets/cover_view_widget.dart
@@ -33,6 +33,27 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
   // Android TV — and keyboard users anywhere — a clearly visible focus target.
   bool _focused = false;
 
+  @override
+  void initState() {
+    super.initState();
+    // Track highlight-mode changes so the ring is dropped immediately if the
+    // user switches to touch input while a card is focused (it must never show
+    // for touch), not only when focus is lost.
+    FocusManager.instance.addHighlightModeListener(_onHighlightModeChanged);
+  }
+
+  @override
+  void dispose() {
+    FocusManager.instance.removeHighlightModeListener(_onHighlightModeChanged);
+    super.dispose();
+  }
+
+  void _onHighlightModeChanged(FocusHighlightMode mode) {
+    if (mode != FocusHighlightMode.traditional && _focused) {
+      setState(() => _focused = false);
+    }
+  }
+
   void _onFocusChange(bool hasFocus) {
     final show =
         hasFocus &&
@@ -44,6 +65,10 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
 
   @override
   Widget build(BuildContext context) {
+    // Comfortable grid renders the label below the card, so it must not also be
+    // placed inside the card. Render it once, and only when provided.
+    final showBottomText =
+        widget.isComfortableGrid && widget.bottomTextWidget != null;
     return Padding(
       padding: const EdgeInsets.all(5),
       child: Column(
@@ -52,7 +77,9 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 120),
               decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(7),
+                // Outer radius = inner clip radius (5) + border width (3) so the
+                // ring's corners stay concentric with the card and don't clip.
+                borderRadius: BorderRadius.circular(8),
                 border: Border.all(
                   color: _focused ? context.primaryColor : Colors.transparent,
                   width: 3,
@@ -73,12 +100,9 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
                         : Colors.transparent,
                     child: widget.image == null
                         ? widget.isComfortableGrid
-                              ? Column(
-                                  children: [
-                                    ...widget.children,
-                                    widget.bottomTextWidget!,
-                                  ],
-                                )
+                              // bottomTextWidget is rendered once below the card,
+                              // so it's not duplicated inside here anymore.
+                              ? Column(children: widget.children)
                               : Stack(children: widget.children)
                         : Ink.image(
                             fit: BoxFit.cover,
@@ -90,7 +114,7 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
               ),
             ),
           ),
-          if (widget.isComfortableGrid) widget.bottomTextWidget!,
+          if (showBottomText) widget.bottomTextWidget!,
         ],
       ),
     );

--- a/lib/modules/widgets/gridview_widget.dart
+++ b/lib/modules/widgets/gridview_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
 class GridViewWidget extends StatelessWidget {
   final ScrollController? controller;
@@ -27,7 +28,9 @@ class GridViewWidget extends StatelessWidget {
         gridDelegate: (gridSize == null || gridSize == 0)
             ? SliverGridDelegateWithMaxCrossAxisExtent(
                 childAspectRatio: childAspectRatio!,
-                maxCrossAxisExtent: 220,
+                // Denser default on TV — from across a room 220px covers show
+                // only ~4 huge tiles; 150 gives more, smaller covers.
+                maxCrossAxisExtent: isTv ? 150 : 220,
               )
             : SliverGridDelegateWithFixedCrossAxisCount(
                 crossAxisCount: gridSize!,

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 /// macOS, Linux or Windows
 final bool isDesktop =
@@ -9,3 +11,26 @@ final bool isMobile = Platform.isAndroid || Platform.isIOS;
 
 /// macOS or iOS
 final bool isApple = Platform.isMacOS || Platform.isIOS;
+
+/// Whether the app is running on an Android TV / leanback device.
+///
+/// Defaults to false and is hydrated once at startup by [initIsTv] (Android
+/// only); it stays false on every other platform. Nothing branches on this
+/// yet — it's the detection foundation for Android TV support (see #729).
+bool isTv = false;
+
+/// Asks the native side whether this is a TV / leanback device and caches the
+/// answer in [isTv]. No-op (and leaves [isTv] false) on non-Android platforms
+/// or if the channel isn't available. Safe to call once the engine is up.
+Future<void> initIsTv() async {
+  if (!Platform.isAndroid) return;
+  try {
+    const channel = MethodChannel('com.kodjodevf.mangayomi.device');
+    isTv = (await channel.invokeMethod<bool>('isTv')) ?? false;
+  } catch (_) {
+    isTv = false;
+  }
+  if (kDebugMode) {
+    debugPrint('[platform] isTv = $isTv');
+  }
+}


### PR DESCRIPTION
Makes the library grid reachable and navigable with a TV remote's d-pad.

## Changes
- **Single-category direct render** — when there's one category (the common case), render the grid directly instead of wrapping it in a category `TabBar` + `TabBarView`. A `TabBarView` is a `PageView`, and directional d-pad focus can't reliably cross into/out of it, so the grid was stranded while a *direct* grid (like the Browse screen) works fine. Tabs are kept for 2+ categories. (Also a small simplification for everyone.)
- **Autofocus the first cover on TV** so the grid becomes the content scope's focus target and the d-pad reliably lands on it (instead of a top app-bar action).
- **Denser default grid on TV** — auto tile extent 220→150; from across a room 220px covers show only ~4 huge tiles.

Stacks on **#769** (cover focus ring) + **#771** (isTv). Part of #729. Verified on a physical Fire TV.
