### PR TITLE
fix: preserve source chapter order

### DIFF
--- a/lib/models/chapter.dart
+++ b/lib/models/chapter.dart
@@ -32,6 +32,8 @@ class Chapter {
 
   String? description;
 
+  int? sourceOrder;
+
   /// video size
   String? downloadSize;
 
@@ -56,6 +58,7 @@ class Chapter {
     this.isFiller = false,
     this.thumbnailUrl,
     this.description,
+    this.sourceOrder,
     this.downloadSize,
     this.duration,
     this.updatedAt = 0,
@@ -75,6 +78,7 @@ class Chapter {
     isFiller = json['isFiller'] ?? false;
     thumbnailUrl = json['thumbnailUrl'];
     description = json['description'];
+    sourceOrder = json['sourceOrder'];
     downloadSize = json['downloadSize'];
     duration = json['duration'];
     updatedAt = json['updatedAt'];
@@ -94,6 +98,7 @@ class Chapter {
     'isFiller': isFiller,
     'thumbnailUrl': thumbnailUrl,
     'description': description,
+    'sourceOrder': sourceOrder,
     'downloadSize': downloadSize,
     'duration': duration,
     'updatedAt': updatedAt ?? 0,

--- a/lib/models/chapter.g.dart
+++ b/lib/models/chapter.g.dart
@@ -61,17 +61,22 @@ const ChapterSchema = CollectionSchema(
       name: r'scanlator',
       type: IsarType.string,
     ),
-    r'thumbnailUrl': PropertySchema(
+    r'sourceOrder': PropertySchema(
       id: 12,
+      name: r'sourceOrder',
+      type: IsarType.long,
+    ),
+    r'thumbnailUrl': PropertySchema(
+      id: 13,
       name: r'thumbnailUrl',
       type: IsarType.string,
     ),
     r'updatedAt': PropertySchema(
-      id: 13,
+      id: 14,
       name: r'updatedAt',
       type: IsarType.long,
     ),
-    r'url': PropertySchema(id: 14, name: r'url', type: IsarType.string),
+    r'url': PropertySchema(id: 15, name: r'url', type: IsarType.string),
   },
 
   estimateSize: _chapterEstimateSize,
@@ -183,9 +188,10 @@ void _chapterSerialize(
   writer.writeLong(offsets[9], object.mangaId);
   writer.writeString(offsets[10], object.name);
   writer.writeString(offsets[11], object.scanlator);
-  writer.writeString(offsets[12], object.thumbnailUrl);
-  writer.writeLong(offsets[13], object.updatedAt);
-  writer.writeString(offsets[14], object.url);
+  writer.writeLong(offsets[12], object.sourceOrder);
+  writer.writeString(offsets[13], object.thumbnailUrl);
+  writer.writeLong(offsets[14], object.updatedAt);
+  writer.writeString(offsets[15], object.url);
 }
 
 Chapter _chapterDeserialize(
@@ -208,9 +214,10 @@ Chapter _chapterDeserialize(
     mangaId: reader.readLongOrNull(offsets[9]),
     name: reader.readStringOrNull(offsets[10]),
     scanlator: reader.readStringOrNull(offsets[11]),
-    thumbnailUrl: reader.readStringOrNull(offsets[12]),
-    updatedAt: reader.readLongOrNull(offsets[13]),
-    url: reader.readStringOrNull(offsets[14]),
+    sourceOrder: reader.readLongOrNull(offsets[12]),
+    thumbnailUrl: reader.readStringOrNull(offsets[13]),
+    updatedAt: reader.readLongOrNull(offsets[14]),
+    url: reader.readStringOrNull(offsets[15]),
   );
   return object;
 }
@@ -247,10 +254,12 @@ P _chapterDeserializeProp<P>(
     case 11:
       return (reader.readStringOrNull(offset)) as P;
     case 12:
-      return (reader.readStringOrNull(offset)) as P;
-    case 13:
       return (reader.readLongOrNull(offset)) as P;
+    case 13:
+      return (reader.readStringOrNull(offset)) as P;
     case 14:
+      return (reader.readLongOrNull(offset)) as P;
+    case 15:
       return (reader.readStringOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -1879,6 +1888,81 @@ extension ChapterQueryFilter
     });
   }
 
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> sourceOrderIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'sourceOrder'),
+      );
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> sourceOrderIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'sourceOrder'),
+      );
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> sourceOrderEqualTo(
+    int? value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'sourceOrder', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> sourceOrderGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'sourceOrder',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> sourceOrderLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'sourceOrder',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterFilterCondition> sourceOrderBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'sourceOrder',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
   QueryBuilder<Chapter, Chapter, QAfterFilterCondition> thumbnailUrlIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(
@@ -2446,6 +2530,18 @@ extension ChapterQuerySortBy on QueryBuilder<Chapter, Chapter, QSortBy> {
     });
   }
 
