### PR TITLE
Fix Fit Width in Vertical Continuous reader

### DIFF
--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -1263,19 +1263,32 @@ enum ReaderMode {
 
 extension ReaderModeExtension on ReaderMode {
   /// Vertical continuous || Webtoon || Horizontal continuous || Horizontal continuous (RTL)
-  bool get isContinuous => isVerticalContinuous || isHorizontalContinuous;
-
-  /// Vertical || Vertical continuous || Webtoon
-  bool get isVertical => this == ReaderMode.vertical || isVerticalContinuous;
+  bool get usesContinuousScroller =>
+      isVerticalContinuous || isWebtoon || isHorizontalContinuous;
 
   /// Vertical continuous || Webtoon
-  bool get isVerticalContinuous =>
-      this == ReaderMode.verticalContinuous || this == ReaderMode.webtoon;
+  bool get usesVerticalContinuousScroller => isVerticalContinuous || isWebtoon;
+
+  /// Vertical || Vertical continuous || Webtoon
+  bool get isVertical =>
+      this == ReaderMode.vertical || usesVerticalContinuousScroller;
+
+  /// Vertical continuous
+  bool get isVerticalContinuous => this == ReaderMode.verticalContinuous;
+
+  /// Webtoon
+  bool get isWebtoon => this == ReaderMode.webtoon;
 
   /// Horizontal continuous || Horizontal continuous (RTL)
   bool get isHorizontalContinuous =>
       this == ReaderMode.horizontalContinuous ||
       this == ReaderMode.horizontalContinuousRTL;
+
+  /// Reader modes that can show a gap between pages.
+  bool get supportsPageGaps => isVerticalContinuous || isHorizontalContinuous;
+
+  /// Webtoon-only side padding setting.
+  bool get supportsWebtoonSidePadding => isWebtoon;
 
   /// Right to Left || Horizontal continuous (RTL)
   bool get isRTL =>

--- a/lib/modules/manga/reader/continuous_reader_layout_policy.dart
+++ b/lib/modules/manga/reader/continuous_reader_layout_policy.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+import 'package:mangayomi/models/settings.dart';
+
+@immutable
+class ContinuousReaderLayoutPolicy {
+  final bool fillAvailableWidth;
+  final int sidePaddingPercent;
+  final bool showPageGaps;
+
+  const ContinuousReaderLayoutPolicy.verticalContinuous({
+    required ScaleType scaleType,
+    required this.showPageGaps,
+  }) : fillAvailableWidth = scaleType == ScaleType.fitWidth,
+       sidePaddingPercent = 0;
+
+  const ContinuousReaderLayoutPolicy.webtoon({required this.sidePaddingPercent})
+    : fillAvailableWidth = false,
+      showPageGaps = false;
+
+  const ContinuousReaderLayoutPolicy.horizontal({required this.showPageGaps})
+    : fillAvailableWidth = false,
+      sidePaddingPercent = 0;
+}

--- a/lib/modules/manga/reader/image_view_continuous.dart
+++ b/lib/modules/manga/reader/image_view_continuous.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/modules/manga/reader/continuous_reader_layout_policy.dart';
+import 'package:mangayomi/modules/manga/reader/image_view_vertical.dart';
+import 'package:mangayomi/modules/manga/reader/u_chap_data_preload.dart';
+import 'package:mangayomi/modules/manga/reader/widgets/double_page_view.dart';
+import 'package:mangayomi/modules/manga/reader/widgets/transition_view_vertical.dart';
+import 'package:mangayomi/modules/more/settings/reader/reader_screen.dart';
+import 'package:photo_view/photo_view.dart';
+import 'package:photo_view/photo_view_gallery.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+/// Shared scrolling engine for continuous reader modes.
+class ImageViewContinuous extends StatelessWidget {
+  final List<UChapDataPreload> pages;
+  final ItemScrollController itemScrollController;
+  final ScrollOffsetController scrollOffsetController;
+  final ItemPositionsListener itemPositionsListener;
+  final Axis scrollDirection;
+  final double minCacheExtent;
+  final int initialScrollIndex;
+  final ScrollPhysics physics;
+  final Function(UChapDataPreload data) onLongPressData;
+  final Function(bool) onFailedToLoadImage;
+  final BackgroundColor backgroundColor;
+  final bool isDoublePageMode;
+  final bool isHorizontalContinuous;
+  final PhotoViewController photoViewController;
+  final PhotoViewScaleStateController photoViewScaleStateController;
+  final Alignment scalePosition;
+  final Function(ScaleEndDetails) onScaleEnd;
+  final Function(Offset) onDoubleTapDown;
+  final VoidCallback onDoubleTap;
+  final ContinuousReaderLayoutPolicy layoutPolicy;
+  final bool reverse;
+  final ValueNotifier<bool> isScrolling;
+
+  const ImageViewContinuous({
+    super.key,
+    required this.pages,
+    required this.itemScrollController,
+    required this.scrollOffsetController,
+    required this.itemPositionsListener,
+    required this.scrollDirection,
+    required this.minCacheExtent,
+    required this.initialScrollIndex,
+    required this.physics,
+    required this.onLongPressData,
+    required this.onFailedToLoadImage,
+    required this.backgroundColor,
+    required this.isDoublePageMode,
+    required this.isHorizontalContinuous,
+    required this.photoViewController,
+    required this.photoViewScaleStateController,
+    required this.scalePosition,
+    required this.onScaleEnd,
+    required this.onDoubleTapDown,
+    required this.onDoubleTap,
+    required this.layoutPolicy,
+    required this.isScrolling,
+    this.reverse = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return PhotoViewGallery.builder(
+      itemCount: 1,
+      builder: (_, _) => PhotoViewGalleryPageOptions.customChild(
+        controller: photoViewController,
+        scaleStateController: photoViewScaleStateController,
+        basePosition: scalePosition,
+        onScaleEnd: (context, details, controllerValue) => onScaleEnd(details),
+        child: ScrollablePositionedList.separated(
+          scrollDirection: scrollDirection,
+          reverse: reverse,
+          minCacheExtent: minCacheExtent,
+          initialScrollIndex: initialScrollIndex,
+          itemCount: pages.length,
+          physics: physics,
+          itemScrollController: itemScrollController,
+          scrollOffsetController: scrollOffsetController,
+          itemPositionsListener: itemPositionsListener,
+          itemBuilder: (context, index) => _buildItem(context, index),
+          separatorBuilder: _buildSeparator,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildItem(BuildContext context, int index) {
+    final currentPage = pages[index];
+    final uniqueKey = ValueKey(
+      '${currentPage.chapter?.id ?? "trans"}-${currentPage.index ?? index}',
+    );
+
+    return KeyedSubtree(
+      key: uniqueKey,
+      child: (isDoublePageMode && !isHorizontalContinuous)
+          ? _buildDoublePageItem(context, index)
+          : _buildSinglePageItem(context, index),
+    );
+  }
+
+  Widget _buildSinglePageItem(BuildContext context, int index) {
+    final currentPage = pages[index];
+    final sidePaddingPercent = layoutPolicy.sidePaddingPercent;
+    final double sidePad = sidePaddingPercent > 0
+        ? MediaQuery.sizeOf(context).width * sidePaddingPercent / 100
+        : 0;
+
+    if (currentPage.isTransitionPage) {
+      return GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onDoubleTapDown: (details) => onDoubleTapDown(details.globalPosition),
+        onDoubleTap: onDoubleTap,
+        child: TransitionViewVertical(data: currentPage),
+      );
+    }
+
+    return Padding(
+      padding: isHorizontalContinuous
+          ? EdgeInsets.zero
+          : EdgeInsets.symmetric(horizontal: sidePad),
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onDoubleTapDown: (details) => onDoubleTapDown(details.globalPosition),
+        onDoubleTap: onDoubleTap,
+        child: ImageViewVertical(
+          data: currentPage,
+          failedToLoadImage: onFailedToLoadImage,
+          onLongPressData: onLongPressData,
+          isHorizontal: isHorizontalContinuous,
+          isScrolling: isScrolling,
+          fillAvailableWidth: layoutPolicy.fillAvailableWidth,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDoublePageItem(BuildContext context, int index) {
+    final pageLength = pages.length;
+    if (index >= pageLength) {
+      return const SizedBox.shrink();
+    }
+
+    final int index1 = index * 2 - 1;
+    final int index2 = index1 + 1;
+
+    final List<UChapDataPreload?> datas = index == 0
+        ? [pages[0], null]
+        : [
+            index1 < pageLength ? pages[index1] : null,
+            index2 < pageLength ? pages[index2] : null,
+          ];
+
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onDoubleTapDown: (details) => onDoubleTapDown(details.globalPosition),
+      onDoubleTap: onDoubleTap,
+      child: DoublePageView.vertical(
+        pages: datas,
+        backgroundColor: backgroundColor,
+        onFailedToLoadImage: onFailedToLoadImage,
+        onLongPressData: onLongPressData,
+      ),
+    );
+  }
+
+  Widget _buildSeparator(BuildContext context, int index) {
+    if (!layoutPolicy.showPageGaps) {
+      return const SizedBox.shrink();
+    }
+
+    if (isHorizontalContinuous) {
+      return VerticalDivider(
+        color: getBackgroundColor(backgroundColor),
+        width: 6,
+      );
+    }
+    return Divider(color: getBackgroundColor(backgroundColor), height: 6);
+  }
+}

--- a/lib/modules/manga/reader/image_view_vertical.dart
+++ b/lib/modules/manga/reader/image_view_vertical.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/modules/manga/reader/providers/reader_controller_provider.dart';
 import 'package:mangayomi/modules/manga/reader/u_chap_data_preload.dart';
 import 'package:mangayomi/modules/manga/reader/widgets/color_filter_widget.dart';
+import 'package:mangayomi/modules/manga/reader/widgets/continuous_image_width.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
@@ -15,6 +16,7 @@ class ImageViewVertical extends ConsumerWidget {
   final Function(UChapDataPreload data) onLongPressData;
   final bool isHorizontal;
   final ValueNotifier<bool> isScrolling;
+  final bool fillAvailableWidth;
 
   final Function(bool) failedToLoadImage;
 
@@ -25,6 +27,7 @@ class ImageViewVertical extends ConsumerWidget {
     required this.failedToLoadImage,
     required this.isHorizontal,
     required this.isScrolling,
+    this.fillAvailableWidth = false,
   });
 
   @override
@@ -129,7 +132,10 @@ class ImageViewVertical extends ConsumerWidget {
                 children: [
                   if (data.index == 0)
                     SizedBox(height: MediaQuery.of(context).padding.top),
-                  imageWidget,
+                  ContinuousImageWidth(
+                    fillAvailableWidth: fillAvailableWidth,
+                    child: imageWidget,
+                  ),
                 ],
               ),
       ),

--- a/lib/modules/manga/reader/image_view_vertical_continuous.dart
+++ b/lib/modules/manga/reader/image_view_vertical_continuous.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/manga/reader/continuous_reader_layout_policy.dart';
 import 'package:mangayomi/modules/manga/reader/image_view_continuous.dart';
 
-class ImageViewWebtoon extends ImageViewContinuous {
-  ImageViewWebtoon({
+class ImageViewVerticalContinuous extends ImageViewContinuous {
+  ImageViewVerticalContinuous({
     super.key,
     required super.pages,
     required super.itemScrollController,
@@ -23,13 +24,15 @@ class ImageViewWebtoon extends ImageViewContinuous {
     required super.onDoubleTapDown,
     required super.onDoubleTap,
     required super.isScrolling,
-    required int webtoonSidePadding,
+    required ScaleType scaleType,
+    required bool showPageGaps,
   }) : super(
          scrollDirection: Axis.vertical,
          isHorizontalContinuous: false,
          reverse: false,
-         layoutPolicy: ContinuousReaderLayoutPolicy.webtoon(
-           sidePaddingPercent: webtoonSidePadding,
+         layoutPolicy: ContinuousReaderLayoutPolicy.verticalContinuous(
+           scaleType: scaleType,
+           showPageGaps: showPageGaps,
          ),
        );
 }

--- a/lib/modules/manga/reader/providers/reader_controller_provider.dart
+++ b/lib/modules/manga/reader/providers/reader_controller_provider.dart
@@ -188,7 +188,7 @@ class ReaderController extends _$ReaderController
     final pageLength = getPageLength([]);
     if (pageLength == 0 || (!save && newIndex == _lastSavedIndex)) return;
     _lastSavedIndex = newIndex;
-    final isContinuousLike = getReaderMode().isVerticalContinuous;
+    final isContinuousLike = getReaderMode().usesVerticalContinuousScroller;
     final isRead = isContinuousLike
         ? (newIndex + 2) >= pageLength - 1
         : (newIndex + 2) >= pageLength;

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -414,7 +414,7 @@ class _MangaChapterPageGalleryState
               builder: (context, failedToLoadImage, child) {
                 return Stack(
                   children: [
-                    readerMode.isContinuous
+                    readerMode.usesContinuousScroller
                         ? ImageViewWebtoon(
                             pages: pages,
                             itemScrollController: _itemScrollController,
@@ -543,7 +543,7 @@ class _MangaChapterPageGalleryState
                           navigationLayout: navigationLayout,
                           isRTL: _isReverseHorizontal,
                           hasImageError: failedToLoadImage,
-                          isContinuousMode: readerMode.isContinuous,
+                          isContinuousMode: readerMode.usesContinuousScroller,
                           onToggleUI: _isViewFunction,
                           onPreviousPage: () =>
                               _handlePageNavigation(forward: false),
@@ -691,7 +691,7 @@ class _MangaChapterPageGalleryState
                       formatCurrentIndex: _currentIndexLabel,
                     ),
                     ReaderAutoScrollButton(
-                      isContinuousMode: readerMode.isContinuous,
+                      isContinuousMode: readerMode.usesContinuousScroller,
                       isUiVisible: _isView,
                       autoScrollPage: _autoScrollPage,
                       autoScroll: _autoScroll,
@@ -845,7 +845,7 @@ class _MangaChapterPageGalleryState
     );
     if (readerMode == null || _currentIndex == null) return;
 
-    if (readerMode.isContinuous) {
+    if (readerMode.usesContinuousScroller) {
       final isHorizontal = readerMode.isHorizontalContinuous;
       final viewportSize = MediaQuery.sizeOf(context);
       final dimension = isHorizontal ? viewportSize.width : viewportSize.height;
@@ -1130,7 +1130,7 @@ class _MangaChapterPageGalleryState
     }
     _setReaderMode(readerMode, ref);
 
-    if (!readerMode.isVerticalContinuous) {
+    if (!readerMode.usesVerticalContinuousScroller) {
       _autoScroll.value = false;
     }
     _autoPagescroll();
@@ -1173,18 +1173,25 @@ class _MangaChapterPageGalleryState
     if (needsReload) {
       final isLocalArchive = (currentChapter.archivePath ?? '').isNotEmpty;
       final storageProvider = StorageProvider();
-      final mangaDirectory = await storageProvider.getMangaMainDirectory(currentChapter);
+      final mangaDirectory = await storageProvider.getMangaMainDirectory(
+        currentChapter,
+      );
       final archivePath = isLocalArchive
           ? currentChapter.archivePath
-          : (mangaDirectory != null ? p.join(mangaDirectory.path, "${currentChapter.name}.cbz") : null);
+          : (mangaDirectory != null
+                ? p.join(mangaDirectory.path, "${currentChapter.name}.cbz")
+                : null);
 
       if (archivePath != null && await File(archivePath).exists()) {
         try {
-          final local = await ref.read(getArchiveDataFromFileProvider(archivePath).future);
+          final local = await ref.read(
+            getArchiveDataFromFileProvider(archivePath).future,
+          );
           final images = local.images ?? [];
           int imgIdx = 0;
           for (final page in pages) {
-            if (page.chapter?.id == currentChapter.id && !page.isTransitionPage) {
+            if (page.chapter?.id == currentChapter.id &&
+                !page.isTransitionPage) {
               if (imgIdx < images.length) {
                 page.archiveImage = images[imgIdx].image;
               }
@@ -1233,11 +1240,7 @@ class _MangaChapterPageGalleryState
       }
     }
 
-    await Future.wait([
-      worker(),
-      worker(),
-      worker(),
-    ]);
+    await Future.wait([worker(), worker(), worker()]);
   }
 
   Future<void> _onPageChanged(int index) async {
@@ -1356,7 +1359,7 @@ class _MangaChapterPageGalleryState
   }
 
   void _setReaderMode(ReaderMode value, WidgetRef ref) async {
-    if (!value.isVerticalContinuous) {
+    if (!value.usesVerticalContinuousScroller) {
       _autoScroll.value = false;
     } else if (_autoScrollPage.value) {
       _autoPagescroll();
@@ -1513,6 +1516,6 @@ class _MangaChapterPageGalleryState
 
   bool _isContinuousMode([ReaderMode? mode]) {
     final readerMode = mode ?? ref.read(_currentReaderMode);
-    return readerMode!.isContinuous;
+    return readerMode!.usesContinuousScroller;
   }
 }

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -35,7 +35,11 @@ import 'package:mangayomi/modules/manga/reader/providers/push_router.dart';
 import 'package:mangayomi/services/get_chapter_pages.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/modules/manga/reader/image_view_paged.dart';
+import 'package:mangayomi/modules/manga/reader/continuous_reader_layout_policy.dart';
+import 'package:mangayomi/modules/manga/reader/image_view_continuous.dart';
+import 'package:mangayomi/modules/manga/reader/image_view_vertical_continuous.dart';
 import 'package:mangayomi/modules/manga/reader/providers/reader_controller_provider.dart';
+import 'package:mangayomi/modules/manga/reader/u_chap_data_preload.dart';
 import 'package:mangayomi/modules/manga/reader/widgets/circular_progress_indicator_animate_rotate.dart';
 import 'package:mangayomi/modules/manga/reader/widgets/transition_view_paged.dart';
 import 'package:mangayomi/modules/more/settings/reader/reader_screen.dart';
@@ -415,56 +419,10 @@ class _MangaChapterPageGalleryState
                 return Stack(
                   children: [
                     readerMode.usesContinuousScroller
-                        ? ImageViewWebtoon(
-                            pages: pages,
-                            itemScrollController: _itemScrollController,
-                            scrollOffsetController: _pageOffsetController,
-                            itemPositionsListener: _itemPositionsListener,
-                            scrollDirection: isHorizontalContinuous
-                                ? Axis.horizontal
-                                : Axis.vertical,
-                            minCacheExtent: isHorizontalContinuous
-                                ? pagePreloadAmount * context.width(1)
-                                : pagePreloadAmount * context.height(1),
-                            initialScrollIndex: _readerController
-                                .getPageIndex(),
-                            physics: const ClampingScrollPhysics(),
-                            onLongPressData: (data) => ImageActionsDialog.show(
-                              context: context,
-                              data: data,
-                              manga: widget.chapter.manga.value!,
-                              chapterName: widget.chapter.name!,
-                            ),
-                            onFailedToLoadImage: (value) {
-                              // TODO: Handle failed image loading
-                              // if (_failedToLoadImage.value != value &&
-                              //     context.mounted) {
-                              //   _failedToLoadImage.value = value;
-                              // }
-                            },
+                        ? _buildContinuousReader(
+                            readerMode: readerMode,
+                            pagePreloadAmount: pagePreloadAmount,
                             backgroundColor: backgroundColor,
-                            isDoublePageMode:
-                                _pageMode == PageMode.doublePage &&
-                                !isHorizontalContinuous,
-                            isHorizontalContinuous: isHorizontalContinuous,
-                            readerMode: ref.watch(_currentReaderMode)!,
-                            photoViewController: _photoViewController,
-                            photoViewScaleStateController:
-                                _photoViewScaleStateController,
-                            scalePosition: _scalePosition,
-                            onScaleEnd: (details) => _onScaleEnd(
-                              context,
-                              details,
-                              _photoViewController.value,
-                            ),
-                            onDoubleTapDown: (offset) => _toggleScale(offset),
-                            onDoubleTap: () {},
-                            webtoonSidePadding: ref.watch(
-                              webtoonSidePaddingStateProvider,
-                            ),
-                            showPageGaps: ref.watch(showPageGapsStateProvider),
-                            reverse: _isReverseHorizontal,
-                            isScrolling: _isScrolling,
                           )
                         : Material(
                             color: getBackgroundColor(backgroundColor),
@@ -707,6 +665,98 @@ class _MangaChapterPageGalleryState
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildContinuousReader({
+    required ReaderMode readerMode,
+    required int pagePreloadAmount,
+    required BackgroundColor backgroundColor,
+  }) {
+    void onLongPress(UChapDataPreload data) => ImageActionsDialog.show(
+      context: context,
+      data: data,
+      manga: widget.chapter.manga.value!,
+      chapterName: widget.chapter.name!,
+    );
+
+    void onScaleEnd(ScaleEndDetails details) =>
+        _onScaleEnd(context, details, _photoViewController.value);
+
+    if (readerMode.isVerticalContinuous) {
+      return ImageViewVerticalContinuous(
+        pages: pages,
+        itemScrollController: _itemScrollController,
+        scrollOffsetController: _pageOffsetController,
+        itemPositionsListener: _itemPositionsListener,
+        minCacheExtent: pagePreloadAmount * context.height(1),
+        initialScrollIndex: _readerController.getPageIndex(),
+        physics: const ClampingScrollPhysics(),
+        onLongPressData: onLongPress,
+        onFailedToLoadImage: (_) {},
+        backgroundColor: backgroundColor,
+        isDoublePageMode: _pageMode == PageMode.doublePage,
+        photoViewController: _photoViewController,
+        photoViewScaleStateController: _photoViewScaleStateController,
+        scalePosition: _scalePosition,
+        onScaleEnd: onScaleEnd,
+        onDoubleTapDown: _toggleScale,
+        onDoubleTap: () {},
+        isScrolling: _isScrolling,
+        scaleType: ref.watch(scaleTypeStateProvider),
+        showPageGaps: ref.watch(showPageGapsStateProvider),
+      );
+    }
+
+    if (readerMode.isWebtoon) {
+      return ImageViewWebtoon(
+        pages: pages,
+        itemScrollController: _itemScrollController,
+        scrollOffsetController: _pageOffsetController,
+        itemPositionsListener: _itemPositionsListener,
+        minCacheExtent: pagePreloadAmount * context.height(1),
+        initialScrollIndex: _readerController.getPageIndex(),
+        physics: const ClampingScrollPhysics(),
+        onLongPressData: onLongPress,
+        onFailedToLoadImage: (_) {},
+        backgroundColor: backgroundColor,
+        isDoublePageMode: _pageMode == PageMode.doublePage,
+        photoViewController: _photoViewController,
+        photoViewScaleStateController: _photoViewScaleStateController,
+        scalePosition: _scalePosition,
+        onScaleEnd: onScaleEnd,
+        onDoubleTapDown: _toggleScale,
+        onDoubleTap: () {},
+        isScrolling: _isScrolling,
+        webtoonSidePadding: ref.watch(webtoonSidePaddingStateProvider),
+      );
+    }
+
+    return ImageViewContinuous(
+      pages: pages,
+      itemScrollController: _itemScrollController,
+      scrollOffsetController: _pageOffsetController,
+      itemPositionsListener: _itemPositionsListener,
+      scrollDirection: Axis.horizontal,
+      minCacheExtent: pagePreloadAmount * context.width(1),
+      initialScrollIndex: _readerController.getPageIndex(),
+      physics: const ClampingScrollPhysics(),
+      onLongPressData: onLongPress,
+      onFailedToLoadImage: (_) {},
+      backgroundColor: backgroundColor,
+      isDoublePageMode: false,
+      isHorizontalContinuous: true,
+      photoViewController: _photoViewController,
+      photoViewScaleStateController: _photoViewScaleStateController,
+      scalePosition: _scalePosition,
+      onScaleEnd: onScaleEnd,
+      onDoubleTapDown: _toggleScale,
+      onDoubleTap: () {},
+      layoutPolicy: ContinuousReaderLayoutPolicy.horizontal(
+        showPageGaps: ref.watch(showPageGapsStateProvider),
+      ),
+      reverse: _isReverseHorizontal,
+      isScrolling: _isScrolling,
     );
   }
 
@@ -1173,25 +1223,18 @@ class _MangaChapterPageGalleryState
     if (needsReload) {
       final isLocalArchive = (currentChapter.archivePath ?? '').isNotEmpty;
       final storageProvider = StorageProvider();
-      final mangaDirectory = await storageProvider.getMangaMainDirectory(
-        currentChapter,
-      );
+      final mangaDirectory = await storageProvider.getMangaMainDirectory(currentChapter);
       final archivePath = isLocalArchive
           ? currentChapter.archivePath
-          : (mangaDirectory != null
-                ? p.join(mangaDirectory.path, "${currentChapter.name}.cbz")
-                : null);
+          : (mangaDirectory != null ? p.join(mangaDirectory.path, "${currentChapter.name}.cbz") : null);
 
       if (archivePath != null && await File(archivePath).exists()) {
         try {
-          final local = await ref.read(
-            getArchiveDataFromFileProvider(archivePath).future,
-          );
+          final local = await ref.read(getArchiveDataFromFileProvider(archivePath).future);
           final images = local.images ?? [];
           int imgIdx = 0;
           for (final page in pages) {
-            if (page.chapter?.id == currentChapter.id &&
-                !page.isTransitionPage) {
+            if (page.chapter?.id == currentChapter.id && !page.isTransitionPage) {
               if (imgIdx < images.length) {
                 page.archiveImage = images[imgIdx].image;
               }
@@ -1240,7 +1283,11 @@ class _MangaChapterPageGalleryState
       }
     }
 
-    await Future.wait([worker(), worker(), worker()]);
+    await Future.wait([
+      worker(),
+      worker(),
+      worker(),
+    ]);
   }
 
   Future<void> _onPageChanged(int index) async {

--- a/lib/modules/manga/reader/services/page_navigation_service.dart
+++ b/lib/modules/manga/reader/services/page_navigation_service.dart
@@ -30,7 +30,7 @@ class PageNavigationService {
   }) {
     if (index < 0) return;
 
-    if (readerMode.isContinuous) {
+    if (readerMode.usesContinuousScroller) {
       _navigateContinuous(index, animate);
     } else {
       _navigatePaged(index, animate);
@@ -70,7 +70,7 @@ class PageNavigationService {
   void jumpToPage({required int index, required ReaderMode readerMode}) {
     if (index < 0) return;
 
-    if (readerMode.isContinuous) {
+    if (readerMode.usesContinuousScroller) {
       itemScrollController.jumpTo(index: index);
     } else {
       if (extendedController.hasClients) {

--- a/lib/modules/manga/reader/widgets/continuous_image_width.dart
+++ b/lib/modules/manga/reader/widgets/continuous_image_width.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ContinuousImageWidth extends StatelessWidget {
+  final bool fillAvailableWidth;
+  final Widget child;
+
+  const ContinuousImageWidth({
+    super.key,
+    required this.fillAvailableWidth,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!fillAvailableWidth) return child;
+    return SizedBox(width: double.infinity, child: child);
+  }
+}

--- a/lib/modules/manga/reader/widgets/reader_settings_modal.dart
+++ b/lib/modules/manga/reader/widgets/reader_settings_modal.dart
@@ -199,8 +199,8 @@ class _ReadingModeTab extends ConsumerWidget {
               },
             ),
 
-            // Show Page Gaps (only for continuous modes)
-            if (readerMode.isContinuous)
+            // Show Page Gaps (only for supported continuous modes)
+            if (readerMode.supportsPageGaps)
               SwitchListTile(
                 value: showPageGaps,
                 title: Text(
@@ -217,8 +217,8 @@ class _ReadingModeTab extends ConsumerWidget {
                 },
               ),
 
-            // Webtoon Side Padding (only for continuous modes)
-            if (readerMode.isContinuous)
+            // Webtoon Side Padding (Webtoon only)
+            if (readerMode.supportsWebtoonSidePadding)
               ListTile(
                 title: Text(
                   '${l10n.webtoon_side_padding}: $webtoonSidePadding%',
@@ -243,7 +243,7 @@ class _ReadingModeTab extends ConsumerWidget {
               ),
 
             // Auto-scroll (only for continuous modes)
-            if (readerMode.isContinuous)
+            if (readerMode.usesContinuousScroller)
               ValueListenableBuilder(
                 valueListenable: autoScrollPage,
                 builder: (context, valueT, child) {

--- a/test/modules/manga/reader/continuous_image_width_test.dart
+++ b/test/modules/manga/reader/continuous_image_width_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/manga/reader/widgets/continuous_image_width.dart';
+
+void main() {
+  testWidgets('fills available width only when requested', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1200, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    Future<double> pumpWidth(bool fillAvailableWidth) async {
+      const imageKey = Key('image');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                ContinuousImageWidth(
+                  fillAvailableWidth: fillAvailableWidth,
+                  child: const SizedBox(key: imageKey, width: 720, height: 100),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      return tester.getSize(find.byKey(imageKey)).width;
+    }
+
+    expect(await pumpWidth(false), 720);
+    expect(await pumpWidth(true), 1200);
+  });
+}

--- a/test/modules/manga/reader/continuous_reader_entry_widget_test.dart
+++ b/test/modules/manga/reader/continuous_reader_entry_widget_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/modules/manga/reader/image_view_vertical_continuous.dart';
+import 'package:mangayomi/modules/manga/reader/image_view_webtoon.dart';
+import 'package:photo_view/photo_view.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+void main() {
+  test('Vertical Continuous injects Vertical layout policy', () {
+    final photoController = PhotoViewController();
+    final scaleController = PhotoViewScaleStateController();
+    final scrolling = ValueNotifier(false);
+    addTearDown(photoController.dispose);
+    addTearDown(scaleController.dispose);
+    addTearDown(scrolling.dispose);
+
+    final reader = ImageViewVerticalContinuous(
+      pages: const [],
+      itemScrollController: ItemScrollController(),
+      scrollOffsetController: ScrollOffsetController(),
+      itemPositionsListener: ItemPositionsListener.create(),
+      minCacheExtent: 800,
+      initialScrollIndex: 0,
+      physics: const ClampingScrollPhysics(),
+      onLongPressData: (_) {},
+      onFailedToLoadImage: (_) {},
+      backgroundColor: BackgroundColor.black,
+      isDoublePageMode: false,
+      photoViewController: photoController,
+      photoViewScaleStateController: scaleController,
+      scalePosition: Alignment.center,
+      onScaleEnd: (_) {},
+      onDoubleTapDown: (_) {},
+      onDoubleTap: () {},
+      isScrolling: scrolling,
+      scaleType: ScaleType.fitWidth,
+      showPageGaps: true,
+    );
+
+    expect(reader.scrollDirection, Axis.vertical);
+    expect(reader.layoutPolicy.fillAvailableWidth, isTrue);
+    expect(reader.layoutPolicy.sidePaddingPercent, 0);
+    expect(reader.layoutPolicy.showPageGaps, isTrue);
+  });
+
+  test('Webtoon injects Webtoon-only padding and gap policy', () {
+    final photoController = PhotoViewController();
+    final scaleController = PhotoViewScaleStateController();
+    final scrolling = ValueNotifier(false);
+    addTearDown(photoController.dispose);
+    addTearDown(scaleController.dispose);
+    addTearDown(scrolling.dispose);
+
+    final reader = ImageViewWebtoon(
+      pages: const [],
+      itemScrollController: ItemScrollController(),
+      scrollOffsetController: ScrollOffsetController(),
+      itemPositionsListener: ItemPositionsListener.create(),
+      minCacheExtent: 800,
+      initialScrollIndex: 0,
+      physics: const ClampingScrollPhysics(),
+      onLongPressData: (_) {},
+      onFailedToLoadImage: (_) {},
+      backgroundColor: BackgroundColor.black,
+      isDoublePageMode: false,
+      photoViewController: photoController,
+      photoViewScaleStateController: scaleController,
+      scalePosition: Alignment.center,
+      onScaleEnd: (_) {},
+      onDoubleTapDown: (_) {},
+      onDoubleTap: () {},
+      isScrolling: scrolling,
+      webtoonSidePadding: 16,
+    );
+
+    expect(reader.scrollDirection, Axis.vertical);
+    expect(reader.layoutPolicy.fillAvailableWidth, isFalse);
+    expect(reader.layoutPolicy.sidePaddingPercent, 16);
+    expect(reader.layoutPolicy.showPageGaps, isFalse);
+  });
+}

--- a/test/modules/manga/reader/continuous_reader_layout_policy_test.dart
+++ b/test/modules/manga/reader/continuous_reader_layout_policy_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/modules/manga/reader/continuous_reader_layout_policy.dart';
+
+void main() {
+  group('ContinuousReaderLayoutPolicy', () {
+    test('Vertical Continuous inherits Fit Width without Webtoon padding', () {
+      const policy = ContinuousReaderLayoutPolicy.verticalContinuous(
+        scaleType: ScaleType.fitWidth,
+        showPageGaps: true,
+      );
+
+      expect(policy.fillAvailableWidth, isTrue);
+      expect(policy.sidePaddingPercent, 0);
+      expect(policy.showPageGaps, isTrue);
+    });
+
+    test('Vertical Continuous preserves intrinsic width for other scales', () {
+      const policy = ContinuousReaderLayoutPolicy.verticalContinuous(
+        scaleType: ScaleType.fitScreen,
+        showPageGaps: false,
+      );
+
+      expect(policy.fillAvailableWidth, isFalse);
+      expect(policy.sidePaddingPercent, 0);
+      expect(policy.showPageGaps, isFalse);
+    });
+
+    test('Webtoon keeps intrinsic sizing, side padding, and no gaps', () {
+      const policy = ContinuousReaderLayoutPolicy.webtoon(
+        sidePaddingPercent: 12,
+      );
+
+      expect(policy.fillAvailableWidth, isFalse);
+      expect(policy.sidePaddingPercent, 12);
+      expect(policy.showPageGaps, isFalse);
+    });
+
+    test('Horizontal Continuous keeps its existing gap policy', () {
+      const policy = ContinuousReaderLayoutPolicy.horizontal(
+        showPageGaps: true,
+      );
+
+      expect(policy.fillAvailableWidth, isFalse);
+      expect(policy.sidePaddingPercent, 0);
+      expect(policy.showPageGaps, isTrue);
+    });
+  });
+}

--- a/test/modules/manga/reader/reader_mode_extension_test.dart
+++ b/test/modules/manga/reader/reader_mode_extension_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/models/settings.dart';
+
+void main() {
+  group('ReaderMode capabilities', () {
+    test('keeps Vertical Continuous and Webtoon concrete modes separate', () {
+      expect(ReaderMode.verticalContinuous.isVerticalContinuous, isTrue);
+      expect(ReaderMode.webtoon.isVerticalContinuous, isFalse);
+      expect(ReaderMode.webtoon.isWebtoon, isTrue);
+      expect(ReaderMode.verticalContinuous.isWebtoon, isFalse);
+    });
+
+    test('shares only continuous scrolling capabilities', () {
+      expect(ReaderMode.verticalContinuous.usesContinuousScroller, isTrue);
+      expect(ReaderMode.webtoon.usesContinuousScroller, isTrue);
+      expect(ReaderMode.horizontalContinuous.usesContinuousScroller, isTrue);
+      expect(ReaderMode.vertical.usesContinuousScroller, isFalse);
+
+      expect(
+        ReaderMode.verticalContinuous.usesVerticalContinuousScroller,
+        isTrue,
+      );
+      expect(ReaderMode.webtoon.usesVerticalContinuousScroller, isTrue);
+      expect(
+        ReaderMode.horizontalContinuous.usesVerticalContinuousScroller,
+        isFalse,
+      );
+    });
+
+    test('exposes mode-specific settings capabilities', () {
+      expect(ReaderMode.verticalContinuous.supportsPageGaps, isTrue);
+      expect(ReaderMode.horizontalContinuous.supportsPageGaps, isTrue);
+      expect(ReaderMode.webtoon.supportsPageGaps, isFalse);
+
+      expect(ReaderMode.webtoon.supportsWebtoonSidePadding, isTrue);
+      expect(ReaderMode.verticalContinuous.supportsWebtoonSidePadding, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- separate Vertical Continuous layout policy from Webtoon
- make Fit Width fill the available width only in Vertical Continuous
- limit Webtoon side padding and page-gap behavior to their intended modes

## Context
Follow-up to #608: the closing fix updated paged readers, while Vertical Continuous still used intrinsic image width through the shared Webtoon renderer.

Vertical Continuous now keeps the shared continuous scrolling engine, navigation, preload, and read-progress behavior, but uses Vertical-specific sizing and settings. Webtoon keeps its existing intrinsic sizing, side padding, and gapless layout.

## Validation
- 10 focused reader mode, layout policy, entry-widget, and width-constraint tests
- scoped Flutter analyzer for `lib/models/settings.dart`, `lib/modules/manga/reader`, and `test/modules/manga/reader`
- `git diff --check`

## Known upstream baseline
- `test/widget_test.dart` already fails on `main` because `MyApp` is pumped without a `ProviderScope`; this PR does not modify that unrelated template test.
- repository-wide `flutter analyze` reports pre-existing missing-package errors under `rust_builder/cargokit/build_tool`; the changed scope analyzes cleanly.