### PR TITLE
fix(library): unread badge respects the per-manga scanlator filter (#796)

### DIFF
--- a/lib/modules/library/providers/library_filter_provider.dart
+++ b/lib/modules/library/providers/library_filter_provider.dart
@@ -1,4 +1,5 @@
 import 'package:isar_community/isar.dart';
+import 'package:mangayomi/utils/extensions/manga_extensions.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/download.dart';
 import 'package:mangayomi/models/manga.dart';
@@ -125,10 +126,7 @@ List<Manga> filteredLibraryManga(
       case 2:
         return a.lastUpdate?.compareTo(b.lastUpdate ?? 0) ?? 0;
       case 3:
-        return a.chapters
-            .where((e) => !e.isRead!)
-            .length
-            .compareTo(b.chapters.where((e) => !e.isRead!).length);
+        return a.unreadChaptersCount.compareTo(b.unreadChaptersCount);
       case 4:
         return a.chapters.length.compareTo(b.chapters.length);
       case 5:

--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/extensions/manga_extensions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/modules/library/providers/library_state_provider.dart';
 import 'package:mangayomi/models/manga.dart';
@@ -102,10 +103,7 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                                       Padding(
                                         padding: const EdgeInsets.only(left: 3),
                                         child: Text(
-                                          entry.chapters
-                                              .where((e) => !e.isRead!)
-                                              .length
-                                              .toString(),
+                                          entry.unreadChaptersCount.toString(),
                                           style: TextStyle(
                                             color:
                                                 context.dynamicBlackWhiteColor,

--- a/lib/modules/library/widgets/library_listview_widget.dart
+++ b/lib/modules/library/widgets/library_listview_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/extensions/manga_extensions.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/library/widgets/continue_reader_button.dart';
@@ -121,10 +122,7 @@ class LibraryListViewWidget extends StatelessWidget {
                                         right: 3,
                                       ),
                                       child: Text(
-                                        entry.chapters
-                                            .where((e) => !e.isRead!)
-                                            .length
-                                            .toString(),
+                                        entry.unreadChaptersCount.toString(),
                                         style: TextStyle(
                                           color: context.dynamicBlackWhiteColor,
                                         ),

--- a/lib/utils/extensions/manga_extensions.dart
+++ b/lib/utils/extensions/manga_extensions.dart
@@ -7,6 +7,26 @@ import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/utils/chapter_recognition.dart';
 
 extension MangaExtensions on Manga {
+  /// Number of unread chapters, excluding chapters from scanlators the user has
+  /// filtered out for this manga. Mirrors the chapter list's scanlator filter,
+  /// so the library "unread" badge and the unread sort reflect what the user
+  /// actually sees rather than counting duplicate chapters from hidden
+  /// scanlators (#796).
+  int get unreadChaptersCount {
+    final filter = isar.settings
+        .getSync(227)
+        ?.filterScanlatorList
+        ?.where((e) => e.mangaId == id)
+        .firstOrNull
+        ?.scanlators;
+    if (filter == null || filter.isEmpty) {
+      return chapters.where((c) => !(c.isRead ?? false)).length;
+    }
+    return chapters
+        .where((c) => !(c.isRead ?? false) && !filter.contains(c.scanlator))
+        .length;
+  }
+
   /// Filtered chapters respecting the user's active filters (unread,
   /// bookmarked, downloaded, scanlator). Sorted by chapter number ascending.
   /// Base list — no user-chosen sort, no deduplication.


### PR DESCRIPTION
Closes #796.

Some sources expose the same chapters under multiple scanlators. The chapter list lets you filter scanlators to hide the duplicates, but the library's **unread** badge still counted every scanlator — so the number was inflated and didn't match what you actually see.

This adds `Manga.unreadChaptersCount`, which counts unread chapters while excluding the scanlators filtered out for that manga — reusing the same `settings.filterScanlatorList` the chapter list already filters by:

```dart
int get unreadChaptersCount {
  final filter = isar.settings.getSync(227)
      ?.filterScanlatorList
      ?.where((e) => e.mangaId == id).firstOrNull?.scanlators;
  if (filter == null || filter.isEmpty) {
    return chapters.where((c) => !(c.isRead ?? false)).length;
  }
  return chapters
      .where((c) => !(c.isRead ?? false) && !filter.contains(c.scanlator))
      .length;
}
```

It's wired into the **grid badge**, the **list-view badge**, and the **"unread" sort**, so all three agree. When no scanlator filter is set, the count is identical to before.