+  QueryBuilder<Chapter, Chapter, QAfterSortBy> sortBySourceOrder() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sourceOrder', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterSortBy> sortBySourceOrderDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sourceOrder', Sort.desc);
+    });
+  }
+
   QueryBuilder<Chapter, Chapter, QAfterSortBy> sortByThumbnailUrl() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'thumbnailUrl', Sort.asc);
@@ -2641,6 +2737,18 @@ extension ChapterQuerySortThenBy
     });
   }
 
+  QueryBuilder<Chapter, Chapter, QAfterSortBy> thenBySourceOrder() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sourceOrder', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Chapter, Chapter, QAfterSortBy> thenBySourceOrderDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sourceOrder', Sort.desc);
+    });
+  }
+
   QueryBuilder<Chapter, Chapter, QAfterSortBy> thenByThumbnailUrl() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'thumbnailUrl', Sort.asc);
@@ -2768,6 +2876,12 @@ extension ChapterQueryWhereDistinct
     });
   }
 
+  QueryBuilder<Chapter, Chapter, QDistinct> distinctBySourceOrder() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'sourceOrder');
+    });
+  }
+
   QueryBuilder<Chapter, Chapter, QDistinct> distinctByThumbnailUrl({
     bool caseSensitive = true,
   }) {
@@ -2868,6 +2982,12 @@ extension ChapterQueryProperty
   QueryBuilder<Chapter, String?, QQueryOperations> scanlatorProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'scanlator');
+    });
+  }
+
+  QueryBuilder<Chapter, int?, QQueryOperations> sourceOrderProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'sourceOrder');
     });
   }
 

--- a/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
+++ b/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
@@ -1,5 +1,6 @@
 import 'package:mangayomi/eval/model/m_bridge.dart';
 import 'package:mangayomi/utils/chapter_recognition.dart';
+import 'package:mangayomi/utils/chapter_source_order.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/chapter.dart';
 import 'package:mangayomi/models/update.dart';
