### PR TITLE
fix: preserve WebView script payloads for extensions

### DIFF
--- a/lib/eval/dart/bridge/m_provider.dart
+++ b/lib/eval/dart/bridge/m_provider.dart
@@ -354,9 +354,10 @@ class MProviderBridged {
           .then((res) {
             if (res.statusCode == 200) {
               final data = jsonDecode(res.body) as Map<String, dynamic>;
-              return data['result'] as bool;
+              // Preserve payloads returned by extension WebView scripts.
+              return data['result'];
             }
-            return false;
+            return null;
           }),
     );
     interpreter.registertopLevelFunction('print', (

--- a/lib/eval/javascript/utils.dart
+++ b/lib/eval/javascript/utils.dart
@@ -66,9 +66,11 @@ class JsUtils {
           .then((res) {
             if (res.statusCode == 200) {
               final data = jsonDecode(res.body) as Map<String, dynamic>;
-              return data['result'] as bool;
+              // Extension scripts use this bridge to return extracted values,
+              // not only Cloudflare challenge status.
+              return data['result'];
             }
-            return false;
+            return null;
           });
     });
     runtime.onMessage('parseEpub', (dynamic args) async {


### PR DESCRIPTION
## Summary\nPreserves the result returned by evaluateJavascriptViaWebview instead of forcing it to a boolean.\n\n## Motivation\nJavaScript extensions can use the helper to run a page in a headless WebView, but the current bridge discards all non-boolean script results. Returning the payload enables sources to consume values such as rendered image URLs while retaining 
ull for failed calls.\n\n## Validation\n- git diff --check\n- Existing extension tests: 
pm test (24 passing)\n\nNo Flutter/Dart SDK is available in the validation environment, so this is opened as a draft.