### PR TITLE
fix(downloads): fail loudly instead of hanging when a download can't start

### DIFF
--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -86,6 +86,9 @@ Future<void> downloadChapter(
     );
     List<Track>? subtitles;
     bool isOk = false;
+    // Reason the download couldn't be prepared, if any — used to fail loudly
+    // instead of hanging in the wait-loop below.
+    String? startFailure;
     final manga = chapter.manga.value!;
     final chapterName = chapter.name!.replaceForbiddenCharacters(' ');
     final itemType = chapter.manga.value!.itemType;
@@ -211,7 +214,11 @@ Future<void> downloadChapter(
         if (value.pageUrls.isNotEmpty) {
           pageUrls = value.pageUrls;
           isOk = true;
+        } else {
+          startFailure = "No pages returned by the source";
         }
+      }).catchError((Object e) {
+        startFailure = "Failed to load chapter pages: $e";
       });
     } else if (itemType == ItemType.anime) {
       ref.read(getVideoListProvider(episode: chapter).future).then((
@@ -246,7 +253,16 @@ Future<void> downloadChapter(
           }
           videoHeader.addAll(videosUrls.first.headers ?? {});
           isOk = true;
+        } else {
+          // Got a video list but nothing matched .m3u8/.m3u or a known video
+          // extension — record why instead of spinning forever below.
+          startFailure = value.$1.isEmpty
+              ? "No videos returned by the source"
+              : "No downloadable URL among ${value.$1.length} video(s) "
+                    "(none matched .m3u8/.m3u or a known extension)";
         }
+      }).catchError((Object e) {
+        startFailure = "Failed to load the video list: $e";
       });
     } else if (itemType == ItemType.novel && chapter.url != null) {
       final manga = chapter.manga.value!;
@@ -268,13 +284,28 @@ Future<void> downloadChapter(
       isOk = true;
     }
 
+    // Wait for the source to resolve pages/video — but never forever. Bail on
+    // a recorded failure or after a timeout so a bad/unmatched URL surfaces an
+    // error instead of a silent, endless stall.
+    final startDeadline = DateTime.now().add(const Duration(seconds: 45));
     await Future.doWhile(() async {
       await Future.delayed(const Duration(seconds: 1));
-      if (isOk == true) {
+      if (isOk == true || startFailure != null) {
+        return false;
+      }
+      if (DateTime.now().isAfter(startDeadline)) {
+        startFailure = "Timed out preparing the download";
         return false;
       }
       return true;
     });
+
+    if (!isOk) {
+      botToast(startFailure ?? "Couldn't start the download");
+      if (callback != null) callback();
+      keepAlive.close();
+      return;
+    }
 
     if (pageUrls.isNotEmpty) {
       bool cbzFileExist =
@@ -399,7 +430,11 @@ Future<void> downloadChapter(
       callback();
     }
     keepAlive.close();
-  } catch (_) {
+  } catch (e) {
+    // Surface the failure instead of swallowing it — a silent catch here is
+    // exactly how "downloads just don't start" stays invisible.
+    botToast("Download failed to start: $e");
+    if (callback != null) callback();
     keepAlive.close();
   }
 }


### PR DESCRIPTION
## Problem
When an anime download can't start, it hangs **forever with no feedback**. The start path waits for the source to resolve a video like this:

```dart
ref.read(getVideoListProvider(...).future).then((value) { ... isOk = true; });  // no .catchError
await Future.doWhile(() async {
  await Future.delayed(const Duration(seconds: 1));
  return isOk != true;   // no timeout — spins forever
});
```

So if `getVideoList` **throws**, or every returned URL matches **neither** `.m3u8`/`.m3u` **nor** `isMediaVideo()`, `isOk` never flips and the loop spins indefinitely. Playback doesn't use that filter, so streaming works while the download silently stalls — and each new source quirk reappears as the same mysterious "downloads won't start" (e.g. #724 fixed two specific triggers, but the fragile pattern lets the next one recur identically). The outer `catch (_) {}` swallows the rest.

## Fix
Make the start path fail **loudly with a reason** instead of hanging:
- Record a `startFailure` reason on every non-start path — `getVideoList`/`getChapterPages` throwing (`.catchError`), an empty video list, or **URLs that match no known pattern** (with the count, so it's diagnosable).
- Give the wait-loop a **45s deadline** and exit on `startFailure`, so it can never spin forever.
- **Surface** the reason via toast and stop the outer `catch` from silently swallowing errors.

No behaviour change on the success path (incl. m3u8). Manga/novel get the same guard since they share the loop.
