### PR TITLE
Fix dynamic source BaseUrls in WebViews

### DIFF
--- a/lib/eval/javascript/service.dart
+++ b/lib/eval/javascript/service.dart
@@ -16,6 +16,18 @@ import 'package:mangayomi/models/video.dart';
 
 import '../interface.dart';
 
+String resolveJavaScriptSourceBaseUrl(
+  String fallback,
+  String Function() resolveRuntimeBaseUrl,
+) {
+  try {
+    final value = resolveRuntimeBaseUrl().trim();
+    return value.isEmpty ? fallback : value;
+  } catch (_) {
+    return fallback;
+  }
+}
+
 class JsExtensionService implements ExtensionService {
   late JavascriptRuntime runtime;
   @override
@@ -109,7 +121,11 @@ var extention = new DefaultExtension();
 
   @override
   String get sourceBaseUrl {
-    return source.baseUrl!;
+    final fallback = source.baseUrl ?? '';
+    return resolveJavaScriptSourceBaseUrl(
+      fallback,
+      () => _extensionCall<String>('getBaseUrl()', ''),
+    );
   }
 
   @override

--- a/lib/eval/javascript/service.dart
+++ b/lib/eval/javascript/service.dart
@@ -103,6 +103,7 @@ var extention = new DefaultExtension();
   void dispose() {
     if (!_isInitialized) return;
     _jsDomSelector.dispose();
+    runtime.dispose();
     _isInitialized = false;
   }
 

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -37,6 +37,7 @@ import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/services/http/m_client.dart';
+import 'package:mangayomi/services/get_source_baseurl.dart';
 import 'package:mangayomi/utils/extensions/string_extensions.dart';
 import 'package:mangayomi/utils/riverpod.dart';
 import 'package:mangayomi/utils/utils.dart';
@@ -1874,8 +1875,10 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                       widget.manga!.sourceId,
                     );
                     if (source == null) return;
