### PR TITLE
feat(reader): global "Show page number" toggle in Reader settings (#790)

### DIFF
--- a/lib/modules/more/settings/reader/reader_screen.dart
+++ b/lib/modules/more/settings/reader/reader_screen.dart
@@ -29,6 +29,7 @@ class ReaderScreen extends ConsumerWidget {
     final keepScreenOn = ref.watch(keepScreenOnReaderStateProvider);
     final autoReadDuplChap = ref.watch(autoReadDuplicateChaptersStateProvider);
     final showPageGaps = ref.watch(showPageGapsStateProvider);
+    final showPagesNumber = ref.watch(showPagesNumberStateProvider);
     final webtoonSidePadding = ref.watch(webtoonSidePaddingStateProvider);
     final navigationLayout = ref.watch(readerNavigationLayoutStateProvider);
     return Scaffold(
@@ -409,6 +410,13 @@ class ReaderScreen extends ConsumerWidget {
               title: Text(context.l10n.show_page_gaps),
               onChanged: (value) {
                 ref.read(showPageGapsStateProvider.notifier).set(value);
+              },
+            ),
+            SwitchListTile(
+              value: showPagesNumber,
+              title: Text(context.l10n.show_page_number),
+              onChanged: (value) {
+                ref.read(showPagesNumberStateProvider.notifier).set(value);
               },
             ),
             SwitchListTile(


### PR DESCRIPTION
Closes #790.

The page-number setting is already global — `Settings.showPagesNumber`, exposed through `showPagesNumberStateProvider` — but the only place to reach it is the in-reader settings modal. So it reads as a per-comic option, and there's no way to turn it off once for everything.

This surfaces that same provider in **Settings → Reader**, alongside the other global reader toggles (page gaps, tap zones, page transitions…):

```dart
SwitchListTile(
  value: showPagesNumber,
  title: Text(context.l10n.show_page_number),
  onChanged: (value) {
    ref.read(showPagesNumberStateProvider.notifier).set(value);
  },
),
```

No new storage, provider, or string — it reuses `showPagesNumberStateProvider` and the existing localised `show_page_number` label. Behaviour is unchanged for anyone who already found the in-reader toggle; this only makes the same setting discoverable as a global one.