@@ -75,12 +76,15 @@ Future<dynamic> updateMangaDetail(
       ..updatedAt = now;
 
     final chaps = getManga.chapters;
+    final indexedChapters = chaps == null
+        ? const <IndexedSourceChapter>[]
+        : ChapterSourceOrder.indexSourceChapters(chaps);
 
     await isar.writeTxn(() async {
       // Persist updated manga metadata.
       final savedMangaId = await isar.mangas.put(manga);
 
-      if (chaps == null || chaps.isEmpty) return;
+      if (indexedChapters.isEmpty) return;
 
       // loadSync() was called before the transaction; the set is still valid
       // here because we haven't written to chapters yet.
@@ -106,9 +110,9 @@ Future<dynamic> updateMangaDetail(
 
       final newChapters = <Chapter>[];
 
-      for (final chap in chaps) {
-        final url = chap.url?.trim();
-        if (url == null || url.isEmpty) continue;
+      for (final indexedChapter in indexedChapters) {
+        final chap = indexedChapter.chapter;
+        final url = chap.url!;
         final existing = existingByUrl[url];
 
         if (existing == null) {
@@ -131,6 +135,7 @@ Future<dynamic> updateMangaDetail(
             isFiller: chap.isFiller,
             thumbnailUrl: chap.thumbnailUrl,
             description: chap.description,
+            sourceOrder: indexedChapter.sourceOrder,
             downloadSize: chap.downloadSize,
             duration: chap.duration,
           )..manga.value = manga;
@@ -151,6 +156,7 @@ Future<dynamic> updateMangaDetail(
             ..isFiller = chap.isFiller
             ..thumbnailUrl = chap.thumbnailUrl
             ..description = chap.description
+            ..sourceOrder = indexedChapter.sourceOrder
             ..downloadSize = chap.downloadSize
             ..duration = chap.duration;
           await isar.chapters.put(existing);

--- a/lib/modules/more/data_and_storage/providers/restore.dart
+++ b/lib/modules/more/data_and_storage/providers/restore.dart
@@ -425,6 +425,9 @@ void restoreTachiBkBackup(Ref ref, String path, BackupType bkType) {
               : "1",
           scanlator: tempChapter.scanlator,
           url: tempChapter.url,
+          sourceOrder: tempChapter.hasSourceOrder()
+              ? _protoInt(tempChapter.sourceOrder)
+              : null,
         );
         isar.chapters.putSync(chapter..manga.value = manga);
         chapter.manga.saveSync();
@@ -513,6 +516,9 @@ void restoreTachiBkBackup(Ref ref, String path, BackupType bkType) {
                 : "1",
             scanlator: tempEpisode.scanlator,
             url: tempEpisode.url,
+            sourceOrder: tempEpisode.hasSourceOrder()
+                ? _protoInt(tempEpisode.sourceOrder)
+                : null,
           );
           isar.chapters.putSync(episode..manga.value = anime);
           episode.manga.saveSync();

--- a/lib/utils/chapter_source_order.dart
+++ b/lib/utils/chapter_source_order.dart
@@ -1,0 +1,64 @@
+import 'package:mangayomi/eval/model/m_chapter.dart';
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/utils/chapter_recognition.dart';
+
+class IndexedSourceChapter {
+  final MChapter chapter;
+  final int sourceOrder;
+
+  const IndexedSourceChapter({
+    required this.chapter,
+    required this.sourceOrder,
+  });
+}
+
+class ChapterSourceOrder {
+  const ChapterSourceOrder._();
+
+  static List<IndexedSourceChapter> indexSourceChapters(
+    Iterable<MChapter> chapters,
+  ) {
+    final unique = <MChapter>[];
+    final seenUrls = <String>{};
+
+    for (final chapter in chapters) {
+      final url = chapter.url?.trim();
+      if (url == null || url.isEmpty || !seenUrls.add(url)) continue;
+      chapter.url = url;
+      unique.add(chapter);
+    }
+
+    return List.generate(
+      unique.length,
+      (index) => IndexedSourceChapter(
+        chapter: unique[index],
+        sourceOrder: unique.length - index - 1,
+      ),
+    );
+  }
+
+  static int compare(Chapter a, Chapter b, String mangaTitle) {
+    final recognition = ChapterRecognition();
+    final aOrder = value(a, mangaTitle, recognition: recognition);
+    final bOrder = value(b, mangaTitle, recognition: recognition);
+    final order = aOrder.compareTo(bOrder);
+    if (order != 0) return order;
+
+    final name = (a.name ?? '').compareTo(b.name ?? '');
+    if (name != 0) return name;
+
+    return (a.url ?? '').compareTo(b.url ?? '');
+  }
+
+  static int value(
+    Chapter chapter,
+    String mangaTitle, {
+    ChapterRecognition? recognition,
+  }) {
+    return chapter.sourceOrder ??
+        (recognition ?? ChapterRecognition()).parseChapterNumber(
+          mangaTitle,
+          chapter.name ?? '',
+        );
+  }
+}

--- a/lib/utils/extensions/manga_extensions.dart
+++ b/lib/utils/extensions/manga_extensions.dart
@@ -5,6 +5,7 @@ import 'package:mangayomi/models/download.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/utils/chapter_recognition.dart';
+import 'package:mangayomi/utils/chapter_source_order.dart';
 
 extension MangaExtensions on Manga {
   /// Filtered chapters respecting the user's active filters (unread,
@@ -42,9 +43,10 @@ extension MangaExtensions on Manga {
 
     // Memoize so each chapter name is parsed at most once during the sort.
     final numCache = <int?, int>{};
-    int chapNum(Chapter c) => numCache[c.id] ??= recognition.parseChapterNumber(
+    int chapNum(Chapter c) => numCache[c.id] ??= ChapterSourceOrder.value(
+      c,
       mangaTitle,
-      c.name ?? '',
+      recognition: recognition,
     );
 
     // Sort by chapter number — DB insertion order is NOT guaranteed to be ascending
@@ -108,10 +110,13 @@ extension MangaExtensions on Manga {
         final mangaTitle = name ?? '';
 
         // Returns the parsed chapter number for a chapter, used as the primary
-        // numeric sort key for cases 0 and 1.
+        // numeric sort key for scanlator grouping.
         final numCache = <int?, int>{};
-        int chapNum(Chapter c) => numCache[c.id] ??= recognition
-            .parseChapterNumber(mangaTitle, c.name ?? '');
+        int chapNum(Chapter c) => numCache[c.id] ??= ChapterSourceOrder.value(
+          c,
+          mangaTitle,
+          recognition: recognition,
+        );
         list.sort((a, b) {
           final s = (a.scanlator ?? '').compareTo(b.scanlator ?? '');
           if (s != 0) return s;
@@ -153,7 +158,11 @@ extension MangaExtensions on Manga {
     return list
         .where(
           (c) => seen.add(
-            recognition.parseChapterNumber(mangaTitle, c.name ?? ''),
+            ChapterSourceOrder.value(
+              c,
+              mangaTitle,
+              recognition: recognition,
+            ),
           ),
         )
         .toList();

--- a/test/utils/chapter_source_order_test.dart
+++ b/test/utils/chapter_source_order_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/eval/model/m_chapter.dart';
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/utils/chapter_source_order.dart';
+
+void main() {
+  test('source order survives Chapter JSON serialization', () {
+    final chapter = Chapter(
+      mangaId: 1,
+      name: 'Season 1 afterword',
+      sourceOrder: 7,
+    );
+
+    expect(Chapter.fromJson(chapter.toJson()).sourceOrder, 7);
+  });
+
+  test('indexes valid unique URLs in returned order', () {
+    final indexed = ChapterSourceOrder.indexSourceChapters([
+      MChapter(name: 'new', url: '/new'),
+      MChapter(name: 'duplicate', url: '/new'),
+      MChapter(name: 'invalid', url: '  '),
+      MChapter(name: 'old', url: '/old'),
+    ]);
+
+    expect(indexed.map((entry) => entry.chapter.url), ['/new', '/old']);
+    expect(indexed.map((entry) => entry.sourceOrder), [1, 0]);
+  });
+
+  test('source order overrides the recognized title number', () {
+    final chapter = Chapter(
+      mangaId: 1,
+      name: 'Episode 1',
+      sourceOrder: 97,
+    );
+
+    expect(ChapterSourceOrder.value(chapter, 'Series title'), 97);
+  });
+
+  test('legacy rows fall back to the recognized title number', () {
+    final chapter = Chapter(mangaId: 1, name: 'Episode 12');
+
+    expect(ChapterSourceOrder.value(chapter, 'Series title'), 12);
+  });
+}


### PR DESCRIPTION
## Summary
- persist each chapter's position from the source response during detail refreshes
- use that persisted position as the numeric key for the existing chapter-number sort, with title parsing as a fallback for legacy rows
- restore persisted positions from backups and ignore invalid or duplicate chapter URLs while indexing
- keep the existing sort labels, options, and saved sort behavior unchanged

## Root cause
Chapter ordering was reconstructed from numbers parsed out of chapter titles. Special or irregular chapter names can therefore receive an unrelated numeric value and appear in the wrong position even when the source returned the correct sequence.

## Validation
- `flutter test test/utils/chapter_source_order_test.dart`
- `dart analyze` on the changed Dart files and regression test
- `flutter build windows --release`
- manual Windows launch, source list load, 1000-chapter detail load, and verification that the existing `By chapter number` UI remains unchanged

## Test suite note
The full `flutter test` command still fails in the unchanged `test/widget_test.dart` smoke test because `MyApp` is pumped without a Riverpod `ProviderScope` (`Bad state: No ProviderScope found`). The focused tests added by this PR pass.