-                    final url =
-                        "${source.baseUrl}${widget.manga!.link!.getUrlWithoutDomain}";
+                    final baseUrl = ref.read(
+                      sourceBaseUrlProvider(source: source),
+                    );
+                    final url = buildSourceUrl(baseUrl, widget.manga!.link!);
 
                     Map<String, dynamic> data = {
                       'url': url,

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -31,8 +31,10 @@ import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_pr
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/others.dart';
 import 'package:mangayomi/utils/riverpod.dart';
+import 'package:mangayomi/utils/utils.dart';
 import 'package:mangayomi/modules/manga/reader/providers/push_router.dart';
 import 'package:mangayomi/services/get_chapter_pages.dart';
+import 'package:mangayomi/services/get_source_baseurl.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/modules/manga/reader/image_view_paged.dart';
 import 'package:mangayomi/modules/manga/reader/providers/reader_controller_provider.dart';
@@ -575,7 +577,17 @@ class _MangaChapterPageGalleryState
                           (chapter.manga.value!.isLocalArchive ?? false) ==
                               false
                           ? () {
-                              final data = buildWebViewData(chapter);
+                              final manga = chapter.manga.value!;
+                              final source = getSource(
+                                manga.lang!,
+                                manga.source!,
+                                manga.sourceId,
+                              );
+                              if (source == null) return;
+                              final baseUrl = ref.read(
+                                sourceBaseUrlProvider(source: source),
+                              );
+                              final data = buildWebViewData(chapter, baseUrl);
                               if (data != null) {
                                 context.push("/mangawebview", extra: data);
                               }

--- a/lib/modules/manga/reader/widgets/reader_app_bar.dart
+++ b/lib/modules/manga/reader/widgets/reader_app_bar.dart
@@ -3,11 +3,11 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/services/get_source_baseurl.dart';
 import 'package:mangayomi/modules/manga/reader/widgets/btn_chapter_list_dialog.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
-import 'package:mangayomi/utils/extensions/string_extensions.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/utils/utils.dart';
 
@@ -142,14 +142,14 @@ class ReaderAppBar extends ConsumerWidget {
 }
 
 /// Builds the web view navigation data.
-Map<String, dynamic>? buildWebViewData(Chapter chapter) {
+Map<String, dynamic>? buildWebViewData(Chapter chapter, String baseUrl) {
   final manga = chapter.manga.value;
   if (manga == null) return null;
 
   final source = getSource(manga.lang!, manga.source!, manga.sourceId);
   if (source == null) return null;
 
-  final url = "${source.baseUrl}${chapter.url!.getUrlWithoutDomain}";
+  final url = buildSourceUrl(baseUrl, chapter.url!);
 
   return {'url': url, 'sourceId': source.id.toString(), 'title': chapter.name!};
 }

--- a/lib/modules/novel/novel_reader_view.dart
+++ b/lib/modules/novel/novel_reader_view.dart
@@ -24,6 +24,7 @@ import 'package:mangayomi/modules/novel/widgets/novel_reader_settings_sheet.dart
 import 'package:mangayomi/modules/widgets/custom_draggable_tabbar.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/get_html_content.dart';
+import 'package:mangayomi/services/get_source_baseurl.dart';
 import 'package:mangayomi/src/rust/api/epub.dart';
 import 'package:mangayomi/utils/extensions/dom_extensions.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
@@ -918,9 +919,8 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
                 manga.source!,
                 manga.sourceId,
               )!;
-              final url = chapter.url!.startsWith('/')
-                  ? '${source.baseUrl}/${chapter.url!}'
-                  : chapter.url!;
+              final baseUrl = ref.read(sourceBaseUrlProvider(source: source));
+              final url = buildSourceUrl(baseUrl, chapter.url!);
               if (Platform.isLinux) {
                 final uri = Uri.parse(url);
                 await launchUrl(

--- a/lib/services/get_source_baseurl.dart
+++ b/lib/services/get_source_baseurl.dart
@@ -1,9 +1,17 @@
 import 'package:mangayomi/eval/lib.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
+import 'package:mangayomi/utils/extensions/string_extensions.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'get_source_baseurl.g.dart';
+
+String buildSourceUrl(String baseUrl, String url) {
+  final normalizedBase = baseUrl.trim().replaceFirst(RegExp(r'/+$'), '');
+  final normalizedPath = url.trim().getUrlWithoutDomain;
+  final separator = normalizedPath.startsWith('/') ? '' : '/';
+  return '$normalizedBase$separator$normalizedPath';
+}
 
 @riverpod
 String sourceBaseUrl(Ref ref, {required Source source}) {

--- a/test/eval/javascript/service_source_base_url_test.dart
+++ b/test/eval/javascript/service_source_base_url_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/eval/javascript/service.dart';
+
+void main() {
+  test('uses the JavaScript extension runtime BaseUrl', () {
+    expect(
+      resolveJavaScriptSourceBaseUrl(
+        'https://manifest.example',
+        () => 'https://runtime.example',
+      ),
+      'https://runtime.example',
+    );
+  });
+
+  test('falls back when getBaseUrl is not implemented', () {
+    expect(
+      resolveJavaScriptSourceBaseUrl(
+        'https://manifest.example',
+        () => throw StateError('getBaseUrl is not implemented'),
+      ),
+      'https://manifest.example',
+    );
+  });
+
+  test('falls back when the runtime BaseUrl is blank', () {
+    expect(
+      resolveJavaScriptSourceBaseUrl('https://manifest.example', () => '   '),
+      'https://manifest.example',
+    );
+  });
+
+  test('falls back when runtime BaseUrl resolution throws', () {
+    expect(
+      resolveJavaScriptSourceBaseUrl(
+        'https://manifest.example',
+        () => throw Exception('failed'),
+      ),
+      'https://manifest.example',
+    );
+  });
+}

--- a/test/services/get_source_baseurl_test.dart
+++ b/test/services/get_source_baseurl_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/get_source_baseurl.dart';
+
+void main() {
+  test('joins a source BaseUrl and relative path with one slash', () {
+    expect(
+      buildSourceUrl('https://toki30.com', '/webtoon/1'),
+      'https://toki30.com/webtoon/1',
+    );
+    expect(
+      buildSourceUrl('https://toki30.com/', '/webtoon/1'),
+      'https://toki30.com/webtoon/1',
+    );
+    expect(
+      buildSourceUrl('https://sbxh9.com', 'manga/2'),
+      'https://sbxh9.com/manga/2',
+    );
+  });
+
+  test('replaces the domain of an absolute stored URL', () {
+    expect(
+      buildSourceUrl(
+        'https://toki30.com',
+        'https://newtoki1.org/webtoon/1?x=1#page',
+      ),
+      'https://toki30.com/webtoon/1?x=1#page',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- resolve JavaScript source BaseUrl from the extension runtime `getBaseUrl()`, with the manifest BaseUrl as a compatibility fallback
- normalize source URLs so stored absolute chapter links are rebuilt against the current runtime domain
- use the runtime BaseUrl for manga detail, manga reader, and novel reader WebView actions
- dispose JavaScript runtimes when temporary extension services are released

## Root cause
JavaScript extensions could override their BaseUrl at runtime, but several client WebView actions still concatenated paths with the static manifest `Source.baseUrl`. Changing an extension preference therefore updated source requests but not those WebViews.

## Validation
- `flutter test test/services/get_source_baseurl_test.dart test/eval/javascript/service_source_base_url_test.dart` (6 tests passed)
- `dart analyze lib` (no errors; one pre-existing `WillPopScope` deprecation info)
- `flutter build windows --release`
- Windows runtime checks with `https://toki30.com`, `https://sbxh9.com`, and `https://newtoki1.org`