### PR TITLE
feat(android-tv): Android TV support with d-pad UI, TV home and player (#729)

### DIFF
--- a/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/kodjodevf/mangayomi/MainActivity.kt
@@ -7,7 +7,11 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.embedding.android.FlutterFragmentActivity
 import androidx.core.content.FileProvider
+import android.app.UiModeManager
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.net.Uri
 import java.io.File
@@ -55,6 +59,33 @@ class MainActivity: FlutterFragmentActivity() {
                 }
             }
         }
+
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.kodjodevf.mangayomi.device",
+            StandardMethodCodec.INSTANCE
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "isTv" -> {
+                    result.success(isTvDevice())
+                }
+                else -> {
+                    result.notImplemented()
+                }
+            }
+        }
+    }
+
+    // Reports whether this is an Android TV / leanback device. Used by the
+    // Dart side to branch the UI on form factor (see #729). Kept conservative
+    // so a phone is never misdetected as a TV: a phone has neither the
+    // television UI mode nor the leanback feature.
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        if (uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true
+        }
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     }
 
     private fun installApk(filePath: String?) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -92,6 +92,9 @@ void main(List<String> args) async {
 
       MediaKit.ensureInitialized();
       await RustLib.init();
+      // Detect Android TV / leanback so the UI can branch on form factor.
+      // No-op on other platforms. See #729.
+      await initIsTv();
       await getIsolateService.start();
       await ffiImageDecoder.start();
       if (!isMobile) {

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -384,6 +384,13 @@ class Settings {
   bool? webtoonDoubleTapZoomEnabled;
   int? readerHideThreshold;
 
+  // Android TV preferences (null = follow the default). See #729.
+  bool? autoPlayNextEpisode;
+  bool? tvAnimeOnlyOverride;
+  bool? tvPlayerStyle;
+  bool? tvHomeStyle;
+  bool? tvHomeGenreRows;
+
   Settings({
     this.id = 227,
     this.updatedAt = 0,
@@ -568,6 +575,11 @@ class Settings {
     this.webtoonDisableZoomOut = false,
     this.webtoonDoubleTapZoomEnabled = true,
     this.readerHideThreshold = 1,
+    this.autoPlayNextEpisode,
+    this.tvAnimeOnlyOverride,
+    this.tvPlayerStyle,
+    this.tvHomeStyle,
+    this.tvHomeGenreRows,
   });
 
   Settings.fromJson(Map<String, dynamic> json) {
@@ -874,6 +886,11 @@ class Settings {
     webtoonDisableZoomOut = json['webtoonDisableZoomOut'];
     webtoonDoubleTapZoomEnabled = json['webtoonDoubleTapZoomEnabled'];
     readerHideThreshold = json['readerHideThreshold'];
+    autoPlayNextEpisode = json['autoPlayNextEpisode'];
+    tvAnimeOnlyOverride = json['tvAnimeOnlyOverride'];
+    tvPlayerStyle = json['tvPlayerStyle'];
+    tvHomeStyle = json['tvHomeStyle'];
+    tvHomeGenreRows = json['tvHomeGenreRows'];
   }
 
   Map<String, dynamic> toJson() => {
@@ -1082,6 +1099,11 @@ class Settings {
     'webtoonDisableZoomOut': webtoonDisableZoomOut,
     'webtoonDoubleTapZoomEnabled': webtoonDoubleTapZoomEnabled,
     'readerHideThreshold': readerHideThreshold,
+    'autoPlayNextEpisode': autoPlayNextEpisode,
+    'tvAnimeOnlyOverride': tvAnimeOnlyOverride,
+    'tvPlayerStyle': tvPlayerStyle,
+    'tvHomeStyle': tvHomeStyle,
+    'tvHomeGenreRows': tvHomeGenreRows,
   };
 }
 

--- a/lib/models/settings.g.dart
+++ b/lib/models/settings.g.dart
@@ -118,896 +118,921 @@ const SettingsSchema = CollectionSchema(
       name: r'autoExtensionsUpdates',
       type: IsarType.bool,
     ),
-    r'autoReadDuplicateChapters': PropertySchema(
+    r'autoPlayNextEpisode': PropertySchema(
       id: 19,
+      name: r'autoPlayNextEpisode',
+      type: IsarType.bool,
+    ),
+    r'autoReadDuplicateChapters': PropertySchema(
+      id: 20,
       name: r'autoReadDuplicateChapters',
       type: IsarType.bool,
     ),
     r'autoScrollPages': PropertySchema(
-      id: 20,
+      id: 21,
       name: r'autoScrollPages',
       type: IsarType.objectList,
 
       target: r'AutoScrollPages',
     ),
     r'automaticBackground': PropertySchema(
-      id: 21,
+      id: 22,
       name: r'automaticBackground',
       type: IsarType.bool,
     ),
     r'backgroundColor': PropertySchema(
-      id: 22,
+      id: 23,
       name: r'backgroundColor',
       type: IsarType.byte,
       enumMap: _SettingsbackgroundColorEnumValueMap,
     ),
     r'backupCompressionLevel': PropertySchema(
-      id: 23,
+      id: 24,
       name: r'backupCompressionLevel',
       type: IsarType.long,
     ),
     r'backupFrequency': PropertySchema(
-      id: 24,
+      id: 25,
       name: r'backupFrequency',
       type: IsarType.long,
     ),
     r'backupListOptions': PropertySchema(
-      id: 25,
+      id: 26,
       name: r'backupListOptions',
       type: IsarType.longList,
     ),
     r'btServerAddress': PropertySchema(
-      id: 26,
+      id: 27,
       name: r'btServerAddress',
       type: IsarType.string,
     ),
     r'btServerPort': PropertySchema(
-      id: 27,
+      id: 28,
       name: r'btServerPort',
       type: IsarType.long,
     ),
     r'chapterFilterBookmarkedList': PropertySchema(
-      id: 28,
+      id: 29,
       name: r'chapterFilterBookmarkedList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterBookmarked',
     ),
     r'chapterFilterDownloadedList': PropertySchema(
-      id: 29,
+      id: 30,
       name: r'chapterFilterDownloadedList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterDownloaded',
     ),
     r'chapterFilterUnreadList': PropertySchema(
-      id: 30,
+      id: 31,
       name: r'chapterFilterUnreadList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterUnread',
     ),
     r'chapterPageIndexList': PropertySchema(
-      id: 31,
+      id: 32,
       name: r'chapterPageIndexList',
       type: IsarType.objectList,
 
       target: r'ChapterPageIndex',
     ),
     r'chapterPageUrlsList': PropertySchema(
-      id: 32,
+      id: 33,
       name: r'chapterPageUrlsList',
       type: IsarType.objectList,
 
       target: r'ChapterPageurls',
     ),
     r'checkForAppUpdates': PropertySchema(
-      id: 33,
+      id: 34,
       name: r'checkForAppUpdates',
       type: IsarType.bool,
     ),
     r'checkForExtensionUpdates': PropertySchema(
-      id: 34,
+      id: 35,
       name: r'checkForExtensionUpdates',
       type: IsarType.bool,
     ),
     r'clearChapterCacheOnAppLaunch': PropertySchema(
-      id: 35,
+      id: 36,
       name: r'clearChapterCacheOnAppLaunch',
       type: IsarType.bool,
     ),
     r'colorFilterBlendMode': PropertySchema(
-      id: 36,
+      id: 37,
       name: r'colorFilterBlendMode',
       type: IsarType.byte,
       enumMap: _SettingscolorFilterBlendModeEnumValueMap,
     ),
     r'concurrentDownloads': PropertySchema(
-      id: 37,
+      id: 38,
       name: r'concurrentDownloads',
       type: IsarType.long,
     ),
     r'cookiesList': PropertySchema(
-      id: 38,
+      id: 39,
       name: r'cookiesList',
       type: IsarType.objectList,
 
       target: r'MCookie',
     ),
     r'cropBorders': PropertySchema(
-      id: 39,
+      id: 40,
       name: r'cropBorders',
       type: IsarType.bool,
     ),
     r'customColorFilter': PropertySchema(
-      id: 40,
+      id: 41,
       name: r'customColorFilter',
       type: IsarType.object,
 
       target: r'CustomColorFilter',
     ),
     r'customDns': PropertySchema(
-      id: 41,
+      id: 42,
       name: r'customDns',
       type: IsarType.string,
     ),
     r'dateFormat': PropertySchema(
-      id: 42,
+      id: 43,
       name: r'dateFormat',
       type: IsarType.string,
     ),
     r'debandingType': PropertySchema(
-      id: 43,
+      id: 44,
       name: r'debandingType',
       type: IsarType.byte,
       enumMap: _SettingsdebandingTypeEnumValueMap,
     ),
     r'defaultDoubleTapToSkipLength': PropertySchema(
-      id: 44,
+      id: 45,
       name: r'defaultDoubleTapToSkipLength',
       type: IsarType.long,
     ),
     r'defaultPlayBackSpeed': PropertySchema(
-      id: 45,
+      id: 46,
       name: r'defaultPlayBackSpeed',
       type: IsarType.double,
     ),
     r'defaultReaderMode': PropertySchema(
-      id: 46,
+      id: 47,
       name: r'defaultReaderMode',
       type: IsarType.byte,
       enumMap: _SettingsdefaultReaderModeEnumValueMap,
     ),
     r'defaultSkipIntroLength': PropertySchema(
-      id: 47,
+      id: 48,
       name: r'defaultSkipIntroLength',
       type: IsarType.long,
     ),
     r'defaultSubtitleLang': PropertySchema(
-      id: 48,
+      id: 49,
       name: r'defaultSubtitleLang',
       type: IsarType.object,
 
       target: r'L10nLocale',
     ),
     r'deleteDownloadAfterReading': PropertySchema(
-      id: 49,
+      id: 50,
       name: r'deleteDownloadAfterReading',
       type: IsarType.bool,
     ),
     r'disableSectionType': PropertySchema(
-      id: 50,
+      id: 51,
       name: r'disableSectionType',
       type: IsarType.byte,
       enumMap: _SettingsdisableSectionTypeEnumValueMap,
     ),
     r'displayType': PropertySchema(
-      id: 51,
+      id: 52,
       name: r'displayType',
       type: IsarType.byte,
       enumMap: _SettingsdisplayTypeEnumValueMap,
     ),
     r'doHEnabled': PropertySchema(
-      id: 52,
+      id: 53,
       name: r'doHEnabled',
       type: IsarType.bool,
     ),
     r'doHProviderId': PropertySchema(
-      id: 53,
+      id: 54,
       name: r'doHProviderId',
       type: IsarType.long,
     ),
     r'doubleTapAnimationSpeed': PropertySchema(
-      id: 54,
+      id: 55,
       name: r'doubleTapAnimationSpeed',
       type: IsarType.long,
     ),
     r'downloadLocation': PropertySchema(
-      id: 55,
+      id: 56,
       name: r'downloadLocation',
       type: IsarType.string,
     ),
     r'downloadOnlyOnWifi': PropertySchema(
-      id: 56,
+      id: 57,
       name: r'downloadOnlyOnWifi',
       type: IsarType.bool,
     ),
     r'downloadedOnlyMode': PropertySchema(
-      id: 57,
+      id: 58,
       name: r'downloadedOnlyMode',
       type: IsarType.bool,
     ),
     r'dualPageInvert': PropertySchema(
-      id: 58,
+      id: 59,
       name: r'dualPageInvert',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFit': PropertySchema(
-      id: 59,
+      id: 60,
       name: r'dualPageRotateToFit',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFitInvert': PropertySchema(
-      id: 60,
+      id: 61,
       name: r'dualPageRotateToFitInvert',
       type: IsarType.bool,
     ),
     r'enableAniSkip': PropertySchema(
-      id: 61,
+      id: 62,
       name: r'enableAniSkip',
       type: IsarType.bool,
     ),
     r'enableAudioPitchCorrection': PropertySchema(
-      id: 62,
+      id: 63,
       name: r'enableAudioPitchCorrection',
       type: IsarType.bool,
     ),
     r'enableAutoSkip': PropertySchema(
-      id: 63,
+      id: 64,
       name: r'enableAutoSkip',
       type: IsarType.bool,
     ),
     r'enableCustomColorFilter': PropertySchema(
-      id: 64,
+      id: 65,
       name: r'enableCustomColorFilter',
       type: IsarType.bool,
     ),
     r'enableDiscordRpc': PropertySchema(
-      id: 65,
+      id: 66,
       name: r'enableDiscordRpc',
       type: IsarType.bool,
     ),
     r'enableGpuNext': PropertySchema(
-      id: 66,
+      id: 67,
       name: r'enableGpuNext',
       type: IsarType.bool,
     ),
     r'enableHardwareAcceleration': PropertySchema(
-      id: 67,
+      id: 68,
       name: r'enableHardwareAcceleration',
       type: IsarType.bool,
     ),
     r'enableLogs': PropertySchema(
-      id: 68,
+      id: 69,
       name: r'enableLogs',
       type: IsarType.bool,
     ),
     r'extensionServerPath': PropertySchema(
-      id: 69,
+      id: 70,
       name: r'extensionServerPath',
       type: IsarType.string,
     ),
     r'filterScanlatorList': PropertySchema(
-      id: 70,
+      id: 71,
       name: r'filterScanlatorList',
       type: IsarType.objectList,
 
       target: r'FilterScanlator',
     ),
     r'flashColor': PropertySchema(
-      id: 71,
+      id: 72,
       name: r'flashColor',
       type: IsarType.long,
     ),
     r'flashDuration': PropertySchema(
-      id: 72,
+      id: 73,
       name: r'flashDuration',
       type: IsarType.long,
     ),
     r'flashInterval': PropertySchema(
-      id: 73,
+      id: 74,
       name: r'flashInterval',
       type: IsarType.long,
     ),
     r'flashOnPageChange': PropertySchema(
-      id: 74,
+      id: 75,
       name: r'flashOnPageChange',
       type: IsarType.bool,
     ),
     r'flexColorSchemeBlendLevel': PropertySchema(
-      id: 75,
+      id: 76,
       name: r'flexColorSchemeBlendLevel',
       type: IsarType.double,
     ),
     r'flexSchemeColorIndex': PropertySchema(
-      id: 76,
+      id: 77,
       name: r'flexSchemeColorIndex',
       type: IsarType.long,
     ),
     r'followSystemTheme': PropertySchema(
-      id: 77,
+      id: 78,
       name: r'followSystemTheme',
       type: IsarType.bool,
     ),
     r'forceLandscapePlayer': PropertySchema(
-      id: 78,
+      id: 79,
       name: r'forceLandscapePlayer',
       type: IsarType.bool,
     ),
     r'fullScreenPlayer': PropertySchema(
-      id: 79,
+      id: 80,
       name: r'fullScreenPlayer',
       type: IsarType.bool,
     ),
     r'fullScreenReader': PropertySchema(
-      id: 80,
+      id: 81,
       name: r'fullScreenReader',
       type: IsarType.bool,
     ),
     r'grayscale': PropertySchema(
-      id: 81,
+      id: 82,
       name: r'grayscale',
       type: IsarType.bool,
     ),
     r'hideDiscordRpcInIncognito': PropertySchema(
-      id: 82,
+      id: 83,
       name: r'hideDiscordRpcInIncognito',
       type: IsarType.bool,
     ),
     r'hideItems': PropertySchema(
-      id: 83,
+      id: 84,
       name: r'hideItems',
       type: IsarType.stringList,
     ),
     r'hwdecMode': PropertySchema(
-      id: 84,
+      id: 85,
       name: r'hwdecMode',
       type: IsarType.string,
     ),
     r'incognitoMode': PropertySchema(
-      id: 85,
+      id: 86,
       name: r'incognitoMode',
       type: IsarType.bool,
     ),
     r'invertColors': PropertySchema(
-      id: 86,
+      id: 87,
       name: r'invertColors',
       type: IsarType.bool,
     ),
-    r'jrePath': PropertySchema(id: 87, name: r'jrePath', type: IsarType.string),
+    r'jrePath': PropertySchema(id: 88, name: r'jrePath', type: IsarType.string),
     r'keepScreenOnReader': PropertySchema(
-      id: 88,
+      id: 89,
       name: r'keepScreenOnReader',
       type: IsarType.bool,
     ),
     r'landscapeZoom': PropertySchema(
-      id: 89,
+      id: 90,
       name: r'landscapeZoom',
       type: IsarType.bool,
     ),
     r'lastTrackerLibraryLocation': PropertySchema(
-      id: 90,
+      id: 91,
       name: r'lastTrackerLibraryLocation',
       type: IsarType.string,
     ),
     r'libraryDownloadedChapters': PropertySchema(
-      id: 91,
+      id: 92,
       name: r'libraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'libraryFilterAnimeBookMarkedType': PropertySchema(
-      id: 92,
+      id: 93,
       name: r'libraryFilterAnimeBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeCompletedType': PropertySchema(
-      id: 93,
+      id: 94,
       name: r'libraryFilterAnimeCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeDownloadType': PropertySchema(
-      id: 94,
+      id: 95,
       name: r'libraryFilterAnimeDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeStartedType': PropertySchema(
-      id: 95,
+      id: 96,
       name: r'libraryFilterAnimeStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeTrackingType': PropertySchema(
-      id: 96,
+      id: 97,
       name: r'libraryFilterAnimeTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeUnreadType': PropertySchema(
-      id: 97,
+      id: 98,
       name: r'libraryFilterAnimeUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasBookMarkedType': PropertySchema(
-      id: 98,
+      id: 99,
       name: r'libraryFilterMangasBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasCompletedType': PropertySchema(
-      id: 99,
+      id: 100,
       name: r'libraryFilterMangasCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasDownloadType': PropertySchema(
-      id: 100,
+      id: 101,
       name: r'libraryFilterMangasDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasStartedType': PropertySchema(
-      id: 101,
+      id: 102,
       name: r'libraryFilterMangasStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasTrackingType': PropertySchema(
-      id: 102,
+      id: 103,
       name: r'libraryFilterMangasTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasUnreadType': PropertySchema(
-      id: 103,
+      id: 104,
       name: r'libraryFilterMangasUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelBookMarkedType': PropertySchema(
-      id: 104,
+      id: 105,
       name: r'libraryFilterNovelBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelCompletedType': PropertySchema(
-      id: 105,
+      id: 106,
       name: r'libraryFilterNovelCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelDownloadType': PropertySchema(
-      id: 106,
+      id: 107,
       name: r'libraryFilterNovelDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelStartedType': PropertySchema(
-      id: 107,
+      id: 108,
       name: r'libraryFilterNovelStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelTrackingType': PropertySchema(
-      id: 108,
+      id: 109,
       name: r'libraryFilterNovelTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelUnreadType': PropertySchema(
-      id: 109,
+      id: 110,
       name: r'libraryFilterNovelUnreadType',
       type: IsarType.long,
     ),
     r'libraryLocalSource': PropertySchema(
-      id: 110,
+      id: 111,
       name: r'libraryLocalSource',
       type: IsarType.bool,
     ),
     r'libraryShowCategoryTabs': PropertySchema(
-      id: 111,
+      id: 112,
       name: r'libraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'libraryShowContinueReadingButton': PropertySchema(
-      id: 112,
+      id: 113,
       name: r'libraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'libraryShowLanguage': PropertySchema(
-      id: 113,
+      id: 114,
       name: r'libraryShowLanguage',
       type: IsarType.bool,
     ),
     r'libraryShowNumbersOfItems': PropertySchema(
-      id: 114,
+      id: 115,
       name: r'libraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'localFolders': PropertySchema(
-      id: 115,
+      id: 116,
       name: r'localFolders',
       type: IsarType.stringList,
     ),
     r'locale': PropertySchema(
-      id: 116,
+      id: 117,
       name: r'locale',
       type: IsarType.object,
 
       target: r'L10nLocale',
     ),
     r'mangaExtensionsRepo': PropertySchema(
-      id: 117,
+      id: 118,
       name: r'mangaExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'mangaGridSize': PropertySchema(
-      id: 118,
+      id: 119,
       name: r'mangaGridSize',
       type: IsarType.long,
     ),
     r'mangaHomeDisplayType': PropertySchema(
-      id: 119,
+      id: 120,
       name: r'mangaHomeDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsmangaHomeDisplayTypeEnumValueMap,
     ),
     r'markEpisodeAsSeenType': PropertySchema(
-      id: 120,
+      id: 121,
       name: r'markEpisodeAsSeenType',
       type: IsarType.long,
     ),
     r'mergeLibraryNavMobile': PropertySchema(
-      id: 121,
+      id: 122,
       name: r'mergeLibraryNavMobile',
       type: IsarType.bool,
     ),
     r'navigateToPan': PropertySchema(
-      id: 122,
+      id: 123,
       name: r'navigateToPan',
       type: IsarType.bool,
     ),
     r'navigationOrder': PropertySchema(
-      id: 123,
+      id: 124,
       name: r'navigationOrder',
       type: IsarType.stringList,
     ),
     r'novelDisplayType': PropertySchema(
-      id: 124,
+      id: 125,
       name: r'novelDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsnovelDisplayTypeEnumValueMap,
     ),
     r'novelExtensionsRepo': PropertySchema(
-      id: 125,
+      id: 126,
       name: r'novelExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'novelFontSize': PropertySchema(
-      id: 126,
+      id: 127,
       name: r'novelFontSize',
       type: IsarType.long,
     ),
     r'novelGridSize': PropertySchema(
-      id: 127,
+      id: 128,
       name: r'novelGridSize',
       type: IsarType.long,
     ),
     r'novelLibraryDownloadedChapters': PropertySchema(
-      id: 128,
+      id: 129,
       name: r'novelLibraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'novelLibraryLocalSource': PropertySchema(
-      id: 129,
+      id: 130,
       name: r'novelLibraryLocalSource',
       type: IsarType.bool,
     ),
     r'novelLibraryShowCategoryTabs': PropertySchema(
-      id: 130,
+      id: 131,
       name: r'novelLibraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'novelLibraryShowContinueReadingButton': PropertySchema(
-      id: 131,
+      id: 132,
       name: r'novelLibraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'novelLibraryShowLanguage': PropertySchema(
-      id: 132,
+      id: 133,
       name: r'novelLibraryShowLanguage',
       type: IsarType.bool,
     ),
     r'novelLibraryShowNumbersOfItems': PropertySchema(
-      id: 133,
+      id: 134,
       name: r'novelLibraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'novelReaderLineHeight': PropertySchema(
-      id: 134,
+      id: 135,
       name: r'novelReaderLineHeight',
       type: IsarType.double,
     ),
     r'novelReaderPadding': PropertySchema(
-      id: 135,
+      id: 136,
       name: r'novelReaderPadding',
       type: IsarType.long,
     ),
     r'novelReaderTextColor': PropertySchema(
-      id: 136,
+      id: 137,
       name: r'novelReaderTextColor',
       type: IsarType.string,
     ),
     r'novelReaderTheme': PropertySchema(
-      id: 137,
+      id: 138,
       name: r'novelReaderTheme',
       type: IsarType.string,
     ),
     r'novelRemoveExtraParagraphSpacing': PropertySchema(
-      id: 138,
+      id: 139,
       name: r'novelRemoveExtraParagraphSpacing',
       type: IsarType.bool,
     ),
     r'novelShowScrollPercentage': PropertySchema(
-      id: 139,
+      id: 140,
       name: r'novelShowScrollPercentage',
       type: IsarType.bool,
     ),
     r'novelTapToScroll': PropertySchema(
-      id: 140,
+      id: 141,
       name: r'novelTapToScroll',
       type: IsarType.bool,
     ),
     r'novelTextAlign': PropertySchema(
-      id: 141,
+      id: 142,
       name: r'novelTextAlign',
       type: IsarType.byte,
       enumMap: _SettingsnovelTextAlignEnumValueMap,
     ),
     r'onlyIncludePinnedSources': PropertySchema(
-      id: 142,
+      id: 143,
       name: r'onlyIncludePinnedSources',
       type: IsarType.bool,
     ),
     r'pagePreloadAmount': PropertySchema(
-      id: 143,
+      id: 144,
       name: r'pagePreloadAmount',
       type: IsarType.long,
     ),
     r'personalPageModeList': PropertySchema(
-      id: 144,
+      id: 145,
       name: r'personalPageModeList',
       type: IsarType.objectList,
 
       target: r'PersonalPageMode',
     ),
     r'personalReaderModeList': PropertySchema(
-      id: 145,
+      id: 146,
       name: r'personalReaderModeList',
       type: IsarType.objectList,
 
       target: r'PersonalReaderMode',
     ),
     r'playerSubtitleSettings': PropertySchema(
-      id: 146,
+      id: 147,
       name: r'playerSubtitleSettings',
       type: IsarType.object,
 
       target: r'PlayerSubtitleSettings',
     ),
     r'pureBlackDarkMode': PropertySchema(
-      id: 147,
+      id: 148,
       name: r'pureBlackDarkMode',
       type: IsarType.bool,
     ),
     r'readerBrightness': PropertySchema(
-      id: 148,
+      id: 149,
       name: r'readerBrightness',
       type: IsarType.double,
     ),
     r'readerContrast': PropertySchema(
-      id: 149,
+      id: 150,
       name: r'readerContrast',
       type: IsarType.double,
     ),
     r'readerHideThreshold': PropertySchema(
-      id: 150,
+      id: 151,
       name: r'readerHideThreshold',
       type: IsarType.long,
     ),
     r'readerNavigationLayout': PropertySchema(
-      id: 151,
+      id: 152,
       name: r'readerNavigationLayout',
       type: IsarType.long,
     ),
     r'readerSaturation': PropertySchema(
-      id: 152,
+      id: 153,
       name: r'readerSaturation',
       type: IsarType.double,
     ),
     r'relativeTimesTamps': PropertySchema(
-      id: 153,
+      id: 154,
       name: r'relativeTimesTamps',
       type: IsarType.long,
     ),
     r'rpcShowCoverImage': PropertySchema(
-      id: 154,
+      id: 155,
       name: r'rpcShowCoverImage',
       type: IsarType.bool,
     ),
     r'rpcShowReadingWatchingProgress': PropertySchema(
-      id: 155,
+      id: 156,
       name: r'rpcShowReadingWatchingProgress',
       type: IsarType.bool,
     ),
     r'rpcShowTitle': PropertySchema(
-      id: 156,
+      id: 157,
       name: r'rpcShowTitle',
       type: IsarType.bool,
     ),
     r'saveAsCBZArchive': PropertySchema(
-      id: 157,
+      id: 158,
       name: r'saveAsCBZArchive',
       type: IsarType.bool,
     ),
     r'scaleType': PropertySchema(
-      id: 158,
+      id: 159,
       name: r'scaleType',
       type: IsarType.byte,
       enumMap: _SettingsscaleTypeEnumValueMap,
     ),
     r'showNSFW': PropertySchema(
-      id: 159,
+      id: 160,
       name: r'showNSFW',
       type: IsarType.bool,
     ),
     r'showNavigationOverlayOnStart': PropertySchema(
-      id: 160,
+      id: 161,
       name: r'showNavigationOverlayOnStart',
       type: IsarType.bool,
     ),
     r'showPageGaps': PropertySchema(
-      id: 161,
+      id: 162,
       name: r'showPageGaps',
       type: IsarType.bool,
     ),
     r'showPagesNumber': PropertySchema(
-      id: 162,
+      id: 163,
       name: r'showPagesNumber',
       type: IsarType.bool,
     ),
     r'sortChapterList': PropertySchema(
-      id: 163,
+      id: 164,
       name: r'sortChapterList',
       type: IsarType.objectList,
 
       target: r'SortChapter',
     ),
     r'sortLibraryAnime': PropertySchema(
-      id: 164,
+      id: 165,
       name: r'sortLibraryAnime',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryManga': PropertySchema(
-      id: 165,
+      id: 166,
       name: r'sortLibraryManga',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryNovel': PropertySchema(
-      id: 166,
+      id: 167,
       name: r'sortLibraryNovel',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'splitWidePages': PropertySchema(
-      id: 167,
+      id: 168,
       name: r'splitWidePages',
       type: IsarType.bool,
     ),
     r'startDatebackup': PropertySchema(
-      id: 168,
+      id: 169,
       name: r'startDatebackup',
       type: IsarType.long,
     ),
     r'tappingInversion': PropertySchema(
-      id: 169,
+      id: 170,
       name: r'tappingInversion',
       type: IsarType.long,
     ),
     r'themeIsDark': PropertySchema(
-      id: 170,
+      id: 171,
       name: r'themeIsDark',
       type: IsarType.bool,
     ),
     r'ttsLanguage': PropertySchema(
-      id: 171,
+      id: 172,
       name: r'ttsLanguage',
       type: IsarType.string,
     ),
     r'ttsPitch': PropertySchema(
-      id: 172,
+      id: 173,
       name: r'ttsPitch',
       type: IsarType.double,
     ),
     r'ttsSpeechRate': PropertySchema(
-      id: 173,
+      id: 174,
       name: r'ttsSpeechRate',
       type: IsarType.double,
     ),
     r'ttsVoice': PropertySchema(
-      id: 174,
+      id: 175,
       name: r'ttsVoice',
       type: IsarType.string,
     ),
+    r'tvAnimeOnlyOverride': PropertySchema(
+      id: 176,
+      name: r'tvAnimeOnlyOverride',
+      type: IsarType.bool,
+    ),
+    r'tvHomeGenreRows': PropertySchema(
+      id: 177,
+      name: r'tvHomeGenreRows',
+      type: IsarType.bool,
+    ),
+    r'tvHomeStyle': PropertySchema(
+      id: 178,
+      name: r'tvHomeStyle',
+      type: IsarType.bool,
+    ),
+    r'tvPlayerStyle': PropertySchema(
+      id: 179,
+      name: r'tvPlayerStyle',
+      type: IsarType.bool,
+    ),
     r'updateErrorsList': PropertySchema(
-      id: 175,
+      id: 180,
       name: r'updateErrorsList',
       type: IsarType.objectList,
 
       target: r'UpdateError',
     ),
     r'updateProgressAfterReading': PropertySchema(
-      id: 176,
+      id: 181,
       name: r'updateProgressAfterReading',
       type: IsarType.bool,
     ),
     r'updatedAt': PropertySchema(
-      id: 177,
+      id: 182,
       name: r'updatedAt',
       type: IsarType.long,
     ),
     r'useLibass': PropertySchema(
-      id: 178,
+      id: 183,
       name: r'useLibass',
       type: IsarType.bool,
     ),
     r'useMpvConfig': PropertySchema(
-      id: 179,
+      id: 184,
       name: r'useMpvConfig',
       type: IsarType.bool,
     ),
     r'usePageTapZones': PropertySchema(
-      id: 180,
+      id: 185,
       name: r'usePageTapZones',
       type: IsarType.bool,
     ),
     r'useYUV420P': PropertySchema(
-      id: 181,
+      id: 186,
       name: r'useYUV420P',
       type: IsarType.bool,
     ),
     r'userAgent': PropertySchema(
-      id: 182,
+      id: 187,
       name: r'userAgent',
       type: IsarType.string,
     ),
     r'volumeBoostCap': PropertySchema(
-      id: 183,
+      id: 188,
       name: r'volumeBoostCap',
       type: IsarType.long,
     ),
     r'webtoonDisableZoomOut': PropertySchema(
-      id: 184,
+      id: 189,
       name: r'webtoonDisableZoomOut',
       type: IsarType.bool,
     ),
     r'webtoonDoubleTapZoomEnabled': PropertySchema(
-      id: 185,
+      id: 190,
       name: r'webtoonDoubleTapZoomEnabled',
       type: IsarType.bool,
     ),
     r'webtoonSidePadding': PropertySchema(
-      id: 186,
+      id: 191,
       name: r'webtoonSidePadding',
       type: IsarType.long,
     ),
     r'zoomStartPosition': PropertySchema(
-      id: 187,
+      id: 192,
       name: r'zoomStartPosition',
       type: IsarType.long,
     ),
@@ -1577,280 +1602,285 @@ void _settingsSerialize(
   writer.writeString(offsets[16], object.audioPreferredLanguages);
   writer.writeString(offsets[17], object.autoBackupLocation);
   writer.writeBool(offsets[18], object.autoExtensionsUpdates);
-  writer.writeBool(offsets[19], object.autoReadDuplicateChapters);
+  writer.writeBool(offsets[19], object.autoPlayNextEpisode);
+  writer.writeBool(offsets[20], object.autoReadDuplicateChapters);
   writer.writeObjectList<AutoScrollPages>(
-    offsets[20],
+    offsets[21],
     allOffsets,
     AutoScrollPagesSchema.serialize,
     object.autoScrollPages,
   );
-  writer.writeBool(offsets[21], object.automaticBackground);
-  writer.writeByte(offsets[22], object.backgroundColor.index);
-  writer.writeLong(offsets[23], object.backupCompressionLevel);
-  writer.writeLong(offsets[24], object.backupFrequency);
-  writer.writeLongList(offsets[25], object.backupListOptions);
-  writer.writeString(offsets[26], object.btServerAddress);
-  writer.writeLong(offsets[27], object.btServerPort);
+  writer.writeBool(offsets[22], object.automaticBackground);
+  writer.writeByte(offsets[23], object.backgroundColor.index);
+  writer.writeLong(offsets[24], object.backupCompressionLevel);
+  writer.writeLong(offsets[25], object.backupFrequency);
+  writer.writeLongList(offsets[26], object.backupListOptions);
+  writer.writeString(offsets[27], object.btServerAddress);
+  writer.writeLong(offsets[28], object.btServerPort);
   writer.writeObjectList<ChapterFilterBookmarked>(
-    offsets[28],
+    offsets[29],
     allOffsets,
     ChapterFilterBookmarkedSchema.serialize,
     object.chapterFilterBookmarkedList,
   );
   writer.writeObjectList<ChapterFilterDownloaded>(
-    offsets[29],
+    offsets[30],
     allOffsets,
     ChapterFilterDownloadedSchema.serialize,
     object.chapterFilterDownloadedList,
   );
   writer.writeObjectList<ChapterFilterUnread>(
-    offsets[30],
+    offsets[31],
     allOffsets,
     ChapterFilterUnreadSchema.serialize,
     object.chapterFilterUnreadList,
   );
   writer.writeObjectList<ChapterPageIndex>(
-    offsets[31],
+    offsets[32],
     allOffsets,
     ChapterPageIndexSchema.serialize,
     object.chapterPageIndexList,
   );
   writer.writeObjectList<ChapterPageurls>(
-    offsets[32],
+    offsets[33],
     allOffsets,
     ChapterPageurlsSchema.serialize,
     object.chapterPageUrlsList,
   );
-  writer.writeBool(offsets[33], object.checkForAppUpdates);
-  writer.writeBool(offsets[34], object.checkForExtensionUpdates);
-  writer.writeBool(offsets[35], object.clearChapterCacheOnAppLaunch);
-  writer.writeByte(offsets[36], object.colorFilterBlendMode.index);
-  writer.writeLong(offsets[37], object.concurrentDownloads);
+  writer.writeBool(offsets[34], object.checkForAppUpdates);
+  writer.writeBool(offsets[35], object.checkForExtensionUpdates);
+  writer.writeBool(offsets[36], object.clearChapterCacheOnAppLaunch);
+  writer.writeByte(offsets[37], object.colorFilterBlendMode.index);
+  writer.writeLong(offsets[38], object.concurrentDownloads);
   writer.writeObjectList<MCookie>(
-    offsets[38],
+    offsets[39],
     allOffsets,
     MCookieSchema.serialize,
     object.cookiesList,
   );
-  writer.writeBool(offsets[39], object.cropBorders);
+  writer.writeBool(offsets[40], object.cropBorders);
   writer.writeObject<CustomColorFilter>(
-    offsets[40],
+    offsets[41],
     allOffsets,
     CustomColorFilterSchema.serialize,
     object.customColorFilter,
   );
-  writer.writeString(offsets[41], object.customDns);
-  writer.writeString(offsets[42], object.dateFormat);
-  writer.writeByte(offsets[43], object.debandingType.index);
-  writer.writeLong(offsets[44], object.defaultDoubleTapToSkipLength);
-  writer.writeDouble(offsets[45], object.defaultPlayBackSpeed);
-  writer.writeByte(offsets[46], object.defaultReaderMode.index);
-  writer.writeLong(offsets[47], object.defaultSkipIntroLength);
+  writer.writeString(offsets[42], object.customDns);
+  writer.writeString(offsets[43], object.dateFormat);
+  writer.writeByte(offsets[44], object.debandingType.index);
+  writer.writeLong(offsets[45], object.defaultDoubleTapToSkipLength);
+  writer.writeDouble(offsets[46], object.defaultPlayBackSpeed);
+  writer.writeByte(offsets[47], object.defaultReaderMode.index);
+  writer.writeLong(offsets[48], object.defaultSkipIntroLength);
   writer.writeObject<L10nLocale>(
-    offsets[48],
+    offsets[49],
     allOffsets,
     L10nLocaleSchema.serialize,
     object.defaultSubtitleLang,
   );
-  writer.writeBool(offsets[49], object.deleteDownloadAfterReading);
-  writer.writeByte(offsets[50], object.disableSectionType.index);
-  writer.writeByte(offsets[51], object.displayType.index);
-  writer.writeBool(offsets[52], object.doHEnabled);
-  writer.writeLong(offsets[53], object.doHProviderId);
-  writer.writeLong(offsets[54], object.doubleTapAnimationSpeed);
-  writer.writeString(offsets[55], object.downloadLocation);
-  writer.writeBool(offsets[56], object.downloadOnlyOnWifi);
-  writer.writeBool(offsets[57], object.downloadedOnlyMode);
-  writer.writeBool(offsets[58], object.dualPageInvert);
-  writer.writeBool(offsets[59], object.dualPageRotateToFit);
-  writer.writeBool(offsets[60], object.dualPageRotateToFitInvert);
-  writer.writeBool(offsets[61], object.enableAniSkip);
-  writer.writeBool(offsets[62], object.enableAudioPitchCorrection);
-  writer.writeBool(offsets[63], object.enableAutoSkip);
-  writer.writeBool(offsets[64], object.enableCustomColorFilter);
-  writer.writeBool(offsets[65], object.enableDiscordRpc);
-  writer.writeBool(offsets[66], object.enableGpuNext);
-  writer.writeBool(offsets[67], object.enableHardwareAcceleration);
-  writer.writeBool(offsets[68], object.enableLogs);
-  writer.writeString(offsets[69], object.extensionServerPath);
+  writer.writeBool(offsets[50], object.deleteDownloadAfterReading);
+  writer.writeByte(offsets[51], object.disableSectionType.index);
+  writer.writeByte(offsets[52], object.displayType.index);
+  writer.writeBool(offsets[53], object.doHEnabled);
+  writer.writeLong(offsets[54], object.doHProviderId);
+  writer.writeLong(offsets[55], object.doubleTapAnimationSpeed);
+  writer.writeString(offsets[56], object.downloadLocation);
+  writer.writeBool(offsets[57], object.downloadOnlyOnWifi);
+  writer.writeBool(offsets[58], object.downloadedOnlyMode);
+  writer.writeBool(offsets[59], object.dualPageInvert);
+  writer.writeBool(offsets[60], object.dualPageRotateToFit);
+  writer.writeBool(offsets[61], object.dualPageRotateToFitInvert);
+  writer.writeBool(offsets[62], object.enableAniSkip);
+  writer.writeBool(offsets[63], object.enableAudioPitchCorrection);
+  writer.writeBool(offsets[64], object.enableAutoSkip);
+  writer.writeBool(offsets[65], object.enableCustomColorFilter);
+  writer.writeBool(offsets[66], object.enableDiscordRpc);
+  writer.writeBool(offsets[67], object.enableGpuNext);
+  writer.writeBool(offsets[68], object.enableHardwareAcceleration);
+  writer.writeBool(offsets[69], object.enableLogs);
+  writer.writeString(offsets[70], object.extensionServerPath);
   writer.writeObjectList<FilterScanlator>(
-    offsets[70],
+    offsets[71],
     allOffsets,
     FilterScanlatorSchema.serialize,
     object.filterScanlatorList,
   );
-  writer.writeLong(offsets[71], object.flashColor);
-  writer.writeLong(offsets[72], object.flashDuration);
-  writer.writeLong(offsets[73], object.flashInterval);
-  writer.writeBool(offsets[74], object.flashOnPageChange);
-  writer.writeDouble(offsets[75], object.flexColorSchemeBlendLevel);
-  writer.writeLong(offsets[76], object.flexSchemeColorIndex);
-  writer.writeBool(offsets[77], object.followSystemTheme);
-  writer.writeBool(offsets[78], object.forceLandscapePlayer);
-  writer.writeBool(offsets[79], object.fullScreenPlayer);
-  writer.writeBool(offsets[80], object.fullScreenReader);
-  writer.writeBool(offsets[81], object.grayscale);
-  writer.writeBool(offsets[82], object.hideDiscordRpcInIncognito);
-  writer.writeStringList(offsets[83], object.hideItems);
-  writer.writeString(offsets[84], object.hwdecMode);
-  writer.writeBool(offsets[85], object.incognitoMode);
-  writer.writeBool(offsets[86], object.invertColors);
-  writer.writeString(offsets[87], object.jrePath);
-  writer.writeBool(offsets[88], object.keepScreenOnReader);
-  writer.writeBool(offsets[89], object.landscapeZoom);
-  writer.writeString(offsets[90], object.lastTrackerLibraryLocation);
-  writer.writeBool(offsets[91], object.libraryDownloadedChapters);
-  writer.writeLong(offsets[92], object.libraryFilterAnimeBookMarkedType);
-  writer.writeLong(offsets[93], object.libraryFilterAnimeCompletedType);
-  writer.writeLong(offsets[94], object.libraryFilterAnimeDownloadType);
-  writer.writeLong(offsets[95], object.libraryFilterAnimeStartedType);
-  writer.writeLong(offsets[96], object.libraryFilterAnimeTrackingType);
-  writer.writeLong(offsets[97], object.libraryFilterAnimeUnreadType);
-  writer.writeLong(offsets[98], object.libraryFilterMangasBookMarkedType);
-  writer.writeLong(offsets[99], object.libraryFilterMangasCompletedType);
-  writer.writeLong(offsets[100], object.libraryFilterMangasDownloadType);
-  writer.writeLong(offsets[101], object.libraryFilterMangasStartedType);
-  writer.writeLong(offsets[102], object.libraryFilterMangasTrackingType);
-  writer.writeLong(offsets[103], object.libraryFilterMangasUnreadType);
-  writer.writeLong(offsets[104], object.libraryFilterNovelBookMarkedType);
-  writer.writeLong(offsets[105], object.libraryFilterNovelCompletedType);
-  writer.writeLong(offsets[106], object.libraryFilterNovelDownloadType);
-  writer.writeLong(offsets[107], object.libraryFilterNovelStartedType);
-  writer.writeLong(offsets[108], object.libraryFilterNovelTrackingType);
-  writer.writeLong(offsets[109], object.libraryFilterNovelUnreadType);
-  writer.writeBool(offsets[110], object.libraryLocalSource);
-  writer.writeBool(offsets[111], object.libraryShowCategoryTabs);
-  writer.writeBool(offsets[112], object.libraryShowContinueReadingButton);
-  writer.writeBool(offsets[113], object.libraryShowLanguage);
-  writer.writeBool(offsets[114], object.libraryShowNumbersOfItems);
-  writer.writeStringList(offsets[115], object.localFolders);
+  writer.writeLong(offsets[72], object.flashColor);
+  writer.writeLong(offsets[73], object.flashDuration);
+  writer.writeLong(offsets[74], object.flashInterval);
+  writer.writeBool(offsets[75], object.flashOnPageChange);
+  writer.writeDouble(offsets[76], object.flexColorSchemeBlendLevel);
+  writer.writeLong(offsets[77], object.flexSchemeColorIndex);
+  writer.writeBool(offsets[78], object.followSystemTheme);
+  writer.writeBool(offsets[79], object.forceLandscapePlayer);
+  writer.writeBool(offsets[80], object.fullScreenPlayer);
+  writer.writeBool(offsets[81], object.fullScreenReader);
+  writer.writeBool(offsets[82], object.grayscale);
+  writer.writeBool(offsets[83], object.hideDiscordRpcInIncognito);
+  writer.writeStringList(offsets[84], object.hideItems);
+  writer.writeString(offsets[85], object.hwdecMode);
+  writer.writeBool(offsets[86], object.incognitoMode);
+  writer.writeBool(offsets[87], object.invertColors);
+  writer.writeString(offsets[88], object.jrePath);
+  writer.writeBool(offsets[89], object.keepScreenOnReader);
+  writer.writeBool(offsets[90], object.landscapeZoom);
+  writer.writeString(offsets[91], object.lastTrackerLibraryLocation);
+  writer.writeBool(offsets[92], object.libraryDownloadedChapters);
+  writer.writeLong(offsets[93], object.libraryFilterAnimeBookMarkedType);
+  writer.writeLong(offsets[94], object.libraryFilterAnimeCompletedType);
+  writer.writeLong(offsets[95], object.libraryFilterAnimeDownloadType);
+  writer.writeLong(offsets[96], object.libraryFilterAnimeStartedType);
+  writer.writeLong(offsets[97], object.libraryFilterAnimeTrackingType);
+  writer.writeLong(offsets[98], object.libraryFilterAnimeUnreadType);
+  writer.writeLong(offsets[99], object.libraryFilterMangasBookMarkedType);
+  writer.writeLong(offsets[100], object.libraryFilterMangasCompletedType);
+  writer.writeLong(offsets[101], object.libraryFilterMangasDownloadType);
+  writer.writeLong(offsets[102], object.libraryFilterMangasStartedType);
+  writer.writeLong(offsets[103], object.libraryFilterMangasTrackingType);
+  writer.writeLong(offsets[104], object.libraryFilterMangasUnreadType);
+  writer.writeLong(offsets[105], object.libraryFilterNovelBookMarkedType);
+  writer.writeLong(offsets[106], object.libraryFilterNovelCompletedType);
+  writer.writeLong(offsets[107], object.libraryFilterNovelDownloadType);
+  writer.writeLong(offsets[108], object.libraryFilterNovelStartedType);
+  writer.writeLong(offsets[109], object.libraryFilterNovelTrackingType);
+  writer.writeLong(offsets[110], object.libraryFilterNovelUnreadType);
+  writer.writeBool(offsets[111], object.libraryLocalSource);
+  writer.writeBool(offsets[112], object.libraryShowCategoryTabs);
+  writer.writeBool(offsets[113], object.libraryShowContinueReadingButton);
+  writer.writeBool(offsets[114], object.libraryShowLanguage);
+  writer.writeBool(offsets[115], object.libraryShowNumbersOfItems);
+  writer.writeStringList(offsets[116], object.localFolders);
   writer.writeObject<L10nLocale>(
-    offsets[116],
+    offsets[117],
     allOffsets,
     L10nLocaleSchema.serialize,
     object.locale,
   );
   writer.writeObjectList<Repo>(
-    offsets[117],
+    offsets[118],
     allOffsets,
     RepoSchema.serialize,
     object.mangaExtensionsRepo,
   );
-  writer.writeLong(offsets[118], object.mangaGridSize);
-  writer.writeByte(offsets[119], object.mangaHomeDisplayType.index);
-  writer.writeLong(offsets[120], object.markEpisodeAsSeenType);
-  writer.writeBool(offsets[121], object.mergeLibraryNavMobile);
-  writer.writeBool(offsets[122], object.navigateToPan);
-  writer.writeStringList(offsets[123], object.navigationOrder);
-  writer.writeByte(offsets[124], object.novelDisplayType.index);
+  writer.writeLong(offsets[119], object.mangaGridSize);
+  writer.writeByte(offsets[120], object.mangaHomeDisplayType.index);
+  writer.writeLong(offsets[121], object.markEpisodeAsSeenType);
+  writer.writeBool(offsets[122], object.mergeLibraryNavMobile);
+  writer.writeBool(offsets[123], object.navigateToPan);
+  writer.writeStringList(offsets[124], object.navigationOrder);
+  writer.writeByte(offsets[125], object.novelDisplayType.index);
   writer.writeObjectList<Repo>(
-    offsets[125],
+    offsets[126],
     allOffsets,
     RepoSchema.serialize,
     object.novelExtensionsRepo,
   );
-  writer.writeLong(offsets[126], object.novelFontSize);
-  writer.writeLong(offsets[127], object.novelGridSize);
-  writer.writeBool(offsets[128], object.novelLibraryDownloadedChapters);
-  writer.writeBool(offsets[129], object.novelLibraryLocalSource);
-  writer.writeBool(offsets[130], object.novelLibraryShowCategoryTabs);
-  writer.writeBool(offsets[131], object.novelLibraryShowContinueReadingButton);
-  writer.writeBool(offsets[132], object.novelLibraryShowLanguage);
-  writer.writeBool(offsets[133], object.novelLibraryShowNumbersOfItems);
-  writer.writeDouble(offsets[134], object.novelReaderLineHeight);
-  writer.writeLong(offsets[135], object.novelReaderPadding);
-  writer.writeString(offsets[136], object.novelReaderTextColor);
-  writer.writeString(offsets[137], object.novelReaderTheme);
-  writer.writeBool(offsets[138], object.novelRemoveExtraParagraphSpacing);
-  writer.writeBool(offsets[139], object.novelShowScrollPercentage);
-  writer.writeBool(offsets[140], object.novelTapToScroll);
-  writer.writeByte(offsets[141], object.novelTextAlign.index);
-  writer.writeBool(offsets[142], object.onlyIncludePinnedSources);
-  writer.writeLong(offsets[143], object.pagePreloadAmount);
+  writer.writeLong(offsets[127], object.novelFontSize);
+  writer.writeLong(offsets[128], object.novelGridSize);
+  writer.writeBool(offsets[129], object.novelLibraryDownloadedChapters);
+  writer.writeBool(offsets[130], object.novelLibraryLocalSource);
+  writer.writeBool(offsets[131], object.novelLibraryShowCategoryTabs);
+  writer.writeBool(offsets[132], object.novelLibraryShowContinueReadingButton);
+  writer.writeBool(offsets[133], object.novelLibraryShowLanguage);
+  writer.writeBool(offsets[134], object.novelLibraryShowNumbersOfItems);
+  writer.writeDouble(offsets[135], object.novelReaderLineHeight);
+  writer.writeLong(offsets[136], object.novelReaderPadding);
+  writer.writeString(offsets[137], object.novelReaderTextColor);
+  writer.writeString(offsets[138], object.novelReaderTheme);
+  writer.writeBool(offsets[139], object.novelRemoveExtraParagraphSpacing);
+  writer.writeBool(offsets[140], object.novelShowScrollPercentage);
+  writer.writeBool(offsets[141], object.novelTapToScroll);
+  writer.writeByte(offsets[142], object.novelTextAlign.index);
+  writer.writeBool(offsets[143], object.onlyIncludePinnedSources);
+  writer.writeLong(offsets[144], object.pagePreloadAmount);
   writer.writeObjectList<PersonalPageMode>(
-    offsets[144],
+    offsets[145],
     allOffsets,
     PersonalPageModeSchema.serialize,
     object.personalPageModeList,
   );
   writer.writeObjectList<PersonalReaderMode>(
-    offsets[145],
+    offsets[146],
     allOffsets,
     PersonalReaderModeSchema.serialize,
     object.personalReaderModeList,
   );
   writer.writeObject<PlayerSubtitleSettings>(
-    offsets[146],
+    offsets[147],
     allOffsets,
     PlayerSubtitleSettingsSchema.serialize,
     object.playerSubtitleSettings,
   );
-  writer.writeBool(offsets[147], object.pureBlackDarkMode);
-  writer.writeDouble(offsets[148], object.readerBrightness);
-  writer.writeDouble(offsets[149], object.readerContrast);
-  writer.writeLong(offsets[150], object.readerHideThreshold);
-  writer.writeLong(offsets[151], object.readerNavigationLayout);
-  writer.writeDouble(offsets[152], object.readerSaturation);
-  writer.writeLong(offsets[153], object.relativeTimesTamps);
-  writer.writeBool(offsets[154], object.rpcShowCoverImage);
-  writer.writeBool(offsets[155], object.rpcShowReadingWatchingProgress);
-  writer.writeBool(offsets[156], object.rpcShowTitle);
-  writer.writeBool(offsets[157], object.saveAsCBZArchive);
-  writer.writeByte(offsets[158], object.scaleType.index);
-  writer.writeBool(offsets[159], object.showNSFW);
-  writer.writeBool(offsets[160], object.showNavigationOverlayOnStart);
-  writer.writeBool(offsets[161], object.showPageGaps);
-  writer.writeBool(offsets[162], object.showPagesNumber);
+  writer.writeBool(offsets[148], object.pureBlackDarkMode);
+  writer.writeDouble(offsets[149], object.readerBrightness);
+  writer.writeDouble(offsets[150], object.readerContrast);
+  writer.writeLong(offsets[151], object.readerHideThreshold);
+  writer.writeLong(offsets[152], object.readerNavigationLayout);
+  writer.writeDouble(offsets[153], object.readerSaturation);
+  writer.writeLong(offsets[154], object.relativeTimesTamps);
+  writer.writeBool(offsets[155], object.rpcShowCoverImage);
+  writer.writeBool(offsets[156], object.rpcShowReadingWatchingProgress);
+  writer.writeBool(offsets[157], object.rpcShowTitle);
+  writer.writeBool(offsets[158], object.saveAsCBZArchive);
+  writer.writeByte(offsets[159], object.scaleType.index);
+  writer.writeBool(offsets[160], object.showNSFW);
+  writer.writeBool(offsets[161], object.showNavigationOverlayOnStart);
+  writer.writeBool(offsets[162], object.showPageGaps);
+  writer.writeBool(offsets[163], object.showPagesNumber);
   writer.writeObjectList<SortChapter>(
-    offsets[163],
+    offsets[164],
     allOffsets,
     SortChapterSchema.serialize,
     object.sortChapterList,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[164],
+    offsets[165],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryAnime,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[165],
+    offsets[166],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryManga,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[166],
+    offsets[167],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryNovel,
   );
-  writer.writeBool(offsets[167], object.splitWidePages);
-  writer.writeLong(offsets[168], object.startDatebackup);
-  writer.writeLong(offsets[169], object.tappingInversion);
-  writer.writeBool(offsets[170], object.themeIsDark);
-  writer.writeString(offsets[171], object.ttsLanguage);
-  writer.writeDouble(offsets[172], object.ttsPitch);
-  writer.writeDouble(offsets[173], object.ttsSpeechRate);
-  writer.writeString(offsets[174], object.ttsVoice);
+  writer.writeBool(offsets[168], object.splitWidePages);
+  writer.writeLong(offsets[169], object.startDatebackup);
+  writer.writeLong(offsets[170], object.tappingInversion);
+  writer.writeBool(offsets[171], object.themeIsDark);
+  writer.writeString(offsets[172], object.ttsLanguage);
+  writer.writeDouble(offsets[173], object.ttsPitch);
+  writer.writeDouble(offsets[174], object.ttsSpeechRate);
+  writer.writeString(offsets[175], object.ttsVoice);
+  writer.writeBool(offsets[176], object.tvAnimeOnlyOverride);
+  writer.writeBool(offsets[177], object.tvHomeGenreRows);
+  writer.writeBool(offsets[178], object.tvHomeStyle);
+  writer.writeBool(offsets[179], object.tvPlayerStyle);
   writer.writeObjectList<UpdateError>(
-    offsets[175],
+    offsets[180],
     allOffsets,
     UpdateErrorSchema.serialize,
     object.updateErrorsList,
   );
-  writer.writeBool(offsets[176], object.updateProgressAfterReading);
-  writer.writeLong(offsets[177], object.updatedAt);
-  writer.writeBool(offsets[178], object.useLibass);
-  writer.writeBool(offsets[179], object.useMpvConfig);
-  writer.writeBool(offsets[180], object.usePageTapZones);
-  writer.writeBool(offsets[181], object.useYUV420P);
-  writer.writeString(offsets[182], object.userAgent);
-  writer.writeLong(offsets[183], object.volumeBoostCap);
-  writer.writeBool(offsets[184], object.webtoonDisableZoomOut);
-  writer.writeBool(offsets[185], object.webtoonDoubleTapZoomEnabled);
-  writer.writeLong(offsets[186], object.webtoonSidePadding);
-  writer.writeLong(offsets[187], object.zoomStartPosition);
+  writer.writeBool(offsets[181], object.updateProgressAfterReading);
+  writer.writeLong(offsets[182], object.updatedAt);
+  writer.writeBool(offsets[183], object.useLibass);
+  writer.writeBool(offsets[184], object.useMpvConfig);
+  writer.writeBool(offsets[185], object.usePageTapZones);
+  writer.writeBool(offsets[186], object.useYUV420P);
+  writer.writeString(offsets[187], object.userAgent);
+  writer.writeLong(offsets[188], object.volumeBoostCap);
+  writer.writeBool(offsets[189], object.webtoonDisableZoomOut);
+  writer.writeBool(offsets[190], object.webtoonDoubleTapZoomEnabled);
+  writer.writeLong(offsets[191], object.webtoonSidePadding);
+  writer.writeLong(offsets[192], object.zoomStartPosition);
 }
 
 Settings _settingsDeserialize(
@@ -1896,312 +1926,317 @@ Settings _settingsDeserialize(
     audioPreferredLanguages: reader.readStringOrNull(offsets[16]),
     autoBackupLocation: reader.readStringOrNull(offsets[17]),
     autoExtensionsUpdates: reader.readBoolOrNull(offsets[18]),
-    autoReadDuplicateChapters: reader.readBoolOrNull(offsets[19]),
+    autoPlayNextEpisode: reader.readBoolOrNull(offsets[19]),
+    autoReadDuplicateChapters: reader.readBoolOrNull(offsets[20]),
     autoScrollPages: reader.readObjectList<AutoScrollPages>(
-      offsets[20],
+      offsets[21],
       AutoScrollPagesSchema.deserialize,
       allOffsets,
       AutoScrollPages(),
     ),
-    automaticBackground: reader.readBoolOrNull(offsets[21]),
+    automaticBackground: reader.readBoolOrNull(offsets[22]),
     backgroundColor:
         _SettingsbackgroundColorValueEnumMap[reader.readByteOrNull(
-          offsets[22],
+          offsets[23],
         )] ??
         BackgroundColor.black,
-    backupCompressionLevel: reader.readLongOrNull(offsets[23]),
-    backupFrequency: reader.readLongOrNull(offsets[24]),
-    backupListOptions: reader.readLongList(offsets[25]),
-    btServerAddress: reader.readStringOrNull(offsets[26]),
-    btServerPort: reader.readLongOrNull(offsets[27]),
+    backupCompressionLevel: reader.readLongOrNull(offsets[24]),
+    backupFrequency: reader.readLongOrNull(offsets[25]),
+    backupListOptions: reader.readLongList(offsets[26]),
+    btServerAddress: reader.readStringOrNull(offsets[27]),
+    btServerPort: reader.readLongOrNull(offsets[28]),
     chapterFilterDownloadedList: reader.readObjectList<ChapterFilterDownloaded>(
-      offsets[29],
+      offsets[30],
       ChapterFilterDownloadedSchema.deserialize,
       allOffsets,
       ChapterFilterDownloaded(),
     ),
     chapterPageIndexList: reader.readObjectList<ChapterPageIndex>(
-      offsets[31],
+      offsets[32],
       ChapterPageIndexSchema.deserialize,
       allOffsets,
       ChapterPageIndex(),
     ),
     chapterPageUrlsList: reader.readObjectList<ChapterPageurls>(
-      offsets[32],
+      offsets[33],
       ChapterPageurlsSchema.deserialize,
       allOffsets,
       ChapterPageurls(),
     ),
-    checkForAppUpdates: reader.readBoolOrNull(offsets[33]),
-    checkForExtensionUpdates: reader.readBoolOrNull(offsets[34]),
-    clearChapterCacheOnAppLaunch: reader.readBoolOrNull(offsets[35]),
+    checkForAppUpdates: reader.readBoolOrNull(offsets[34]),
+    checkForExtensionUpdates: reader.readBoolOrNull(offsets[35]),
+    clearChapterCacheOnAppLaunch: reader.readBoolOrNull(offsets[36]),
     colorFilterBlendMode:
         _SettingscolorFilterBlendModeValueEnumMap[reader.readByteOrNull(
-          offsets[36],
+          offsets[37],
         )] ??
         ColorFilterBlendMode.none,
-    concurrentDownloads: reader.readLongOrNull(offsets[37]),
+    concurrentDownloads: reader.readLongOrNull(offsets[38]),
     cookiesList: reader.readObjectList<MCookie>(
-      offsets[38],
+      offsets[39],
       MCookieSchema.deserialize,
       allOffsets,
       MCookie(),
     ),
-    cropBorders: reader.readBoolOrNull(offsets[39]),
+    cropBorders: reader.readBoolOrNull(offsets[40]),
     customColorFilter: reader.readObjectOrNull<CustomColorFilter>(
-      offsets[40],
+      offsets[41],
       CustomColorFilterSchema.deserialize,
       allOffsets,
     ),
-    customDns: reader.readStringOrNull(offsets[41]),
-    dateFormat: reader.readStringOrNull(offsets[42]),
+    customDns: reader.readStringOrNull(offsets[42]),
+    dateFormat: reader.readStringOrNull(offsets[43]),
     debandingType:
         _SettingsdebandingTypeValueEnumMap[reader.readByteOrNull(
-          offsets[43],
+          offsets[44],
         )] ??
         DebandingType.none,
-    defaultDoubleTapToSkipLength: reader.readLongOrNull(offsets[44]),
-    defaultPlayBackSpeed: reader.readDoubleOrNull(offsets[45]),
+    defaultDoubleTapToSkipLength: reader.readLongOrNull(offsets[45]),
+    defaultPlayBackSpeed: reader.readDoubleOrNull(offsets[46]),
     defaultReaderMode:
         _SettingsdefaultReaderModeValueEnumMap[reader.readByteOrNull(
-          offsets[46],
+          offsets[47],
         )] ??
         ReaderMode.vertical,
-    defaultSkipIntroLength: reader.readLongOrNull(offsets[47]),
-    deleteDownloadAfterReading: reader.readBoolOrNull(offsets[49]),
+    defaultSkipIntroLength: reader.readLongOrNull(offsets[48]),
+    deleteDownloadAfterReading: reader.readBoolOrNull(offsets[50]),
     disableSectionType:
         _SettingsdisableSectionTypeValueEnumMap[reader.readByteOrNull(
-          offsets[50],
+          offsets[51],
         )] ??
         SectionType.all,
     displayType:
-        _SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offsets[51])] ??
+        _SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offsets[52])] ??
         DisplayType.compactGrid,
-    doHEnabled: reader.readBoolOrNull(offsets[52]),
-    doHProviderId: reader.readLongOrNull(offsets[53]),
-    doubleTapAnimationSpeed: reader.readLongOrNull(offsets[54]),
-    downloadLocation: reader.readStringOrNull(offsets[55]),
-    downloadOnlyOnWifi: reader.readBoolOrNull(offsets[56]),
-    downloadedOnlyMode: reader.readBoolOrNull(offsets[57]),
-    dualPageInvert: reader.readBoolOrNull(offsets[58]),
-    dualPageRotateToFit: reader.readBoolOrNull(offsets[59]),
-    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[60]),
-    enableAniSkip: reader.readBoolOrNull(offsets[61]),
-    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[62]),
-    enableAutoSkip: reader.readBoolOrNull(offsets[63]),
-    enableCustomColorFilter: reader.readBoolOrNull(offsets[64]),
-    enableDiscordRpc: reader.readBoolOrNull(offsets[65]),
-    enableGpuNext: reader.readBoolOrNull(offsets[66]),
-    enableHardwareAcceleration: reader.readBoolOrNull(offsets[67]),
-    enableLogs: reader.readBoolOrNull(offsets[68]),
-    extensionServerPath: reader.readStringOrNull(offsets[69]),
-    flashColor: reader.readLongOrNull(offsets[71]),
-    flashDuration: reader.readLongOrNull(offsets[72]),
-    flashInterval: reader.readLongOrNull(offsets[73]),
-    flashOnPageChange: reader.readBoolOrNull(offsets[74]),
-    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[75]),
-    flexSchemeColorIndex: reader.readLongOrNull(offsets[76]),
-    followSystemTheme: reader.readBoolOrNull(offsets[77]),
-    forceLandscapePlayer: reader.readBoolOrNull(offsets[78]),
-    fullScreenPlayer: reader.readBoolOrNull(offsets[79]),
-    fullScreenReader: reader.readBoolOrNull(offsets[80]),
-    grayscale: reader.readBoolOrNull(offsets[81]),
-    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[82]),
-    hideItems: reader.readStringList(offsets[83]),
-    hwdecMode: reader.readStringOrNull(offsets[84]),
+    doHEnabled: reader.readBoolOrNull(offsets[53]),
+    doHProviderId: reader.readLongOrNull(offsets[54]),
+    doubleTapAnimationSpeed: reader.readLongOrNull(offsets[55]),
+    downloadLocation: reader.readStringOrNull(offsets[56]),
+    downloadOnlyOnWifi: reader.readBoolOrNull(offsets[57]),
+    downloadedOnlyMode: reader.readBoolOrNull(offsets[58]),
+    dualPageInvert: reader.readBoolOrNull(offsets[59]),
+    dualPageRotateToFit: reader.readBoolOrNull(offsets[60]),
+    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[61]),
+    enableAniSkip: reader.readBoolOrNull(offsets[62]),
+    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[63]),
+    enableAutoSkip: reader.readBoolOrNull(offsets[64]),
+    enableCustomColorFilter: reader.readBoolOrNull(offsets[65]),
+    enableDiscordRpc: reader.readBoolOrNull(offsets[66]),
+    enableGpuNext: reader.readBoolOrNull(offsets[67]),
+    enableHardwareAcceleration: reader.readBoolOrNull(offsets[68]),
+    enableLogs: reader.readBoolOrNull(offsets[69]),
+    extensionServerPath: reader.readStringOrNull(offsets[70]),
+    flashColor: reader.readLongOrNull(offsets[72]),
+    flashDuration: reader.readLongOrNull(offsets[73]),
+    flashInterval: reader.readLongOrNull(offsets[74]),
+    flashOnPageChange: reader.readBoolOrNull(offsets[75]),
+    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[76]),
+    flexSchemeColorIndex: reader.readLongOrNull(offsets[77]),
+    followSystemTheme: reader.readBoolOrNull(offsets[78]),
+    forceLandscapePlayer: reader.readBoolOrNull(offsets[79]),
+    fullScreenPlayer: reader.readBoolOrNull(offsets[80]),
+    fullScreenReader: reader.readBoolOrNull(offsets[81]),
+    grayscale: reader.readBoolOrNull(offsets[82]),
+    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[83]),
+    hideItems: reader.readStringList(offsets[84]),
+    hwdecMode: reader.readStringOrNull(offsets[85]),
     id: id,
-    incognitoMode: reader.readBoolOrNull(offsets[85]),
-    invertColors: reader.readBoolOrNull(offsets[86]),
-    jrePath: reader.readStringOrNull(offsets[87]),
-    keepScreenOnReader: reader.readBoolOrNull(offsets[88]),
-    landscapeZoom: reader.readBoolOrNull(offsets[89]),
-    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[90]),
-    libraryDownloadedChapters: reader.readBoolOrNull(offsets[91]),
-    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[92]),
-    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[93]),
-    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[94]),
-    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[95]),
-    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[96]),
-    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[97]),
-    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[98]),
-    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[99]),
-    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[100]),
-    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[101]),
-    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[102]),
-    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[103]),
-    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[104]),
-    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[105]),
-    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[106]),
-    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[107]),
-    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[108]),
-    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[109]),
-    libraryLocalSource: reader.readBoolOrNull(offsets[110]),
-    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[111]),
-    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[112]),
-    libraryShowLanguage: reader.readBoolOrNull(offsets[113]),
-    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[114]),
-    localFolders: reader.readStringList(offsets[115]),
+    incognitoMode: reader.readBoolOrNull(offsets[86]),
+    invertColors: reader.readBoolOrNull(offsets[87]),
+    jrePath: reader.readStringOrNull(offsets[88]),
+    keepScreenOnReader: reader.readBoolOrNull(offsets[89]),
+    landscapeZoom: reader.readBoolOrNull(offsets[90]),
+    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[91]),
+    libraryDownloadedChapters: reader.readBoolOrNull(offsets[92]),
+    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[93]),
+    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[94]),
+    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[95]),
+    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[96]),
+    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[97]),
+    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[98]),
+    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[99]),
+    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[100]),
+    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[101]),
+    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[102]),
+    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[103]),
+    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[104]),
+    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[105]),
+    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[106]),
+    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[107]),
+    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[108]),
+    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[109]),
+    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[110]),
+    libraryLocalSource: reader.readBoolOrNull(offsets[111]),
+    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[112]),
+    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[113]),
+    libraryShowLanguage: reader.readBoolOrNull(offsets[114]),
+    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[115]),
+    localFolders: reader.readStringList(offsets[116]),
     mangaExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[117],
+      offsets[118],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    mangaGridSize: reader.readLongOrNull(offsets[118]),
+    mangaGridSize: reader.readLongOrNull(offsets[119]),
     mangaHomeDisplayType:
         _SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[119],
+          offsets[120],
         )] ??
         DisplayType.comfortableGrid,
-    markEpisodeAsSeenType: reader.readLongOrNull(offsets[120]),
-    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[121]),
-    navigateToPan: reader.readBoolOrNull(offsets[122]),
-    navigationOrder: reader.readStringList(offsets[123]),
+    markEpisodeAsSeenType: reader.readLongOrNull(offsets[121]),
+    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[122]),
+    navigateToPan: reader.readBoolOrNull(offsets[123]),
+    navigationOrder: reader.readStringList(offsets[124]),
     novelDisplayType:
         _SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[124],
+          offsets[125],
         )] ??
         DisplayType.comfortableGrid,
     novelExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[125],
+      offsets[126],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    novelFontSize: reader.readLongOrNull(offsets[126]),
-    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[128]),
-    novelLibraryLocalSource: reader.readBoolOrNull(offsets[129]),
-    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[130]),
-    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[131]),
-    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[132]),
-    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[133]),
-    novelReaderLineHeight: reader.readDoubleOrNull(offsets[134]),
-    novelReaderPadding: reader.readLongOrNull(offsets[135]),
-    novelReaderTextColor: reader.readStringOrNull(offsets[136]),
-    novelReaderTheme: reader.readStringOrNull(offsets[137]),
-    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[138]),
-    novelShowScrollPercentage: reader.readBoolOrNull(offsets[139]),
-    novelTapToScroll: reader.readBoolOrNull(offsets[140]),
+    novelFontSize: reader.readLongOrNull(offsets[127]),
+    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[129]),
+    novelLibraryLocalSource: reader.readBoolOrNull(offsets[130]),
+    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[131]),
+    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[132]),
+    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[133]),
+    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[134]),
+    novelReaderLineHeight: reader.readDoubleOrNull(offsets[135]),
+    novelReaderPadding: reader.readLongOrNull(offsets[136]),
+    novelReaderTextColor: reader.readStringOrNull(offsets[137]),
+    novelReaderTheme: reader.readStringOrNull(offsets[138]),
+    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[139]),
+    novelShowScrollPercentage: reader.readBoolOrNull(offsets[140]),
+    novelTapToScroll: reader.readBoolOrNull(offsets[141]),
     novelTextAlign:
         _SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
-          offsets[141],
+          offsets[142],
         )] ??
         NovelTextAlign.left,
-    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[142]),
-    pagePreloadAmount: reader.readLongOrNull(offsets[143]),
+    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[143]),
+    pagePreloadAmount: reader.readLongOrNull(offsets[144]),
     personalPageModeList: reader.readObjectList<PersonalPageMode>(
-      offsets[144],
+      offsets[145],
       PersonalPageModeSchema.deserialize,
       allOffsets,
       PersonalPageMode(),
     ),
     personalReaderModeList: reader.readObjectList<PersonalReaderMode>(
-      offsets[145],
+      offsets[146],
       PersonalReaderModeSchema.deserialize,
       allOffsets,
       PersonalReaderMode(),
     ),
     playerSubtitleSettings: reader.readObjectOrNull<PlayerSubtitleSettings>(
-      offsets[146],
+      offsets[147],
       PlayerSubtitleSettingsSchema.deserialize,
       allOffsets,
     ),
-    pureBlackDarkMode: reader.readBoolOrNull(offsets[147]),
-    readerBrightness: reader.readDoubleOrNull(offsets[148]),
-    readerContrast: reader.readDoubleOrNull(offsets[149]),
-    readerHideThreshold: reader.readLongOrNull(offsets[150]),
-    readerNavigationLayout: reader.readLongOrNull(offsets[151]),
-    readerSaturation: reader.readDoubleOrNull(offsets[152]),
-    relativeTimesTamps: reader.readLongOrNull(offsets[153]),
-    rpcShowCoverImage: reader.readBoolOrNull(offsets[154]),
-    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[155]),
-    rpcShowTitle: reader.readBoolOrNull(offsets[156]),
-    saveAsCBZArchive: reader.readBoolOrNull(offsets[157]),
+    pureBlackDarkMode: reader.readBoolOrNull(offsets[148]),
+    readerBrightness: reader.readDoubleOrNull(offsets[149]),
+    readerContrast: reader.readDoubleOrNull(offsets[150]),
+    readerHideThreshold: reader.readLongOrNull(offsets[151]),
+    readerNavigationLayout: reader.readLongOrNull(offsets[152]),
+    readerSaturation: reader.readDoubleOrNull(offsets[153]),
+    relativeTimesTamps: reader.readLongOrNull(offsets[154]),
+    rpcShowCoverImage: reader.readBoolOrNull(offsets[155]),
+    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[156]),
+    rpcShowTitle: reader.readBoolOrNull(offsets[157]),
+    saveAsCBZArchive: reader.readBoolOrNull(offsets[158]),
     scaleType:
-        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[158])] ??
+        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[159])] ??
         ScaleType.fitScreen,
-    showNSFW: reader.readBoolOrNull(offsets[159]),
-    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[160]),
-    showPageGaps: reader.readBoolOrNull(offsets[161]),
-    showPagesNumber: reader.readBoolOrNull(offsets[162]),
+    showNSFW: reader.readBoolOrNull(offsets[160]),
+    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[161]),
+    showPageGaps: reader.readBoolOrNull(offsets[162]),
+    showPagesNumber: reader.readBoolOrNull(offsets[163]),
     sortChapterList: reader.readObjectList<SortChapter>(
-      offsets[163],
+      offsets[164],
       SortChapterSchema.deserialize,
       allOffsets,
       SortChapter(),
     ),
     sortLibraryAnime: reader.readObjectOrNull<SortLibraryManga>(
-      offsets[164],
-      SortLibraryMangaSchema.deserialize,
-      allOffsets,
-    ),
-    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
       offsets[165],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
       offsets[166],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    splitWidePages: reader.readBoolOrNull(offsets[167]),
-    startDatebackup: reader.readLongOrNull(offsets[168]),
-    tappingInversion: reader.readLongOrNull(offsets[169]),
-    themeIsDark: reader.readBoolOrNull(offsets[170]),
-    ttsLanguage: reader.readStringOrNull(offsets[171]),
-    ttsPitch: reader.readDoubleOrNull(offsets[172]),
-    ttsSpeechRate: reader.readDoubleOrNull(offsets[173]),
-    ttsVoice: reader.readStringOrNull(offsets[174]),
+    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+      offsets[167],
+      SortLibraryMangaSchema.deserialize,
+      allOffsets,
+    ),
+    splitWidePages: reader.readBoolOrNull(offsets[168]),
+    startDatebackup: reader.readLongOrNull(offsets[169]),
+    tappingInversion: reader.readLongOrNull(offsets[170]),
+    themeIsDark: reader.readBoolOrNull(offsets[171]),
+    ttsLanguage: reader.readStringOrNull(offsets[172]),
+    ttsPitch: reader.readDoubleOrNull(offsets[173]),
+    ttsSpeechRate: reader.readDoubleOrNull(offsets[174]),
+    ttsVoice: reader.readStringOrNull(offsets[175]),
+    tvAnimeOnlyOverride: reader.readBoolOrNull(offsets[176]),
+    tvHomeGenreRows: reader.readBoolOrNull(offsets[177]),
+    tvHomeStyle: reader.readBoolOrNull(offsets[178]),
+    tvPlayerStyle: reader.readBoolOrNull(offsets[179]),
     updateErrorsList: reader.readObjectList<UpdateError>(
-      offsets[175],
+      offsets[180],
       UpdateErrorSchema.deserialize,
       allOffsets,
       UpdateError(),
     ),
-    updateProgressAfterReading: reader.readBoolOrNull(offsets[176]),
-    updatedAt: reader.readLongOrNull(offsets[177]),
-    useLibass: reader.readBoolOrNull(offsets[178]),
-    useMpvConfig: reader.readBoolOrNull(offsets[179]),
-    usePageTapZones: reader.readBoolOrNull(offsets[180]),
-    useYUV420P: reader.readBoolOrNull(offsets[181]),
-    userAgent: reader.readStringOrNull(offsets[182]),
-    volumeBoostCap: reader.readLongOrNull(offsets[183]),
-    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[184]),
-    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[185]),
-    webtoonSidePadding: reader.readLongOrNull(offsets[186]),
-    zoomStartPosition: reader.readLongOrNull(offsets[187]),
+    updateProgressAfterReading: reader.readBoolOrNull(offsets[181]),
+    updatedAt: reader.readLongOrNull(offsets[182]),
+    useLibass: reader.readBoolOrNull(offsets[183]),
+    useMpvConfig: reader.readBoolOrNull(offsets[184]),
+    usePageTapZones: reader.readBoolOrNull(offsets[185]),
+    useYUV420P: reader.readBoolOrNull(offsets[186]),
+    userAgent: reader.readStringOrNull(offsets[187]),
+    volumeBoostCap: reader.readLongOrNull(offsets[188]),
+    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[189]),
+    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[190]),
+    webtoonSidePadding: reader.readLongOrNull(offsets[191]),
+    zoomStartPosition: reader.readLongOrNull(offsets[192]),
   );
   object.chapterFilterBookmarkedList = reader
       .readObjectList<ChapterFilterBookmarked>(
-        offsets[28],
+        offsets[29],
         ChapterFilterBookmarkedSchema.deserialize,
         allOffsets,
         ChapterFilterBookmarked(),
       );
   object.chapterFilterUnreadList = reader.readObjectList<ChapterFilterUnread>(
-    offsets[30],
+    offsets[31],
     ChapterFilterUnreadSchema.deserialize,
     allOffsets,
     ChapterFilterUnread(),
   );
   object.defaultSubtitleLang = reader.readObjectOrNull<L10nLocale>(
-    offsets[48],
+    offsets[49],
     L10nLocaleSchema.deserialize,
     allOffsets,
   );
   object.filterScanlatorList = reader.readObjectList<FilterScanlator>(
-    offsets[70],
+    offsets[71],
     FilterScanlatorSchema.deserialize,
     allOffsets,
     FilterScanlator(),
   );
   object.locale = reader.readObjectOrNull<L10nLocale>(
-    offsets[116],
+    offsets[117],
     L10nLocaleSchema.deserialize,
     allOffsets,
   );
-  object.novelGridSize = reader.readLongOrNull(offsets[127]);
+  object.novelGridSize = reader.readLongOrNull(offsets[128]);
   return object;
 }
 
@@ -2272,6 +2307,8 @@ P _settingsDeserializeProp<P>(
     case 19:
       return (reader.readBoolOrNull(offset)) as P;
     case 20:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 21:
       return (reader.readObjectList<AutoScrollPages>(
             offset,
             AutoScrollPagesSchema.deserialize,
@@ -2279,25 +2316,25 @@ P _settingsDeserializeProp<P>(
             AutoScrollPages(),
           ))
           as P;
-    case 21:
-      return (reader.readBoolOrNull(offset)) as P;
     case 22:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 23:
       return (_SettingsbackgroundColorValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               BackgroundColor.black)
           as P;
-    case 23:
-      return (reader.readLongOrNull(offset)) as P;
     case 24:
       return (reader.readLongOrNull(offset)) as P;
     case 25:
-      return (reader.readLongList(offset)) as P;
-    case 26:
-      return (reader.readStringOrNull(offset)) as P;
-    case 27:
       return (reader.readLongOrNull(offset)) as P;
+    case 26:
+      return (reader.readLongList(offset)) as P;
+    case 27:
+      return (reader.readStringOrNull(offset)) as P;
     case 28:
+      return (reader.readLongOrNull(offset)) as P;
+    case 29:
       return (reader.readObjectList<ChapterFilterBookmarked>(
             offset,
             ChapterFilterBookmarkedSchema.deserialize,
@@ -2305,7 +2342,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterBookmarked(),
           ))
           as P;
-    case 29:
+    case 30:
       return (reader.readObjectList<ChapterFilterDownloaded>(
             offset,
             ChapterFilterDownloadedSchema.deserialize,
@@ -2313,7 +2350,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterDownloaded(),
           ))
           as P;
-    case 30:
+    case 31:
       return (reader.readObjectList<ChapterFilterUnread>(
             offset,
             ChapterFilterUnreadSchema.deserialize,
@@ -2321,7 +2358,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterUnread(),
           ))
           as P;
-    case 31:
+    case 32:
       return (reader.readObjectList<ChapterPageIndex>(
             offset,
             ChapterPageIndexSchema.deserialize,
@@ -2329,7 +2366,7 @@ P _settingsDeserializeProp<P>(
             ChapterPageIndex(),
           ))
           as P;
-    case 32:
+    case 33:
       return (reader.readObjectList<ChapterPageurls>(
             offset,
             ChapterPageurlsSchema.deserialize,
@@ -2337,21 +2374,21 @@ P _settingsDeserializeProp<P>(
             ChapterPageurls(),
           ))
           as P;
-    case 33:
-      return (reader.readBoolOrNull(offset)) as P;
     case 34:
       return (reader.readBoolOrNull(offset)) as P;
     case 35:
       return (reader.readBoolOrNull(offset)) as P;
     case 36:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 37:
       return (_SettingscolorFilterBlendModeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               ColorFilterBlendMode.none)
           as P;
-    case 37:
-      return (reader.readLongOrNull(offset)) as P;
     case 38:
+      return (reader.readLongOrNull(offset)) as P;
+    case 39:
       return (reader.readObjectList<MCookie>(
             offset,
             MCookieSchema.deserialize,
@@ -2359,66 +2396,64 @@ P _settingsDeserializeProp<P>(
             MCookie(),
           ))
           as P;
-    case 39:
-      return (reader.readBoolOrNull(offset)) as P;
     case 40:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 41:
       return (reader.readObjectOrNull<CustomColorFilter>(
             offset,
             CustomColorFilterSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 41:
-      return (reader.readStringOrNull(offset)) as P;
     case 42:
       return (reader.readStringOrNull(offset)) as P;
     case 43:
+      return (reader.readStringOrNull(offset)) as P;
+    case 44:
       return (_SettingsdebandingTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DebandingType.none)
           as P;
-    case 44:
-      return (reader.readLongOrNull(offset)) as P;
     case 45:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 46:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 47:
       return (_SettingsdefaultReaderModeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               ReaderMode.vertical)
           as P;
-    case 47:
-      return (reader.readLongOrNull(offset)) as P;
     case 48:
+      return (reader.readLongOrNull(offset)) as P;
+    case 49:
       return (reader.readObjectOrNull<L10nLocale>(
             offset,
             L10nLocaleSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 49:
-      return (reader.readBoolOrNull(offset)) as P;
     case 50:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 51:
       return (_SettingsdisableSectionTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               SectionType.all)
           as P;
-    case 51:
+    case 52:
       return (_SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offset)] ??
               DisplayType.compactGrid)
           as P;
-    case 52:
-      return (reader.readBoolOrNull(offset)) as P;
     case 53:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 54:
       return (reader.readLongOrNull(offset)) as P;
     case 55:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 56:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 57:
       return (reader.readBoolOrNull(offset)) as P;
     case 58:
@@ -2444,8 +2479,10 @@ P _settingsDeserializeProp<P>(
     case 68:
       return (reader.readBoolOrNull(offset)) as P;
     case 69:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 70:
+      return (reader.readStringOrNull(offset)) as P;
+    case 71:
       return (reader.readObjectList<FilterScanlator>(
             offset,
             FilterScanlatorSchema.deserialize,
@@ -2453,20 +2490,18 @@ P _settingsDeserializeProp<P>(
             FilterScanlator(),
           ))
           as P;
-    case 71:
-      return (reader.readLongOrNull(offset)) as P;
     case 72:
       return (reader.readLongOrNull(offset)) as P;
     case 73:
       return (reader.readLongOrNull(offset)) as P;
     case 74:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 75:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 76:
       return (reader.readLongOrNull(offset)) as P;
-    case 77:
+    case 75:
       return (reader.readBoolOrNull(offset)) as P;
+    case 76:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 77:
+      return (reader.readLongOrNull(offset)) as P;
     case 78:
       return (reader.readBoolOrNull(offset)) as P;
     case 79:
@@ -2478,25 +2513,25 @@ P _settingsDeserializeProp<P>(
     case 82:
       return (reader.readBoolOrNull(offset)) as P;
     case 83:
-      return (reader.readStringList(offset)) as P;
-    case 84:
-      return (reader.readStringOrNull(offset)) as P;
-    case 85:
       return (reader.readBoolOrNull(offset)) as P;
+    case 84:
+      return (reader.readStringList(offset)) as P;
+    case 85:
+      return (reader.readStringOrNull(offset)) as P;
     case 86:
       return (reader.readBoolOrNull(offset)) as P;
     case 87:
-      return (reader.readStringOrNull(offset)) as P;
-    case 88:
       return (reader.readBoolOrNull(offset)) as P;
+    case 88:
+      return (reader.readStringOrNull(offset)) as P;
     case 89:
       return (reader.readBoolOrNull(offset)) as P;
     case 90:
-      return (reader.readStringOrNull(offset)) as P;
-    case 91:
       return (reader.readBoolOrNull(offset)) as P;
+    case 91:
+      return (reader.readStringOrNull(offset)) as P;
     case 92:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 93:
       return (reader.readLongOrNull(offset)) as P;
     case 94:
@@ -2532,7 +2567,7 @@ P _settingsDeserializeProp<P>(
     case 109:
       return (reader.readLongOrNull(offset)) as P;
     case 110:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 111:
       return (reader.readBoolOrNull(offset)) as P;
     case 112:
@@ -2542,15 +2577,17 @@ P _settingsDeserializeProp<P>(
     case 114:
       return (reader.readBoolOrNull(offset)) as P;
     case 115:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 116:
+      return (reader.readStringList(offset)) as P;
+    case 117:
       return (reader.readObjectOrNull<L10nLocale>(
             offset,
             L10nLocaleSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 117:
+    case 118:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2558,29 +2595,29 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 118:
-      return (reader.readLongOrNull(offset)) as P;
     case 119:
+      return (reader.readLongOrNull(offset)) as P;
+    case 120:
       return (_SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 120:
-      return (reader.readLongOrNull(offset)) as P;
     case 121:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 122:
       return (reader.readBoolOrNull(offset)) as P;
     case 123:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 124:
+      return (reader.readStringList(offset)) as P;
+    case 125:
       return (_SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 125:
+    case 126:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2588,12 +2625,10 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 126:
-      return (reader.readLongOrNull(offset)) as P;
     case 127:
       return (reader.readLongOrNull(offset)) as P;
     case 128:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 129:
       return (reader.readBoolOrNull(offset)) as P;
     case 130:
@@ -2605,30 +2640,32 @@ P _settingsDeserializeProp<P>(
     case 133:
       return (reader.readBoolOrNull(offset)) as P;
     case 134:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 135:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 136:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 137:
       return (reader.readStringOrNull(offset)) as P;
     case 138:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 139:
       return (reader.readBoolOrNull(offset)) as P;
     case 140:
       return (reader.readBoolOrNull(offset)) as P;
     case 141:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 142:
       return (_SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               NovelTextAlign.left)
           as P;
-    case 142:
-      return (reader.readBoolOrNull(offset)) as P;
     case 143:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 144:
+      return (reader.readLongOrNull(offset)) as P;
+    case 145:
       return (reader.readObjectList<PersonalPageMode>(
             offset,
             PersonalPageModeSchema.deserialize,
@@ -2636,7 +2673,7 @@ P _settingsDeserializeProp<P>(
             PersonalPageMode(),
           ))
           as P;
-    case 145:
+    case 146:
       return (reader.readObjectList<PersonalReaderMode>(
             offset,
             PersonalReaderModeSchema.deserialize,
@@ -2644,29 +2681,27 @@ P _settingsDeserializeProp<P>(
             PersonalReaderMode(),
           ))
           as P;
-    case 146:
+    case 147:
       return (reader.readObjectOrNull<PlayerSubtitleSettings>(
             offset,
             PlayerSubtitleSettingsSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 147:
-      return (reader.readBoolOrNull(offset)) as P;
     case 148:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 149:
       return (reader.readDoubleOrNull(offset)) as P;
     case 150:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 151:
       return (reader.readLongOrNull(offset)) as P;
     case 152:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 153:
       return (reader.readLongOrNull(offset)) as P;
+    case 153:
+      return (reader.readDoubleOrNull(offset)) as P;
     case 154:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 155:
       return (reader.readBoolOrNull(offset)) as P;
     case 156:
@@ -2674,11 +2709,11 @@ P _settingsDeserializeProp<P>(
     case 157:
       return (reader.readBoolOrNull(offset)) as P;
     case 158:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 159:
       return (_SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offset)] ??
               ScaleType.fitScreen)
           as P;
-    case 159:
-      return (reader.readBoolOrNull(offset)) as P;
     case 160:
       return (reader.readBoolOrNull(offset)) as P;
     case 161:
@@ -2686,18 +2721,13 @@ P _settingsDeserializeProp<P>(
     case 162:
       return (reader.readBoolOrNull(offset)) as P;
     case 163:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 164:
       return (reader.readObjectList<SortChapter>(
             offset,
             SortChapterSchema.deserialize,
             allOffsets,
             SortChapter(),
-          ))
-          as P;
-    case 164:
-      return (reader.readObjectOrNull<SortLibraryManga>(
-            offset,
-            SortLibraryMangaSchema.deserialize,
-            allOffsets,
           ))
           as P;
     case 165:
@@ -2715,22 +2745,37 @@ P _settingsDeserializeProp<P>(
           ))
           as P;
     case 167:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readObjectOrNull<SortLibraryManga>(
+            offset,
+            SortLibraryMangaSchema.deserialize,
+            allOffsets,
+          ))
+          as P;
     case 168:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 169:
       return (reader.readLongOrNull(offset)) as P;
     case 170:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 171:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 172:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 173:
       return (reader.readDoubleOrNull(offset)) as P;
     case 174:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 175:
+      return (reader.readStringOrNull(offset)) as P;
+    case 176:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 177:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 178:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 179:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 180:
       return (reader.readObjectList<UpdateError>(
             offset,
             UpdateErrorSchema.deserialize,
@@ -2738,29 +2783,29 @@ P _settingsDeserializeProp<P>(
             UpdateError(),
           ))
           as P;
-    case 176:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 177:
-      return (reader.readLongOrNull(offset)) as P;
-    case 178:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 179:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 180:
-      return (reader.readBoolOrNull(offset)) as P;
     case 181:
       return (reader.readBoolOrNull(offset)) as P;
     case 182:
-      return (reader.readStringOrNull(offset)) as P;
-    case 183:
       return (reader.readLongOrNull(offset)) as P;
+    case 183:
+      return (reader.readBoolOrNull(offset)) as P;
     case 184:
       return (reader.readBoolOrNull(offset)) as P;
     case 185:
       return (reader.readBoolOrNull(offset)) as P;
     case 186:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 187:
+      return (reader.readStringOrNull(offset)) as P;
+    case 188:
+      return (reader.readLongOrNull(offset)) as P;
+    case 189:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 190:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 191:
+      return (reader.readLongOrNull(offset)) as P;
+    case 192:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -4317,6 +4362,33 @@ extension SettingsQueryFilter
           property: r'autoExtensionsUpdates',
           value: value,
         ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  autoPlayNextEpisodeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'autoPlayNextEpisode'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  autoPlayNextEpisodeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'autoPlayNextEpisode'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  autoPlayNextEpisodeEqualTo(bool? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'autoPlayNextEpisode', value: value),
       );
     });
   }
@@ -14661,6 +14733,115 @@ extension SettingsQueryFilter
   }
 
   QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  tvAnimeOnlyOverrideIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'tvAnimeOnlyOverride'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  tvAnimeOnlyOverrideIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'tvAnimeOnlyOverride'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  tvAnimeOnlyOverrideEqualTo(bool? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'tvAnimeOnlyOverride', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  tvHomeGenreRowsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'tvHomeGenreRows'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  tvHomeGenreRowsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'tvHomeGenreRows'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  tvHomeGenreRowsEqualTo(bool? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'tvHomeGenreRows', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> tvHomeStyleIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'tvHomeStyle'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  tvHomeStyleIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'tvHomeStyle'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> tvHomeStyleEqualTo(
+    bool? value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'tvHomeStyle', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  tvPlayerStyleIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'tvPlayerStyle'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  tvPlayerStyleIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'tvPlayerStyle'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> tvPlayerStyleEqualTo(
+    bool? value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'tvPlayerStyle', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
   updateErrorsListIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(
@@ -15860,6 +16041,19 @@ extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
   sortByAutoExtensionsUpdatesDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'autoExtensionsUpdates', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByAutoPlayNextEpisode() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'autoPlayNextEpisode', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  sortByAutoPlayNextEpisodeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'autoPlayNextEpisode', Sort.desc);
     });
   }
 
@@ -17574,6 +17768,55 @@ extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
     });
   }
 
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByTvAnimeOnlyOverride() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvAnimeOnlyOverride', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  sortByTvAnimeOnlyOverrideDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvAnimeOnlyOverride', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByTvHomeGenreRows() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvHomeGenreRows', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByTvHomeGenreRowsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvHomeGenreRows', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByTvHomeStyle() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvHomeStyle', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByTvHomeStyleDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvHomeStyle', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByTvPlayerStyle() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvPlayerStyle', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByTvPlayerStyleDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvPlayerStyle', Sort.desc);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterSortBy>
   sortByUpdateProgressAfterReading() {
     return QueryBuilder.apply(this, (query) {
@@ -17954,6 +18197,19 @@ extension SettingsQuerySortThenBy
   thenByAutoExtensionsUpdatesDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'autoExtensionsUpdates', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByAutoPlayNextEpisode() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'autoPlayNextEpisode', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  thenByAutoPlayNextEpisodeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'autoPlayNextEpisode', Sort.desc);
     });
   }
 
@@ -19680,6 +19936,55 @@ extension SettingsQuerySortThenBy
     });
   }
 
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByTvAnimeOnlyOverride() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvAnimeOnlyOverride', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  thenByTvAnimeOnlyOverrideDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvAnimeOnlyOverride', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByTvHomeGenreRows() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvHomeGenreRows', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByTvHomeGenreRowsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvHomeGenreRows', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByTvHomeStyle() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvHomeStyle', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByTvHomeStyleDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvHomeStyle', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByTvPlayerStyle() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvPlayerStyle', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByTvPlayerStyleDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'tvPlayerStyle', Sort.desc);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterSortBy>
   thenByUpdateProgressAfterReading() {
     return QueryBuilder.apply(this, (query) {
@@ -19959,6 +20264,12 @@ extension SettingsQueryWhereDistinct
   distinctByAutoExtensionsUpdates() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'autoExtensionsUpdates');
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QDistinct> distinctByAutoPlayNextEpisode() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'autoPlayNextEpisode');
     });
   }
 
@@ -20870,6 +21181,30 @@ extension SettingsQueryWhereDistinct
     });
   }
 
+  QueryBuilder<Settings, Settings, QDistinct> distinctByTvAnimeOnlyOverride() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'tvAnimeOnlyOverride');
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QDistinct> distinctByTvHomeGenreRows() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'tvHomeGenreRows');
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QDistinct> distinctByTvHomeStyle() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'tvHomeStyle');
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QDistinct> distinctByTvPlayerStyle() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'tvPlayerStyle');
+    });
+  }
+
   QueryBuilder<Settings, Settings, QDistinct>
   distinctByUpdateProgressAfterReading() {
     return QueryBuilder.apply(this, (query) {
@@ -21083,6 +21418,13 @@ extension SettingsQueryProperty
   autoExtensionsUpdatesProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'autoExtensionsUpdates');
+    });
+  }
+
+  QueryBuilder<Settings, bool?, QQueryOperations>
+  autoPlayNextEpisodeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'autoPlayNextEpisode');
     });
   }
 
@@ -22109,6 +22451,31 @@ extension SettingsQueryProperty
   QueryBuilder<Settings, String?, QQueryOperations> ttsVoiceProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'ttsVoice');
+    });
+  }
+
+  QueryBuilder<Settings, bool?, QQueryOperations>
+  tvAnimeOnlyOverrideProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'tvAnimeOnlyOverride');
+    });
+  }
+
+  QueryBuilder<Settings, bool?, QQueryOperations> tvHomeGenreRowsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'tvHomeGenreRows');
+    });
+  }
+
+  QueryBuilder<Settings, bool?, QQueryOperations> tvHomeStyleProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'tvHomeStyle');
+    });
+  }
+
+  QueryBuilder<Settings, bool?, QQueryOperations> tvPlayerStyleProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'tvPlayerStyle');
     });
   }
 

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -859,9 +859,9 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
       final forceLandscape = ref.read(forceLandscapePlayerStateProvider);
       // Preserve the player orientation across episode changes. Playing the next
       // episode pushes a fresh player, and the old one's dispose() resets the
-      // orientation to portrait. So if the viewer is still in fullscreen — from
+      // orientation to portrait. So if the viewer is still in fullscreen - from
       // the force-landscape setting or a manual toggle that persists across
-      // episodes (fullscreenProvider is global) — re-apply landscape here rather
+      // episodes (fullscreenProvider is global) - re-apply landscape here rather
       // than stranding them in portrait with the fullscreen button still active.
       if (forceLandscape || ref.read(fullscreenProvider)) {
         _setLandscapeMode(true);
@@ -960,7 +960,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
   // themselves on a TV remote.
   final ValueNotifier<int> _revealControls = ValueNotifier(0);
   // TV-only: when the advanced settings panel is open the video docks left and
-  // the panel slides in on the right (YouTube-style), instead of a bottom sheet.
+  // the panel slides in on the right, instead of a bottom sheet.
   bool _tvSettingsOpen = false;
   // Owned focus anchors for the split view so Left/Right cross deterministically
   // (geometric directional focus was losing focus entirely).
@@ -1467,7 +1467,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
   }
 
 
-  // d-pad-focusable option data for the TV settings panel — the same track
+  // d-pad-focusable option data for the TV settings panel - the same track
   // switching the bottom-sheet widgets do, minus the Navigator.pop (the panel
   // is not a route). Records: (label, selected, onTap).
   List<({String label, bool selected, VoidCallback onTap})> _tvQualityOptions() {
@@ -2118,7 +2118,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             controller: _controller,
             desktopFullScreenPlayer: widget.desktopFullScreenPlayer,
           )
-        // A TV is always fullscreen, so the toggle is useless there — hide it.
+        // A TV is always fullscreen, so the toggle is useless there - hide it.
         else if (!isTv)
           IconButton(
             icon: Icon(isFullscreen ? Icons.fullscreen_exit : Icons.fullscreen),
@@ -2394,7 +2394,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
       ],
     );
     if (!splitSettings) return player;
-    // YouTube-style split: video docks left (a single focusable unit — Left
+    // Split layout: video docks left (a single focusable unit, Left
     // from the panel focuses it, Select toggles play/pause), a gap, then the
     // settings panel on the right.
     final accent = Theme.of(context).colorScheme.primary;
@@ -2705,7 +2705,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
 
   // On a TV remote / keyboard, reveal the on-screen controls when the user
   // presses the d-pad. The arrow keys stay unbound above (so they still drive
-  // focus traversal between the control buttons) — we just bump [_revealControls]
+  // focus traversal between the control buttons) - we just bump [_revealControls]
   // so the controls become visible and the focus is on something the user can
   // see. Returns ignored so traversal + the media shortcuts still run.
   KeyEventResult _onPlayerKey(FocusNode node, KeyEvent event) {

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -2193,27 +2193,18 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
               Consumer(
                 builder: (context, ref, _) {
                   final autoPlay = ref.watch(autoPlayNextEpisodeProvider);
-                  // Same drawn play/pause switch as the TV player, for a
-                  // consistent autoplay toggle across all players.
+                  // Same pill control as the TV player, so the autoplay toggle
+                  // is visually identical across mobile, desktop and TV.
                   return Tooltip(
                     message: autoPlay
                         ? 'Autoplay next episode: on'
                         : 'Autoplay next episode: off',
-                    child: InkWell(
-                      borderRadius: BorderRadius.circular(20),
-                      onTap: () => ref
+                    child: AutoplayToggle(
+                      accent: Theme.of(context).colorScheme.primary,
+                      on: autoPlay,
+                      onToggle: () => ref
                           .read(autoPlayNextEpisodeProvider.notifier)
                           .toggle(),
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 8,
-                          vertical: 8,
-                        ),
-                        child: AutoplaySwitch(
-                          on: autoPlay,
-                          accent: Theme.of(context).colorScheme.primary,
-                        ),
-                      ),
                     ),
                   );
                 },

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -21,7 +21,11 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/video.dart' as vid;
 import 'package:mangayomi/modules/anime/providers/anime_player_controller_provider.dart';
+import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
 import 'package:mangayomi/modules/anime/widgets/aniskip_countdown_btn.dart';
+import 'package:mangayomi/modules/anime/widgets/tv_player_controls.dart';
+import 'package:mangayomi/modules/anime/widgets/tv_player_settings_panel.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/anime/widgets/desktop.dart';
 import 'package:mangayomi/modules/anime/widgets/play_or_pause_button.dart';
 import 'package:mangayomi/modules/library/providers/local_archive.dart';
@@ -311,7 +315,7 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
 
   late final StreamSubscription<bool> _completed = _player.stream.completed
       .listen((val) {
-        if (hasNextEpisode && val) {
+        if (hasNextEpisode && val && ref.read(autoPlayNextEpisodeProvider)) {
           if (mounted) {
             pushToNewEpisode(context, _streamController.getNextEpisode());
           }
@@ -853,7 +857,13 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     }
     if (!isDesktop) {
       final forceLandscape = ref.read(forceLandscapePlayerStateProvider);
-      if (forceLandscape) {
+      // Preserve the player orientation across episode changes. Playing the next
+      // episode pushes a fresh player, and the old one's dispose() resets the
+      // orientation to portrait. So if the viewer is still in fullscreen — from
+      // the force-landscape setting or a manual toggle that persists across
+      // episodes (fullscreenProvider is global) — re-apply landscape here rather
+      // than stranding them in portrait with the fullscreen button still active.
+      if (forceLandscape || ref.read(fullscreenProvider)) {
         _setLandscapeMode(true);
       }
     }
@@ -946,8 +956,22 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     });
   }
 
+  // Bumped on each d-pad key (see _onPlayerKey) so the mobile controls reveal
+  // themselves on a TV remote.
+  final ValueNotifier<int> _revealControls = ValueNotifier(0);
+  // TV-only: when the advanced settings panel is open the video docks left and
+  // the panel slides in on the right (YouTube-style), instead of a bottom sheet.
+  bool _tvSettingsOpen = false;
+  // Owned focus anchors for the split view so Left/Right cross deterministically
+  // (geometric directional focus was losing focus entirely).
+  final FocusNode _tvVideoFocus = FocusNode(debugLabel: 'tvVideoFrame');
+  final FocusNode _tvPanelFocus = FocusNode(debugLabel: 'tvPanelHeader');
+
   @override
   void dispose() {
+    _revealControls.dispose();
+    _tvVideoFocus.dispose();
+    _tvPanelFocus.dispose();
     _watchStopwatch.stop();
     _currentPosition.removeListener(_updateRpcTimestamp);
     _subDelayController.removeListener(_onSubDelayChanged);
@@ -1442,6 +1466,195 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     );
   }
 
+
+  // d-pad-focusable option data for the TV settings panel — the same track
+  // switching the bottom-sheet widgets do, minus the Navigator.pop (the panel
+  // is not a route). Records: (label, selected, onTap).
+  List<({String label, bool selected, VoidCallback onTap})> _tvQualityOptions() {
+    List<VideoPrefs> videoQuality = _player.state.tracks.video
+        .where(
+          (element) => element.w != null && element.h != null && widget.isLocal,
+        )
+        .toList()
+        .map((e) => VideoPrefs(videoTrack: e, isLocal: true))
+        .toList();
+    if (widget.videos.isNotEmpty && !widget.isLocal) {
+      for (var video in widget.videos) {
+        videoQuality.add(
+          VideoPrefs(
+            videoTrack: VideoTrack(video.url, video.quality, video.quality),
+            headers: video.headers,
+            isLocal: false,
+          ),
+        );
+      }
+    }
+    return videoQuality.map((quality) {
+      final selected =
+          _video.value!.videoTrack!.title == quality.videoTrack!.title ||
+          widget.isLocal;
+      return (
+        label: widget.isLocal ? _firstVid.quality : quality.videoTrack!.title!,
+        selected: selected,
+        onTap: () {
+          if (_video.value?.videoTrack?.id == quality.videoTrack?.id) return;
+          _video.value = quality;
+          _player.stop();
+          if (quality.isLocal) {
+            if (widget.isLocal) {
+              _player.setVideoTrack(quality.videoTrack!);
+            } else {
+              _openMedia(quality);
+            }
+          } else {
+            _openMedia(quality);
+          }
+          _initSubtitleAndAudio = true;
+        },
+      );
+    }).toList();
+  }
+
+  List<({String label, bool selected, VoidCallback onTap})> _tvSubtitleOptions() {
+    List<VideoPrefs> videoSubtitle = _player.state.tracks.subtitle
+        .toList()
+        .map((e) => VideoPrefs(isLocal: true, subtitle: e))
+        .toList();
+    List<String> subs = [];
+    if (widget.videos.isNotEmpty) {
+      for (var video in widget.videos) {
+        for (var sub in video.subtitles ?? []) {
+          if (!subs.contains(sub.file)) {
+            final file = sub.file!;
+            final label = sub.label;
+            videoSubtitle.add(
+              VideoPrefs(
+                isLocal: widget.isLocal,
+                subtitle: (file.startsWith("http") || file.startsWith("file"))
+                    ? SubtitleTrack.uri(file, title: label, language: label)
+                    : SubtitleTrack.data(file, title: label, language: label),
+              ),
+            );
+            subs.add(sub.file!);
+          }
+        }
+      }
+    }
+    final subtitle = _player.state.track.subtitle;
+    videoSubtitle = videoSubtitle
+        .map((e) {
+          e.title =
+              e.subtitle?.title ??
+              e.subtitle?.language ??
+              e.subtitle?.channels ??
+              "";
+          return e;
+        })
+        .toList()
+        .where((element) => element.title!.isNotEmpty)
+        .toList();
+    videoSubtitle.sort((a, b) => a.title!.compareTo(b.title!));
+    videoSubtitle.insert(
+      0,
+      VideoPrefs(isLocal: false, subtitle: SubtitleTrack.no()),
+    );
+    final List<VideoPrefs> last = [];
+    for (var element in videoSubtitle) {
+      final key = element.title ??
+          element.subtitle?.title ??
+          element.subtitle?.language ??
+          element.subtitle?.channels ??
+          "None";
+      final contains = last.any((sub) =>
+          (sub.title ??
+              sub.subtitle?.title ??
+              sub.subtitle?.language ??
+              sub.subtitle?.channels ??
+              "None") ==
+          key);
+      if (!contains) last.add(element);
+    }
+    return last.toSet().toList().map((sub) {
+      final title = sub.title ??
+          sub.subtitle?.title ??
+          sub.subtitle?.language ??
+          sub.subtitle?.channels ??
+          "None";
+      final selected = (title ==
+              (subtitle.title ??
+                  subtitle.language ??
+                  subtitle.channels ??
+                  "None")) ||
+          (subtitle.id == "no" && title == "None");
+      return (
+        label: title == "None" ? "Off" : title,
+        selected: selected,
+        onTap: () {
+          try {
+            _player.setSubtitleTrack(sub.subtitle!);
+          } catch (_) {}
+        },
+      );
+    }).toList();
+  }
+
+  List<({String label, bool selected, VoidCallback onTap})> _tvAudioOptions() {
+    List<VideoPrefs> videoAudio = _player.state.tracks.audio
+        .toList()
+        .map((e) => VideoPrefs(isLocal: true, audio: e))
+        .toList();
+    List<String> audios = [];
+    if (widget.videos.isNotEmpty && !widget.isLocal) {
+      for (var video in widget.videos) {
+        for (var audio in video.audios ?? []) {
+          if (!audios.contains(audio.file)) {
+            videoAudio.add(
+              VideoPrefs(
+                isLocal: false,
+                audio: AudioTrack.uri(
+                  audio.file!,
+                  title: audio.label,
+                  language: audio.label,
+                ),
+              ),
+            );
+            audios.add(audio.file!);
+          }
+        }
+      }
+    }
+    final audio = _player.state.track.audio;
+    videoAudio = videoAudio
+        .map((e) {
+          e.title =
+              e.audio?.title ?? e.audio?.language ?? e.audio?.channels ?? "";
+          return e;
+        })
+        .toList()
+        .where((element) => element.title!.isNotEmpty)
+        .toList();
+    videoAudio.sort((a, b) => a.title!.compareTo(b.title!));
+    videoAudio.insert(0, VideoPrefs(isLocal: false, audio: AudioTrack.no()));
+    return videoAudio.toSet().toList().map((aud) {
+      final title = aud.title ??
+          aud.audio?.title ??
+          aud.audio?.language ??
+          aud.audio?.channels ??
+          "None";
+      final selected =
+          (aud.audio == audio) || (audio.id == "no" && title == "None");
+      return (
+        label: title == "None" ? "Off" : title,
+        selected: selected,
+        onTap: () {
+          try {
+            _player.setAudioTrack(aud.audio!);
+          } catch (_) {}
+        },
+      );
+    }).toList();
+  }
+
   Future<void> _setPlaybackSpeed(double speed) async {
     await _player.setRate(speed);
     _playbackSpeed.value = speed;
@@ -1546,6 +1759,81 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     );
   }
 
+  Widget _tvControls() {
+    return TvPlayerControls(
+      player: _player,
+      revealControls: _revealControls,
+      title: widget.episode.manga.value?.name ?? '',
+      episodeLabel: widget.episode.name ?? '',
+      // Direct pop, not maybePop: the on-screen back arrow always exits the
+      // player, bypassing the PopScope that makes the remote Back hide the
+      // panel first.
+      onBack: () => Navigator.pop(context),
+      onRestart: () => _player.seek(Duration.zero),
+      onSettings: () {
+        // On TV the settings open as the docked side panel; phones/desktop keep
+        // the bottom-sheet menu.
+        if (isTv) {
+          setState(() => _tvSettingsOpen = true);
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) _tvPanelFocus.requestFocus();
+          });
+        } else {
+          _videoSettingDraggableMenu(context);
+        }
+      },
+      hasNext: hasNextEpisode,
+      onNext: hasNextEpisode
+          ? () => pushToNewEpisode(context, _streamController.getNextEpisode())
+          : null,
+      qualityListenable: _video,
+      buildQualityOptions: _buildTvQualityOptions,
+      speedListenable: _playbackSpeed,
+      onSetSpeed: _setPlaybackSpeed,
+    );
+  }
+
+  // The source video list is the real dub/sub control (entries like "1080p Sub"
+  // / "1080p Dub"); switching re-opens the stream at that source. Mirrors
+  // _videoQualityWidget's selection logic for the TV pill bar.
+  List<TvTrackOption> _buildTvQualityOptions() {
+    if (widget.isLocal || widget.videos.isEmpty) return const <TvTrackOption>[];
+    final currentTitle = _video.value?.videoTrack?.title;
+    return [
+      for (final video in widget.videos)
+        TvTrackOption(
+          label: _shortQuality(video.quality),
+          selected: currentTitle == video.quality,
+          onSelect: () {
+            if (_video.value?.videoTrack?.title == video.quality) return;
+            final prefs = VideoPrefs(
+              videoTrack: VideoTrack(video.url, video.quality, video.quality),
+              headers: video.headers,
+              isLocal: false,
+            );
+            _video.value = prefs;
+            _player.stop();
+            _openMedia(prefs);
+            _initSubtitleAndAudio = true;
+          },
+        ),
+    ];
+  }
+
+  // Shorten a source quality label like "1080p (Sub)" to "1080-sub"/"1080-dub".
+  String _shortQuality(String raw) {
+    final lower = raw.toLowerCase();
+    final res = RegExp(r'(\d{3,4})\s*p?').firstMatch(lower)?.group(1);
+    final tag = lower.contains('sub')
+        ? 'sub'
+        : lower.contains('dub')
+        ? 'dub'
+        : null;
+    if (res != null && tag != null) return '$res-$tag';
+    if (res != null) return '${res}p';
+    return raw;
+  }
+
   Widget _mobileBottomButtonBar(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 30),
@@ -1555,11 +1843,16 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8),
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 _seekToWidget(),
                 _chapterMarkWidget(),
-                _buildSettingsButtons(context),
+                Expanded(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    reverse: true,
+                    child: _buildSettingsButtons(context),
+                  ),
+                ),
               ],
             ),
           ),
@@ -1825,7 +2118,8 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             controller: _controller,
             desktopFullScreenPlayer: widget.desktopFullScreenPlayer,
           )
-        else
+        // A TV is always fullscreen, so the toggle is useless there — hide it.
+        else if (!isTv)
           IconButton(
             icon: Icon(isFullscreen ? Icons.fullscreen_exit : Icons.fullscreen),
             iconSize: 25,
@@ -1896,6 +2190,34 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           ),
           Row(
             children: [
+              Consumer(
+                builder: (context, ref, _) {
+                  final autoPlay = ref.watch(autoPlayNextEpisodeProvider);
+                  // Same drawn play/pause switch as the TV player, for a
+                  // consistent autoplay toggle across all players.
+                  return Tooltip(
+                    message: autoPlay
+                        ? 'Autoplay next episode: on'
+                        : 'Autoplay next episode: off',
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(20),
+                      onTap: () => ref
+                          .read(autoPlayNextEpisodeProvider.notifier)
+                          .toggle(),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 8,
+                        ),
+                        child: AutoplaySwitch(
+                          on: autoPlay,
+                          accent: Theme.of(context).colorScheme.primary,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
               if (_supportAlwaysOnTop())
                 IconButton(
                   icon: Icon(
@@ -1959,16 +2281,21 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     final enableAutoSkip = ref.read(enableAutoSkipStateProvider);
     final aniSkipTimeoutLength = ref.read(aniSkipTimeoutLengthStateProvider);
     final skipIntroLength = ref.read(defaultSkipIntroLengthStateProvider);
-    return Stack(
+    final splitSettings = isTv && _tvSettingsOpen;
+    final Widget player = Stack(
       children: [
         Video(
           subtitleViewConfiguration: SubtitleViewConfiguration(
             visible: false,
             style: subtileTextStyle(ref),
           ),
-          fit: fit,
+          // Docked in the split view, always contain so the whole frame shows
+          // at its true aspect ratio rather than cropping to the narrower slot.
+          fit: splitSettings ? BoxFit.contain : fit,
           key: _key,
-          controls: (state) => isDesktop
+          controls: (state) => (isTv && ref.read(tvPlayerStyleProvider))
+              ? (_tvSettingsOpen ? const SizedBox.shrink() : _tvControls())
+              : (isDesktop || isTv)
               ? DesktopControllerWidget(
                   videoController: _controller,
                   topButtonBarWidget: _topButtonBar(context),
@@ -1988,6 +2315,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
                   defaultSkipIntroLength: skipIntroLength,
                   desktopFullScreenPlayer: widget.desktopFullScreenPlayer,
                   chapterMarks: _chapterMarks,
+                  revealControls: _revealControls,
                 )
               : MobileControllerWidget(
                   videoController: _controller,
@@ -1995,14 +2323,17 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
                   videoStatekey: _key,
                   bottomButtonBarWidget: _mobileBottomButtonBar(context),
                   streamController: _streamController,
+                  revealControls: _revealControls,
                   doubleSpeed: (value) {
                     _isDoubleSpeed.value = value ?? false;
                   },
                   chapterMarks: _chapterMarks,
                 ),
           controller: _controller,
-          width: context.width(1),
-          height: context.height(1),
+          // When docked left for the settings panel, fill the (narrower) slot
+          // the Row gives us rather than forcing full-screen width.
+          width: splitSettings ? null : context.width(1),
+          height: splitSettings ? null : context.height(1),
           resumeUponEnteringForegroundMode: true,
         ),
         Stack(
@@ -2070,6 +2401,43 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             ),
           ),
       ],
+    );
+    if (!splitSettings) return player;
+    // YouTube-style split: video docks left (a single focusable unit — Left
+    // from the panel focuses it, Select toggles play/pause), a gap, then the
+    // settings panel on the right.
+    final accent = Theme.of(context).colorScheme.primary;
+    return ColoredBox(
+      color: Colors.black,
+      child: Row(
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: TvVideoFocusFrame(
+                accent: accent,
+                player: _player,
+                focusNode: _tvVideoFocus,
+                onSelect: () => _player.playOrPause(),
+                onExitRight: () => _tvPanelFocus.requestFocus(),
+                child: player,
+              ),
+            ),
+          ),
+          TvPlayerSettingsPanel(
+            player: _player,
+            speedListenable: _playbackSpeed,
+            onSetSpeed: _setPlaybackSpeed,
+            selectedShaderListenable: _selectedShader,
+            qualityOptions: _tvQualityOptions,
+            subtitleOptions: _tvSubtitleOptions,
+            audioOptions: _tvAudioOptions,
+            headerFocusNode: _tvPanelFocus,
+            onExitLeft: () => _tvVideoFocus.requestFocus(),
+            onClose: () => setState(() => _tvSettingsOpen = false),
+          ),
+        ],
+      ),
     );
   }
 
@@ -2278,7 +2646,92 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(body: _videoPlayer(context));
+    final body = _videoPlayer(context);
+    // Desktop already gets player keyboard shortcuts through media_kit's
+    // DesktopControllerWidget. On mobile / Android TV the controls have none,
+    // so wrap the player so a physical keyboard or TV remote can drive
+    // playback too. See #668 / #729.
+    return Scaffold(
+      body: isDesktop ? body : _wrapWithPlayerShortcuts(body),
+    );
+  }
+
+  /// Maps keyboard and TV-remote keys to player actions for non-desktop
+  /// builds. Only dedicated media keys + the usual mpv-style keys are bound
+  /// (no D-pad arrows beyond seek), so it stays additive and doesn't fight
+  /// touch input. Reuses the existing player + episode-navigation methods.
+  Widget _wrapWithPlayerShortcuts(Widget child) {
+    void seekBy(int seconds) {
+      _player.seek(_player.state.position + Duration(seconds: seconds));
+    }
+
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.space): () {
+          _player.playOrPause();
+        },
+        const SingleActivator(LogicalKeyboardKey.mediaPlayPause): () {
+          _player.playOrPause();
+        },
+        const SingleActivator(LogicalKeyboardKey.mediaPlay): () {
+          _player.play();
+        },
+        const SingleActivator(LogicalKeyboardKey.mediaPause): () {
+          _player.pause();
+        },
+        // Seek via J/L and the dedicated media keys only. Arrow keys are left
+        // unbound so they keep driving d-pad focus traversal on Android TV
+        // (and arrow-key focus movement with a keyboard) instead of seeking.
+        const SingleActivator(LogicalKeyboardKey.keyJ): () => seekBy(-10),
+        const SingleActivator(LogicalKeyboardKey.keyL): () => seekBy(10),
+        const SingleActivator(LogicalKeyboardKey.mediaRewind): () => seekBy(-10),
+        const SingleActivator(LogicalKeyboardKey.mediaFastForward): () =>
+            seekBy(10),
+        const SingleActivator(LogicalKeyboardKey.mediaTrackNext): () {
+          if (hasNextEpisode && mounted) {
+            pushToNewEpisode(context, _streamController.getNextEpisode());
+          }
+        },
+        const SingleActivator(LogicalKeyboardKey.mediaTrackPrevious): () {
+          if (_streamController.hasPreviousEpisode && mounted) {
+            pushToNewEpisode(context, _streamController.getPrevEpisode());
+          }
+        },
+      },
+      child: MouseRegion(
+        // Desktop debugging: a mouse has no d-pad, so let hover and clicks
+        // reveal the auto-hiding controls (bumping the same notifier the remote
+        // does). No-op on a TV, which sends no pointer-hover events.
+        onEnter: (_) => _revealControls.value++,
+        onHover: (_) => _revealControls.value++,
+        child: Listener(
+          onPointerDown: (_) => _revealControls.value++,
+          child: Focus(autofocus: true, onKeyEvent: _onPlayerKey, child: child),
+        ),
+      ),
+    );
+  }
+
+  // On a TV remote / keyboard, reveal the on-screen controls when the user
+  // presses the d-pad. The arrow keys stay unbound above (so they still drive
+  // focus traversal between the control buttons) — we just bump [_revealControls]
+  // so the controls become visible and the focus is on something the user can
+  // see. Returns ignored so traversal + the media shortcuts still run.
+  KeyEventResult _onPlayerKey(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent || event is KeyRepeatEvent) {
+      final k = event.logicalKey;
+      final isNav =
+          k == LogicalKeyboardKey.arrowUp ||
+          k == LogicalKeyboardKey.arrowDown ||
+          k == LogicalKeyboardKey.arrowLeft ||
+          k == LogicalKeyboardKey.arrowRight ||
+          k == LogicalKeyboardKey.select ||
+          k == LogicalKeyboardKey.enter ||
+          k == LogicalKeyboardKey.numpadEnter ||
+          k == LogicalKeyboardKey.gameButtonA;
+      if (isNav) _revealControls.value++;
+    }
+    return KeyEventResult.ignored;
   }
 }
 

--- a/lib/modules/anime/providers/auto_play_next_provider.dart
+++ b/lib/modules/anime/providers/auto_play_next_provider.dart
@@ -1,46 +1,26 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hive/hive.dart';
-
-/// Hive box + key holding the "autoplay next episode" preference.
-///
-/// Stored in Hive (not the Isar Settings collection) so the toggle persists
-/// without touching the generated Isar schema. The box is opened once at
-/// startup in `_postLaunchInit`; see [openPlayerPrefsBox].
-const _playerPrefsBox = 'player_prefs';
-const _autoPlayNextKey = 'auto_play_next_episode';
-
-/// Opens the player-preferences box. Called once during app startup so the
-/// value can be read synchronously by [AutoPlayNextEpisode.build].
-Future<void> openPlayerPrefsBox() async {
-  if (!Hive.isBoxOpen(_playerPrefsBox)) {
-    await Hive.openBox(_playerPrefsBox);
-  }
-}
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/settings.dart';
 
 /// Whether the player should automatically start the next episode when the
 /// current one finishes. Defaults to `true` (the previous always-on behavior).
-/// Toggled from a button in the player and persisted across sessions.
+/// Toggled from a button in the player and persisted on the Settings collection.
 final autoPlayNextEpisodeProvider =
     NotifierProvider<AutoPlayNextEpisode, bool>(AutoPlayNextEpisode.new);
 
 class AutoPlayNextEpisode extends Notifier<bool> {
   @override
-  bool build() {
-    if (Hive.isBoxOpen(_playerPrefsBox)) {
-      // Read defensively: a missing or non-bool value (corrupt / hand-edited
-      // box) falls back to the default rather than throwing during build.
-      final value = Hive.box(_playerPrefsBox).get(_autoPlayNextKey);
-      if (value is bool) return value;
-    }
-    return true;
-  }
+  bool build() => isar.settings.getSync(227)?.autoPlayNextEpisode ?? true;
 
   void toggle() => set(!state);
 
   void set(bool value) {
     state = value;
-    if (Hive.isBoxOpen(_playerPrefsBox)) {
-      Hive.box(_playerPrefsBox).put(_autoPlayNextKey, value);
-    }
+    isar.writeTxnSync(() {
+      final settings = isar.settings.getSync(227);
+      if (settings != null) {
+        isar.settings.putSync(settings..autoPlayNextEpisode = value);
+      }
+    });
   }
 }

--- a/lib/modules/anime/providers/auto_play_next_provider.dart
+++ b/lib/modules/anime/providers/auto_play_next_provider.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+/// Hive box + key holding the "autoplay next episode" preference.
+///
+/// Stored in Hive (not the Isar Settings collection) so the toggle persists
+/// without touching the generated Isar schema. The box is opened once at
+/// startup in `_postLaunchInit`; see [openPlayerPrefsBox].
+const _playerPrefsBox = 'player_prefs';
+const _autoPlayNextKey = 'auto_play_next_episode';
+
+/// Opens the player-preferences box. Called once during app startup so the
+/// value can be read synchronously by [AutoPlayNextEpisode.build].
+Future<void> openPlayerPrefsBox() async {
+  if (!Hive.isBoxOpen(_playerPrefsBox)) {
+    await Hive.openBox(_playerPrefsBox);
+  }
+}
+
+/// Whether the player should automatically start the next episode when the
+/// current one finishes. Defaults to `true` (the previous always-on behavior).
+/// Toggled from a button in the player and persisted across sessions.
+final autoPlayNextEpisodeProvider =
+    NotifierProvider<AutoPlayNextEpisode, bool>(AutoPlayNextEpisode.new);
+
+class AutoPlayNextEpisode extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_playerPrefsBox)) {
+      // Read defensively: a missing or non-bool value (corrupt / hand-edited
+      // box) falls back to the default rather than throwing during build.
+      final value = Hive.box(_playerPrefsBox).get(_autoPlayNextKey);
+      if (value is bool) return value;
+    }
+    return true;
+  }
+
+  void toggle() => set(!state);
+
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_playerPrefsBox)) {
+      Hive.box(_playerPrefsBox).put(_autoPlayNextKey, value);
+    }
+  }
+}

--- a/lib/modules/anime/widgets/desktop.dart
+++ b/lib/modules/anime/widgets/desktop.dart
@@ -27,7 +27,7 @@ class DesktopControllerWidget extends ConsumerStatefulWidget {
   final void Function(bool) desktopFullScreenPlayer;
   final ValueNotifier<List<(String, int)>> chapterMarks;
   // Bumped by the player on each d-pad key so the desktop controls can reveal on
-  // a TV remote — they otherwise only appear on mouse hover. Null off-TV.
+  // a TV remote - they otherwise only appear on mouse hover. Null off-TV.
   final ValueNotifier<int>? revealControls;
   const DesktopControllerWidget({
     super.key,
@@ -75,7 +75,7 @@ class _DesktopControllerWidgetState
   @override
   void initState() {
     super.initState();
-    // Reveal on a d-pad key (TV remote) — the desktop controls otherwise only
+    // Reveal on a d-pad key (TV remote) - the desktop controls otherwise only
     // appear on mouse hover, which a remote can't trigger.
     widget.revealControls?.addListener(_onRevealRequest);
   }

--- a/lib/modules/anime/widgets/desktop.dart
+++ b/lib/modules/anime/widgets/desktop.dart
@@ -26,6 +26,9 @@ class DesktopControllerWidget extends ConsumerStatefulWidget {
   final int defaultSkipIntroLength;
   final void Function(bool) desktopFullScreenPlayer;
   final ValueNotifier<List<(String, int)>> chapterMarks;
+  // Bumped by the player on each d-pad key so the desktop controls can reveal on
+  // a TV remote — they otherwise only appear on mouse hover. Null off-TV.
+  final ValueNotifier<int>? revealControls;
   const DesktopControllerWidget({
     super.key,
     required this.videoController,
@@ -39,6 +42,7 @@ class DesktopControllerWidget extends ConsumerStatefulWidget {
     required this.defaultSkipIntroLength,
     required this.desktopFullScreenPlayer,
     required this.chapterMarks,
+    this.revealControls,
   });
 
   @override
@@ -67,6 +71,18 @@ class _DesktopControllerWidgetState
   final List<StreamSubscription> subscriptions = [];
   DateTime last = DateTime.now();
   Timer? _tapTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    // Reveal on a d-pad key (TV remote) — the desktop controls otherwise only
+    // appear on mouse hover, which a remote can't trigger.
+    widget.revealControls?.addListener(_onRevealRequest);
+  }
+
+  void _onRevealRequest() {
+    if (mounted) onEnter();
+  }
 
   @override
   void setState(VoidCallback fn) {
@@ -99,6 +115,7 @@ class _DesktopControllerWidgetState
 
   @override
   void dispose() {
+    widget.revealControls?.removeListener(_onRevealRequest);
     for (final subscription in subscriptions) {
       subscription.cancel();
     }

--- a/lib/modules/anime/widgets/mobile.dart
+++ b/lib/modules/anime/widgets/mobile.dart
@@ -25,6 +25,8 @@ class MobileControllerWidget extends ConsumerStatefulWidget {
   final GlobalKey<VideoState> videoStatekey;
   final Widget bottomButtonBarWidget;
   final ValueNotifier<List<(String, int)>> chapterMarks;
+  // Bumped by the player on each d-pad key so the controls reveal on a TV remote.
+  final ValueNotifier<int> revealControls;
   const MobileControllerWidget({
     super.key,
     required this.videoController,
@@ -34,6 +36,7 @@ class MobileControllerWidget extends ConsumerStatefulWidget {
     required this.videoStatekey,
     required this.doubleSpeed,
     required this.chapterMarks,
+    required this.revealControls,
   });
 
   @override
@@ -45,6 +48,14 @@ class _MobileControllerWidgetState
     extends ConsumerState<MobileControllerWidget> {
   bool mount = true;
   bool visible = true;
+  // Wraps the control buttons; requestFocus()'d on reveal so the d-pad lands on
+  // a real button (see _onRevealRequest).
+  final FocusScopeNode _controlsScope = FocusScopeNode(
+    debugLabel: 'playerControls',
+  );
+  // The center play/pause — focused first on reveal so the d-pad lands on the
+  // main control rather than the top-bar back button.
+  final FocusNode _playPauseFocus = FocusNode(debugLabel: 'playerPlayPause');
   Duration controlsTransitionDuration = const Duration(milliseconds: 300);
   Color backdropColor = const Color(0x66000000);
   Timer? _timer;
@@ -125,8 +136,40 @@ class _MobileControllerWidgetState
     }
   }
 
+  // Called by the player on each d-pad key: reveal the controls if hidden and
+  // keep them on-screen while the user navigates the buttons with the remote.
+  void _onRevealRequest() {
+    if (!mounted) return;
+    if (!visible) {
+      setState(() {
+        mount = true;
+        visible = true;
+      });
+    }
+    _restartHideTimer();
+    // Move focus onto the controls only when it isn't already there. A
+    // FocusScope delegates requestFocus to its first focusable descendant, so
+    // this reliably lands the d-pad on a real button — unlike directional
+    // traversal from the full-screen player Focus, which never landed anywhere.
+    // Once focus is inside, subsequent keys navigate the buttons freely.
+    if (!_controlsScope.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        // Prefer the center play/pause; fall back to the scope's first button.
+        if (_playPauseFocus.canRequestFocus) {
+          _playPauseFocus.requestFocus();
+        } else {
+          _controlsScope.requestFocus();
+        }
+      });
+    }
+  }
+
   @override
   void dispose() {
+    widget.revealControls.removeListener(_onRevealRequest);
+    _controlsScope.dispose();
+    _playPauseFocus.dispose();
     for (final subscription in subscriptions) {
       subscription.cancel();
     }
@@ -172,6 +215,19 @@ class _MobileControllerWidgetState
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
       _timer?.cancel();
     }
+  }
+
+
+  void _restartHideTimer() {
+    _timer?.cancel();
+    _timer = Timer(controlsHoverDuration, () {
+      if (mounted) {
+        setState(() {
+          visible = false;
+        });
+        SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
+      }
+    });
   }
 
   void onDoubleTapSeekBackward() {
@@ -234,6 +290,7 @@ class _MobileControllerWidgetState
   @override
   void initState() {
     super.initState();
+    widget.revealControls.addListener(_onRevealRequest);
     _volumeController = VolumeController.instance;
 
     Future.microtask(() async {
@@ -309,8 +366,8 @@ class _MobileControllerWidgetState
                   ),
                 ),
         ),
-        Focus(
-          autofocus: true,
+        FocusScope(
+          node: _controlsScope,
           child: Stack(
             clipBehavior: Clip.none,
             alignment: Alignment.center,
@@ -429,12 +486,23 @@ class _MobileControllerWidgetState
                                     : 1.0,
                                 duration: controlsTransitionDuration,
                                 child: Center(
-                                  child: Row(
-                                    children: mobilePrimaryButtonBar(
-                                      context,
-                                      widget.videoStatekey,
-                                      widget.streamController,
-                                      widget.videoController,
+                                  // Brighter focus highlight on the main controls
+                                  // so the focused button stands out against the
+                                  // dark backdrop on a TV.
+                                  child: Theme(
+                                    data: Theme.of(context).copyWith(
+                                      focusColor: Colors.white.withValues(
+                                        alpha: 0.45,
+                                      ),
+                                    ),
+                                    child: Row(
+                                      children: mobilePrimaryButtonBar(
+                                        context,
+                                        widget.videoStatekey,
+                                        widget.streamController,
+                                        widget.videoController,
+                                        playPauseFocus: _playPauseFocus,
+                                      ),
                                     ),
                                   ),
                                 ),
@@ -890,8 +958,9 @@ List<Widget> mobilePrimaryButtonBar(
   BuildContext context,
   GlobalKey<VideoState> key,
   AnimeStreamController streamController,
-  VideoController controller,
-) {
+  VideoController controller, {
+  FocusNode? playPauseFocus,
+}) {
   bool hasPrevEpisode =
       streamController.getEpisodeIndex().$1 + 1 !=
       streamController.getEpisodesLength(streamController.getEpisodeIndex().$2);
@@ -918,7 +987,7 @@ List<Widget> mobilePrimaryButtonBar(
       ),
     ),
     const Spacer(),
-    CustomPlayOrPauseButton(controller: controller),
+    CustomPlayOrPauseButton(controller: controller, focusNode: playPauseFocus),
     const Spacer(),
     IconButton(
       onPressed: hasNextEpisode

--- a/lib/modules/anime/widgets/mobile.dart
+++ b/lib/modules/anime/widgets/mobile.dart
@@ -53,7 +53,7 @@ class _MobileControllerWidgetState
   final FocusScopeNode _controlsScope = FocusScopeNode(
     debugLabel: 'playerControls',
   );
-  // The center play/pause — focused first on reveal so the d-pad lands on the
+  // The center play/pause - focused first on reveal so the d-pad lands on the
   // main control rather than the top-bar back button.
   final FocusNode _playPauseFocus = FocusNode(debugLabel: 'playerPlayPause');
   Duration controlsTransitionDuration = const Duration(milliseconds: 300);
@@ -149,7 +149,7 @@ class _MobileControllerWidgetState
     _restartHideTimer();
     // Move focus onto the controls only when it isn't already there. A
     // FocusScope delegates requestFocus to its first focusable descendant, so
-    // this reliably lands the d-pad on a real button — unlike directional
+    // this reliably lands the d-pad on a real button - unlike directional
     // traversal from the full-screen player Focus, which never landed anywhere.
     // Once focus is inside, subsequent keys navigate the buttons freely.
     if (!_controlsScope.hasFocus) {

--- a/lib/modules/anime/widgets/play_or_pause_button.dart
+++ b/lib/modules/anime/widgets/play_or_pause_button.dart
@@ -8,8 +8,13 @@ import 'package:media_kit_video/media_kit_video.dart';
 /// A material design play/pause button.
 class CustomPlayOrPauseButton extends StatefulWidget {
   final VideoController controller;
+  final FocusNode? focusNode;
 
-  const CustomPlayOrPauseButton({super.key, required this.controller});
+  const CustomPlayOrPauseButton({
+    super.key,
+    required this.controller,
+    this.focusNode,
+  });
 
   @override
   CustomPlayOrPauseButtonState createState() => CustomPlayOrPauseButtonState();
@@ -56,6 +61,7 @@ class CustomPlayOrPauseButtonState extends State<CustomPlayOrPauseButton>
   @override
   Widget build(BuildContext context) {
     return IconButton(
+      focusNode: widget.focusNode,
       onPressed: widget.controller.player.playOrPause,
       iconSize: iconSize,
       color: Colors.white,

--- a/lib/modules/anime/widgets/tv_player_controls.dart
+++ b/lib/modules/anime/widgets/tv_player_controls.dart
@@ -992,15 +992,10 @@ class _TrackPillState extends State<_TrackPill> {
 
 /// A focusable seek bar: Left/Right seek a small fixed amount; Up/Down escape.
 class _TvSeekBar extends StatefulWidget {
-  const _TvSeekBar({
-    required this.player,
-    required this.accent,
-    this.focusNode,
-  });
+  const _TvSeekBar({required this.player, required this.accent});
 
   final Player player;
   final Color accent;
-  final FocusNode? focusNode;
 
   @override
   State<_TvSeekBar> createState() => _TvSeekBarState();
@@ -1012,7 +1007,7 @@ class _TvSeekBarState extends State<_TvSeekBar> {
   // Own a node when the parent doesn't supply one, so a mouse click can focus
   // the bar (and hand keyboard seeking over to it) on desktop.
   FocusNode? _ownNode;
-  FocusNode get _node => widget.focusNode ?? (_ownNode ??= FocusNode());
+  FocusNode get _node => _ownNode ??= FocusNode();
 
   @override
   void dispose() {

--- a/lib/modules/anime/widgets/tv_player_controls.dart
+++ b/lib/modules/anime/widgets/tv_player_controls.dart
@@ -246,7 +246,7 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
                     Consumer(
                       builder: (context, ref, _) {
                         final on = ref.watch(autoPlayNextEpisodeProvider);
-                        return _AutoplayToggle(
+                        return AutoplayToggle(
                           accent: accent,
                           on: on,
                           onToggle: () => ref
@@ -796,9 +796,12 @@ class _PillDivider extends StatelessWidget {
   }
 }
 
-/// A compact YouTube-style "Autoplay" labelled switch, focusable for the d-pad.
-class _AutoplayToggle extends StatefulWidget {
-  const _AutoplayToggle({
+/// A compact YouTube-style autoplay switch, focusable for the d-pad. Shared by
+/// the TV player and the mobile/desktop player so the toggle is visually
+/// identical across platforms.
+class AutoplayToggle extends StatefulWidget {
+  const AutoplayToggle({
+    super.key,
     required this.accent,
     required this.on,
     required this.onToggle,
@@ -809,10 +812,10 @@ class _AutoplayToggle extends StatefulWidget {
   final VoidCallback onToggle;
 
   @override
-  State<_AutoplayToggle> createState() => _AutoplayToggleState();
+  State<AutoplayToggle> createState() => AutoplayToggleState();
 }
 
-class _AutoplayToggleState extends State<_AutoplayToggle> {
+class AutoplayToggleState extends State<AutoplayToggle> {
   bool _focused = false;
 
   @override
@@ -850,7 +853,7 @@ class _AutoplayToggleState extends State<_AutoplayToggle> {
 /// black knob that slides right + shows ▶ when on, left + shows ⏸ when off —
 /// matching the reference toggle style.
 class AutoplaySwitch extends StatelessWidget {
-  const AutoplaySwitch({required this.on, required this.accent});
+  const AutoplaySwitch({super.key, required this.on, required this.accent});
 
   final bool on;
   final Color accent;

--- a/lib/modules/anime/widgets/tv_player_controls.dart
+++ b/lib/modules/anime/widgets/tv_player_controls.dart
@@ -1,0 +1,1234 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
+import 'package:media_kit/media_kit.dart';
+
+/// A dedicated, Netflix-style controls overlay for the anime player on TV.
+///
+/// Only the essentials are on screen — play/pause, prev/next episode, a seek
+/// bar with times, and audio/subtitle access — everything else lives behind the
+/// gear. Built for the d-pad: theme-coloured focus highlight on every control,
+/// the seek bar seeks a small fixed amount on Left/Right and lets Up/Down move
+/// focus away, and the reveal/auto-hide is driven by [revealControls] (bumped by
+/// the player on each key).
+class TvPlayerControls extends StatefulWidget {
+  const TvPlayerControls({
+    super.key,
+    required this.player,
+    required this.revealControls,
+    required this.title,
+    required this.episodeLabel,
+    required this.onBack,
+    required this.onRestart,
+    required this.onSettings,
+    required this.hasNext,
+    required this.onNext,
+    required this.qualityListenable,
+    required this.buildQualityOptions,
+    required this.speedListenable,
+    required this.onSetSpeed,
+  });
+
+  final Player player;
+  final ValueNotifier<int> revealControls;
+  final String title;
+  final String episodeLabel;
+  final VoidCallback onBack;
+  final VoidCallback onRestart;
+  final VoidCallback onSettings;
+  final bool hasNext;
+  final VoidCallback? onNext;
+  // Quality = the source video list (e.g. "1080p Sub"/"1080p Dub") — the real
+  // dub/sub control here. Rebuilt when [qualityListenable] fires.
+  final Listenable qualityListenable;
+  final List<TvTrackOption> Function() buildQualityOptions;
+  // Playback speed: routed through the parent so its own speed notifier (used by
+  // the hold-to-2x gesture) stays in sync rather than calling setRate directly.
+  final ValueListenable<double> speedListenable;
+  final ValueChanged<double> onSetSpeed;
+
+  @override
+  State<TvPlayerControls> createState() => _TvPlayerControlsState();
+}
+
+class _TvPlayerControlsState extends State<TvPlayerControls> {
+  bool _visible = true;
+  Timer? _hideTimer;
+  final FocusScopeNode _scope = FocusScopeNode(debugLabel: 'tvPlayer');
+  final FocusNode _playFocus = FocusNode(debugLabel: 'tvPlayerPlayPause');
+  // Always in the tree, even while hidden (when the controls collapse to an
+  // empty box and leave no focusable node). Focus parks here on hide so a key
+  // press can still wake the panel — otherwise, on a keyboard, once it hides
+  // there's nothing focused to receive the wake key.
+  final FocusNode _rootFocus = FocusNode(debugLabel: 'tvPlayerRoot');
+  static const _hideAfter = Duration(seconds: 4);
+
+  @override
+  void initState() {
+    super.initState();
+    widget.revealControls.addListener(_reveal);
+    // Re-arm the hide timer on every key event (see _onAnyKey): a control's own
+    // handler consumes its key, so an ancestor Focus would never see it — a
+    // hardware-keyboard handler is the only spot that catches *all* presses.
+    HardwareKeyboard.instance.addHandler(_onAnyKey);
+    _startHideTimer();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _playFocus.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    HardwareKeyboard.instance.removeHandler(_onAnyKey);
+    widget.revealControls.removeListener(_reveal);
+    _hideTimer?.cancel();
+    _scope.dispose();
+    _playFocus.dispose();
+    _rootFocus.dispose();
+    super.dispose();
+  }
+
+  // Keep the panel alive while the user is actually pressing keys: any key (a
+  // d-pad nudge, a held seek's repeats) restarts the hide countdown, so it never
+  // vanishes mid-interaction or steals focus off the seek bar. Returns false so
+  // the event still dispatches to whatever is focused. Skipped when a dialog is
+  // on top (that case is handled by _onHideTimer re-arming).
+  bool _onAnyKey(KeyEvent event) {
+    if (mounted && _visible && _isTopRoute) _startHideTimer();
+    return false;
+  }
+
+  // True while the player is the topmost route. When a dialog (speed / settings)
+  // is open on top, the panel must not hide or touch focus — doing so steals
+  // focus out of the dialog and back to the play button behind it.
+  bool get _isTopRoute => ModalRoute.of(context)?.isCurrent ?? true;
+
+  void _reveal() {
+    if (!mounted) return;
+    final wasHidden = !_visible;
+    if (wasHidden) setState(() => _visible = true);
+    // Always extend the hide timer (so a moving mouse keeps controls up), but
+    // only grab focus on the hidden→visible edge — otherwise a stream of mouse
+    // hover events would re-request focus every frame.
+    _startHideTimer();
+    if (wasHidden && !_scope.hasFocus && _isTopRoute) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        (_playFocus.canRequestFocus ? _playFocus : _scope).requestFocus();
+      });
+    }
+  }
+
+  void _startHideTimer() {
+    _hideTimer?.cancel();
+    _hideTimer = Timer(_hideAfter, _onHideTimer);
+  }
+
+  void _onHideTimer() {
+    if (!mounted) return;
+    // A dialog is open on top — keep the panel and don't touch focus; re-arm so
+    // it hides once the player is back on top.
+    if (!_isTopRoute) {
+      _startHideTimer();
+      return;
+    }
+    _hideNow();
+  }
+
+  // Hide the control panel and park focus on the root node so a key press can
+  // still wake it (Back also dismisses the panel before leaving the player).
+  void _hideNow() {
+    _hideTimer?.cancel();
+    if (!mounted || !_visible) return;
+    setState(() => _visible = false);
+    _rootFocus.requestFocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.primary;
+    // TV overscan-safe margins (~5% per side, Netflix-generous). Only the
+    // interactive controls/title are inset — the scrim stays full-bleed, per
+    // Android TV layout guidance.
+    final size = MediaQuery.of(context).size;
+    final safeH = size.width * 0.08;
+    final safeV = size.height * 0.05;
+    // Back dismisses the visible control panel before it leaves the player:
+    // block the pop while the panel shows and hide it instead; a second Back
+    // (panel already hidden) exits normally. The on-screen back arrow still
+    // exits outright — it pops directly, bypassing this.
+    return PopScope(
+      canPop: !_visible,
+      onPopInvokedWithResult: (didPop, result) {
+        if (!didPop && _visible) _hideNow();
+      },
+      child: Focus(
+        focusNode: _rootFocus,
+        // While the panel is hidden this node holds focus; any d-pad / select
+        // key wakes the panel (and is consumed so it doesn't also act). While
+        // visible it defers to the focused control. Back is left alone so it
+        // still exits.
+        onKeyEvent: (node, event) {
+          if (_visible) return KeyEventResult.ignored;
+          if (event is KeyDownEvent || event is KeyRepeatEvent) {
+            final k = event.logicalKey;
+            // OK while hidden reveals the panel *and* toggles play/pause, so a
+            // blind press does the obvious thing without a second keystroke.
+            if (event is KeyDownEvent && _isSelect(k)) {
+              _reveal();
+              widget.player.playOrPause();
+              return KeyEventResult.handled;
+            }
+            final wake =
+                k == LogicalKeyboardKey.arrowUp ||
+                k == LogicalKeyboardKey.arrowDown ||
+                k == LogicalKeyboardKey.arrowLeft ||
+                k == LogicalKeyboardKey.arrowRight;
+            if (wake) {
+              _reveal();
+              return KeyEventResult.handled;
+            }
+          }
+          return KeyEventResult.ignored;
+        },
+        child: FocusScope(
+          node: _scope,
+      // Only build the controls (and their per-frame StreamBuilders) while
+      // visible. Otherwise the seek/time streams rebuild ~4x/sec during
+      // playback and jank the Fire TV — hidden means nothing to render.
+      child: !_visible
+          ? const SizedBox.expand()
+          : Stack(
+              children: [
+              // Scrim so white controls read over any frame.
+              Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        Colors.black.withValues(alpha: 0.55),
+                        Colors.black.withValues(alpha: 0.15),
+                        Colors.black.withValues(alpha: 0.65),
+                      ],
+                      stops: const [0.0, 0.45, 1.0],
+                    ),
+                  ),
+                ),
+              ),
+              // Top-left: back / restart / autoplay (gear lives by the pills).
+              Positioned(
+                top: safeV,
+                left: safeH,
+                child: Row(
+                  children: [
+                    _TvFocusable(
+                      accent: accent,
+                      onPressed: widget.onBack,
+                      child: const Icon(Icons.arrow_back, color: Colors.white),
+                    ),
+                    const SizedBox(width: 8),
+                    _TvFocusable(
+                      accent: accent,
+                      onPressed: widget.onRestart,
+                      child: const Icon(
+                        Icons.replay_outlined,
+                        color: Colors.white,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    // Autoplay-next — YouTube-style labelled switch.
+                    Consumer(
+                      builder: (context, ref, _) {
+                        final on = ref.watch(autoPlayNextEpisodeProvider);
+                        return _AutoplayToggle(
+                          accent: accent,
+                          on: on,
+                          onToggle: () => ref
+                              .read(autoPlayNextEpisodeProvider.notifier)
+                              .toggle(),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              // Top-right: title + episode.
+              Positioned(
+                top: safeV,
+                right: safeH,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    if (widget.title.isNotEmpty)
+                      Text(
+                        widget.title,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    if (widget.episodeLabel.isNotEmpty)
+                      Text(
+                        widget.episodeLabel,
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 14,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              // Bottom: controls + seek + tracks.
+              Positioned(
+                left: safeH,
+                right: safeH,
+                bottom: safeV,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    // Play/pause inline on the left of the seek line. Default
+                    // focus + highlighted; OK on the seek bar also toggles it.
+                    Row(
+                      children: [
+                        _PlayPauseButton(
+                          player: widget.player,
+                          accent: accent,
+                          focusNode: _playFocus,
+                        ),
+                        const SizedBox(width: 14),
+                        _PositionText(player: widget.player),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: _TvSeekBar(
+                            player: widget.player,
+                            accent: accent,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        _RemainingText(player: widget.player),
+                        // Manual skip to the next episode (autoplay still
+                        // auto-advances at the end); shown only if there is one.
+                        if (widget.hasNext) ...[
+                          const SizedBox(width: 8),
+                          _TvFocusable(
+                            accent: accent,
+                            onPressed: widget.onNext,
+                            // Match the play/pause size (34) so the two
+                            // transport controls frame the seek bar evenly.
+                            child: const Icon(
+                              Icons.skip_next,
+                              color: Colors.white,
+                              size: 34,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    // Quality | Subtitles | Speed | Settings pills.
+                    _PillBar(
+                      player: widget.player,
+                      accent: accent,
+                      qualityListenable: widget.qualityListenable,
+                      buildQualityOptions: widget.buildQualityOptions,
+                      onSettings: widget.onSettings,
+                      speedListenable: widget.speedListenable,
+                      onSetSpeed: widget.onSetSpeed,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+bool _isSelect(LogicalKeyboardKey k) =>
+    k == LogicalKeyboardKey.select ||
+    k == LogicalKeyboardKey.enter ||
+    k == LogicalKeyboardKey.numpadEnter ||
+    k == LogicalKeyboardKey.gameButtonA ||
+    k == LogicalKeyboardKey.space;
+
+/// A focusable control that shows a solid theme-accent background when focused
+/// (clearly visible over the dark backdrop) and fires [onPressed] on select.
+class _TvFocusable extends StatefulWidget {
+  const _TvFocusable({
+    required this.accent,
+    required this.child,
+    required this.onPressed,
+    this.focusNode,
+    this.autofocus = false,
+  });
+
+  final Color accent;
+  final Widget child;
+  final VoidCallback? onPressed;
+  final FocusNode? focusNode;
+  final bool autofocus;
+
+  @override
+  State<_TvFocusable> createState() => _TvFocusableState();
+}
+
+class _TvFocusableState extends State<_TvFocusable> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = widget.onPressed != null;
+    return Focus(
+      focusNode: widget.focusNode,
+      autofocus: widget.autofocus,
+      canRequestFocus: enabled,
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey) && enabled) {
+          widget.onPressed!();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onPressed,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: _focused
+                ? widget.accent
+                : Colors.black.withValues(alpha: 0.35),
+          ),
+          child: Opacity(opacity: enabled ? 1.0 : 0.4, child: widget.child),
+        ),
+      ),
+    );
+  }
+}
+
+/// Focusable play/pause button — highlighted when focused, and the default
+/// focus on reveal. OK on the seek bar also toggles it (Netflix convenience).
+class _PlayPauseButton extends StatelessWidget {
+  const _PlayPauseButton({
+    required this.player,
+    required this.accent,
+    required this.focusNode,
+  });
+
+  final Player player;
+  final Color accent;
+  final FocusNode focusNode;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<bool>(
+      stream: player.stream.playing,
+      initialData: player.state.playing,
+      builder: (context, snapshot) {
+        final playing = snapshot.data ?? false;
+        return _TvFocusable(
+          accent: accent,
+          focusNode: focusNode,
+          autofocus: true,
+          onPressed: player.playOrPause,
+          child: Icon(
+            playing ? Icons.pause : Icons.play_arrow,
+            color: Colors.white,
+            size: 34,
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// A selectable option for the Quality group (source-provided video list).
+class TvTrackOption {
+  const TvTrackOption({
+    required this.label,
+    required this.selected,
+    required this.onSelect,
+  });
+  final String label;
+  final bool selected;
+  final VoidCallback onSelect;
+}
+
+/// The bottom pill bar: `Quality | Subtitles | Audio`, centered, current option
+/// in each group checked. Quality is the real dub/sub control here (it re-opens
+/// the stream at the chosen source video), so it comes first.
+class _PillBar extends StatelessWidget {
+  const _PillBar({
+    required this.player,
+    required this.accent,
+    required this.qualityListenable,
+    required this.buildQualityOptions,
+    required this.onSettings,
+    required this.speedListenable,
+    required this.onSetSpeed,
+  });
+
+  final Player player;
+  final Color accent;
+  final Listenable qualityListenable;
+  final List<TvTrackOption> Function() buildQualityOptions;
+  final VoidCallback onSettings;
+  final ValueListenable<double> speedListenable;
+  final ValueChanged<double> onSetSpeed;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: qualityListenable,
+      builder: (context, _) {
+        final quality = buildQualityOptions();
+        return StreamBuilder<Tracks>(
+          stream: player.stream.tracks,
+          initialData: player.state.tracks,
+          builder: (context, tracksSnap) {
+            final tracks = tracksSnap.data ?? player.state.tracks;
+            return StreamBuilder<Track>(
+              stream: player.stream.track,
+              initialData: player.state.track,
+              builder: (context, trackSnap) {
+                final current = trackSnap.data ?? player.state.track;
+                // Real subtitle tracks only (no "auto"/"no" placeholders).
+                final subs = tracks.subtitle
+                    .where((t) => t.id != 'auto' && t.id != 'no')
+                    .toList();
+                // A "sub" quality already bakes subtitles into the stream, so
+                // hide the subtitle group when one is selected.
+                final subQualitySelected = quality.any(
+                  (q) => q.selected && q.label.toLowerCase().contains('sub'),
+                );
+
+                final groups = <List<Widget>>[];
+
+                // Quality group — the real dub/sub control.
+                if (quality.isNotEmpty) {
+                  groups.add([
+                    for (final q in quality)
+                      _TrackPill(
+                        accent: accent,
+                        icon: Icons.high_quality_outlined,
+                        label: q.label,
+                        selected: q.selected,
+                        onTap: q.onSelect,
+                      ),
+                  ]);
+                }
+
+                // Subtitle group — real tracks only, toggleable (re-clicking the
+                // selected one turns subtitles off). No separate "off" pill, and
+                // hidden entirely for sub-quality streams.
+                if (!subQualitySelected && subs.isNotEmpty) {
+                  groups.add([
+                    for (final s in subs)
+                      _TrackPill(
+                        accent: accent,
+                        icon: Icons.subtitles_outlined,
+                        label: _trackLabel(s.title, s.language, s.id),
+                        selected: s.id == current.subtitle.id,
+                        onTap: () => player.setSubtitleTrack(
+                          s.id == current.subtitle.id
+                              ? SubtitleTrack.no()
+                              : s,
+                        ),
+                      ),
+                  ]);
+                }
+
+                // Join groups with a "|" divider.
+                final children = <Widget>[];
+                for (var i = 0; i < groups.length; i++) {
+                  if (i > 0) children.add(const _PillDivider());
+                  children.addAll(groups[i]);
+                }
+                // Speed group, then the gear, both sized to match the track
+                // pills.
+                if (children.isNotEmpty) children.add(const _PillDivider());
+                children.add(
+                  _SpeedPill(
+                    accent: accent,
+                    speedListenable: speedListenable,
+                    onSetSpeed: onSetSpeed,
+                  ),
+                );
+                children.add(const _PillDivider());
+                children.add(
+                  _TrackPill(
+                    accent: accent,
+                    icon: Icons.settings,
+                    label: 'Settings',
+                    selected: false,
+                    onTap: onSettings,
+                  ),
+                );
+                return Wrap(
+                  alignment: WrapAlignment.center,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: children,
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+/// Playback-speed pill: shows the current rate, opens a d-pad-focusable list of
+/// presets. Highlighted (like a selected track) whenever it isn't 1×.
+class _SpeedPill extends StatelessWidget {
+  const _SpeedPill({
+    required this.accent,
+    required this.speedListenable,
+    required this.onSetSpeed,
+  });
+
+  final Color accent;
+  final ValueListenable<double> speedListenable;
+  final ValueChanged<double> onSetSpeed;
+
+  static const _presets = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+
+  static String _fmt(double r) {
+    final s = r == r.roundToDouble() ? r.toStringAsFixed(0) : r.toString();
+    return '$s×';
+  }
+
+  void _showMenu(BuildContext context, double current) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => _SpeedMenu(
+        accent: accent,
+        presets: _presets,
+        current: current,
+        onPick: onSetSpeed,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<double>(
+      valueListenable: speedListenable,
+      builder: (context, rate, _) => _TrackPill(
+        accent: accent,
+        icon: Icons.speed,
+        label: _fmt(rate),
+        selected: (rate - 1.0).abs() > 0.001,
+        onTap: () => _showMenu(context, rate),
+      ),
+    );
+  }
+}
+
+/// The playback-speed picker. Owns its focus containment: Up/Down move within
+/// the list and are *always* consumed (clamped at the ends), so d-pad focus
+/// can't escape past the edges to the controls behind the still-open dialog —
+/// which was letting the speed pill re-open a second dialog on top of this one.
+class _SpeedMenu extends StatefulWidget {
+  const _SpeedMenu({
+    required this.accent,
+    required this.presets,
+    required this.current,
+    required this.onPick,
+  });
+
+  final Color accent;
+  final List<double> presets;
+  final double current;
+  final ValueChanged<double> onPick;
+
+  @override
+  State<_SpeedMenu> createState() => _SpeedMenuState();
+}
+
+class _SpeedMenuState extends State<_SpeedMenu> {
+  late final List<FocusNode> _nodes = List.generate(
+    widget.presets.length,
+    (_) => FocusNode(),
+  );
+  late int _index;
+
+  @override
+  void initState() {
+    super.initState();
+    final sel = widget.presets.indexWhere(
+      (s) => (s - widget.current).abs() < 0.001,
+    );
+    _index = sel >= 0 ? sel : widget.presets.length ~/ 2;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _nodes[_index].requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    for (final n in _nodes) {
+      n.dispose();
+    }
+    super.dispose();
+  }
+
+  void _move(int delta) {
+    final next = (_index + delta).clamp(0, _nodes.length - 1);
+    if (next != _index) {
+      setState(() => _index = next);
+      _nodes[next].requestFocus();
+    }
+  }
+
+  void _pick(int i) {
+    widget.onPick(widget.presets[i]);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Playback speed'),
+      contentPadding: const EdgeInsets.symmetric(vertical: 8),
+      content: SizedBox(
+        width: 300,
+        child: FocusTraversalGroup(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (var i = 0; i < widget.presets.length; i++)
+                Focus(
+                  focusNode: _nodes[i],
+                  onKeyEvent: (node, event) {
+                    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+                      return KeyEventResult.ignored;
+                    }
+                    final k = event.logicalKey;
+                    if (k == LogicalKeyboardKey.arrowDown) {
+                      _move(1);
+                      return KeyEventResult.handled;
+                    }
+                    if (k == LogicalKeyboardKey.arrowUp) {
+                      _move(-1);
+                      return KeyEventResult.handled;
+                    }
+                    // Swallow Left/Right too, so neither can escape sideways.
+                    if (k == LogicalKeyboardKey.arrowLeft ||
+                        k == LogicalKeyboardKey.arrowRight) {
+                      return KeyEventResult.handled;
+                    }
+                    if (event is KeyDownEvent && _isSelect(k)) {
+                      _pick(i);
+                      return KeyEventResult.handled;
+                    }
+                    return KeyEventResult.ignored;
+                  },
+                  child: Padding(
+                    // Inset so the highlight is a rounded pill inside the
+                    // dialog — a full-bleed square looked broken on the last
+                    // row against the dialog's rounded corner.
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 2,
+                    ),
+                    child: InkWell(
+                      onTap: () => _pick(i),
+                      borderRadius: BorderRadius.circular(10),
+                      child: Ink(
+                        decoration: BoxDecoration(
+                          color: i == _index
+                              ? widget.accent.withValues(alpha: 0.18)
+                              : null,
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 12,
+                        ),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: Text(_SpeedPill._fmt(widget.presets[i])),
+                            ),
+                            if ((widget.presets[i] - widget.current).abs() <
+                                0.001)
+                              Icon(Icons.check, color: widget.accent),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A thin vertical "|" separator between pill groups.
+class _PillDivider extends StatelessWidget {
+  const _PillDivider();
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1,
+      height: 22,
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      color: Colors.white.withValues(alpha: 0.3),
+    );
+  }
+}
+
+/// A compact YouTube-style "Autoplay" labelled switch, focusable for the d-pad.
+class _AutoplayToggle extends StatefulWidget {
+  const _AutoplayToggle({
+    required this.accent,
+    required this.on,
+    required this.onToggle,
+  });
+
+  final Color accent;
+  final bool on;
+  final VoidCallback onToggle;
+
+  @override
+  State<_AutoplayToggle> createState() => _AutoplayToggleState();
+}
+
+class _AutoplayToggleState extends State<_AutoplayToggle> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
+          widget.onToggle();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onToggle,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          padding: const EdgeInsets.all(6),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            // Theme tint on focus (like the settings toggles), not an outline.
+            color: _focused
+                ? widget.accent.withValues(alpha: 0.25)
+                : Colors.transparent,
+          ),
+          child: AutoplaySwitch(on: widget.on, accent: widget.accent),
+        ),
+      ),
+    );
+  }
+
+}
+
+/// A drawn play/pause autoplay toggle (no asset): a pill track with a circular
+/// black knob that slides right + shows ▶ when on, left + shows ⏸ when off —
+/// matching the reference toggle style.
+class AutoplaySwitch extends StatelessWidget {
+  const AutoplaySwitch({required this.on, required this.accent});
+
+  final bool on;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    const w = 52.0;
+    const h = 28.0;
+    const trackH = 22.0;
+    const knob = 28.0;
+    return SizedBox(
+      width: w,
+      height: h,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          AnimatedContainer(
+            duration: const Duration(milliseconds: 180),
+            width: w - 4,
+            height: trackH,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(trackH / 2),
+              color: on
+                  ? accent.withValues(alpha: 0.5)
+                  : Colors.white.withValues(alpha: 0.22),
+            ),
+          ),
+          AnimatedAlign(
+            duration: const Duration(milliseconds: 180),
+            curve: Curves.easeOut,
+            alignment: on ? Alignment.centerRight : Alignment.centerLeft,
+            child: Container(
+              width: knob,
+              height: knob,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.black,
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.4),
+                    blurRadius: 3,
+                    offset: const Offset(0, 1),
+                  ),
+                ],
+              ),
+              child: Icon(
+                on ? Icons.play_arrow : Icons.pause,
+                color: Colors.white,
+                size: 16,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _trackLabel(String? title, String? language, String id) {
+  final t = (title ?? '').trim();
+  if (t.isNotEmpty) return t;
+  final l = (language ?? '').trim();
+  if (l.isNotEmpty) return l;
+  return id;
+}
+
+/// A small focusable track pill: accent when focused, faded accent when it's the
+/// current track (with a check), else a translucent fill.
+class _TrackPill extends StatefulWidget {
+  const _TrackPill({
+    required this.accent,
+    required this.icon,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final Color accent;
+  final IconData icon;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  State<_TrackPill> createState() => _TrackPillState();
+}
+
+class _TrackPillState extends State<_TrackPill> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = _focused
+        ? widget.accent
+        : widget.selected
+        ? widget.accent.withValues(alpha: 0.4)
+        : Colors.white.withValues(alpha: 0.15);
+    return Focus(
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
+          widget.onTap();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(16),
+            color: bg,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                widget.selected ? Icons.check : widget.icon,
+                color: Colors.white,
+                size: 14,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                widget.label,
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A focusable seek bar: Left/Right seek a small fixed amount; Up/Down escape.
+class _TvSeekBar extends StatefulWidget {
+  const _TvSeekBar({
+    required this.player,
+    required this.accent,
+    this.focusNode,
+  });
+
+  final Player player;
+  final Color accent;
+  final FocusNode? focusNode;
+
+  @override
+  State<_TvSeekBar> createState() => _TvSeekBarState();
+}
+
+class _TvSeekBarState extends State<_TvSeekBar> {
+  bool _focused = false;
+
+  // Own a node when the parent doesn't supply one, so a mouse click can focus
+  // the bar (and hand keyboard seeking over to it) on desktop.
+  FocusNode? _ownNode;
+  FocusNode get _node => widget.focusNode ?? (_ownNode ??= FocusNode());
+
+  @override
+  void dispose() {
+    _ownNode?.dispose();
+    super.dispose();
+  }
+
+  // Hold-to-accelerate: a held arrow fires key repeats, and each consecutive
+  // repeat in the same direction grows the seek step, so a long hold covers
+  // ground fast while a single tap still nudges ±10s. Reset on release or when
+  // the direction flips.
+  static const _baseStep = 10; // seconds
+  static const _maxStep = 90;
+  int _holdCount = 0;
+  LogicalKeyboardKey? _holdDir;
+
+  Duration _stepFor(LogicalKeyboardKey dir) {
+    if (_holdDir != dir) {
+      _holdDir = dir;
+      _holdCount = 0;
+    } else {
+      _holdCount++;
+    }
+    // +10s per 3 repeats held: 10 → 20 → 30 … capped.
+    final secs = (_baseStep + (_holdCount ~/ 3) * 10).clamp(_baseStep, _maxStep);
+    return Duration(seconds: secs);
+  }
+
+  void _endHold() {
+    _holdDir = null;
+    _holdCount = 0;
+  }
+
+  void _seek(Duration delta) {
+    var target = widget.player.state.position + delta;
+    if (target < Duration.zero) target = Duration.zero;
+    final dur = widget.player.state.duration;
+    if (dur > Duration.zero && target > dur) target = dur;
+    widget.player.seek(target);
+  }
+
+  // Mouse tap / drag on the bar seeks to that fraction of the duration.
+  void _seekToFraction(double frac) {
+    final dur = widget.player.state.duration;
+    if (dur <= Duration.zero) return;
+    if (!_node.hasFocus) _node.requestFocus();
+    widget.player.seek(dur * frac.clamp(0.0, 1.0));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _node,
+      onFocusChange: (f) {
+        setState(() => _focused = f);
+        if (!f) _endHold();
+      },
+      onKeyEvent: (node, event) {
+        final k = event.logicalKey;
+        final isLeft = k == LogicalKeyboardKey.arrowLeft;
+        final isRight = k == LogicalKeyboardKey.arrowRight;
+        // Releasing an arrow ends the hold ramp.
+        if (event is KeyUpEvent) {
+          if (isLeft || isRight) {
+            _endHold();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        }
+        if (event is KeyDownEvent || event is KeyRepeatEvent) {
+          if (isLeft) {
+            _seek(-_stepFor(k));
+            return KeyEventResult.handled;
+          }
+          if (isRight) {
+            _seek(_stepFor(k));
+            return KeyEventResult.handled;
+          }
+          // OK/Select toggles play/pause (Netflix model — no separate button).
+          if (event is KeyDownEvent && _isSelect(k)) {
+            widget.player.playOrPause();
+            return KeyEventResult.handled;
+          }
+          // Up / Down fall through so focus can leave the bar.
+        }
+        return KeyEventResult.ignored;
+      },
+      child: StreamBuilder<Duration>(
+        stream: widget.player.stream.position,
+        initialData: widget.player.state.position,
+        builder: (context, snapshot) {
+          final pos = snapshot.data ?? Duration.zero;
+          final dur = widget.player.state.duration;
+          final frac = dur.inMilliseconds > 0
+              ? (pos.inMilliseconds / dur.inMilliseconds).clamp(0.0, 1.0)
+              : 0.0;
+          final barH = _focused ? 6.0 : 4.0;
+          const knob = 16.0;
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 6),
+            child: SizedBox(
+              height: 16,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final w = constraints.maxWidth;
+                  return GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTapDown: (d) => _seekToFraction(d.localPosition.dx / w),
+                    onHorizontalDragStart: (d) =>
+                        _seekToFraction(d.localPosition.dx / w),
+                    onHorizontalDragUpdate: (d) =>
+                        _seekToFraction(d.localPosition.dx / w),
+                    child: Stack(
+                    children: [
+                      // Track + progress, vertically centred.
+                      Align(
+                        alignment: Alignment.center,
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(barH / 2),
+                          child: SizedBox(
+                            height: barH,
+                            width: w,
+                            child: LinearProgressIndicator(
+                              value: frac,
+                              backgroundColor: Colors.white24,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                widget.accent,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      // Scrubber handle at the current position when focused —
+                      // the focus affordance instead of an outline.
+                      if (_focused)
+                        Positioned(
+                          left: (frac * (w - knob)).clamp(0.0, w - knob),
+                          top: (16 - knob) / 2,
+                          child: Container(
+                            width: knob,
+                            height: knob,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Colors.white,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withValues(alpha: 0.4),
+                                  blurRadius: 3,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                    ],
+                    ),
+                  );
+                },
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+String _fmt(Duration d) {
+  final h = d.inHours;
+  final m = d.inMinutes.remainder(60);
+  final s = d.inSeconds.remainder(60);
+  final mm = m.toString().padLeft(2, '0');
+  final ss = s.toString().padLeft(2, '0');
+  return h > 0 ? '$h:$mm:$ss' : '$mm:$ss';
+}
+
+// Monospace + tabular figures so the timestamps read cleanly and don't jitter
+// as the digits change.
+TextStyle _timeStyle(Color color) => TextStyle(
+  color: color,
+  fontSize: 15,
+  fontFamily: 'monospace',
+  fontWeight: FontWeight.w600,
+  letterSpacing: 0.3,
+  fontFeatures: const [FontFeature.tabularFigures()],
+);
+
+class _PositionText extends StatelessWidget {
+  const _PositionText({required this.player});
+  final Player player;
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<Duration>(
+      stream: player.stream.position,
+      initialData: player.state.position,
+      builder: (context, snapshot) => Text(
+        _fmt(snapshot.data ?? Duration.zero),
+        style: _timeStyle(Colors.white),
+      ),
+    );
+  }
+}
+
+/// Right-side timestamp counts DOWN — time remaining (e.g. "-45:32"), like
+/// Netflix.
+class _RemainingText extends StatelessWidget {
+  const _RemainingText({required this.player});
+  final Player player;
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<Duration>(
+      stream: player.stream.position,
+      initialData: player.state.position,
+      builder: (context, snapshot) {
+        final pos = snapshot.data ?? Duration.zero;
+        final dur = player.state.duration;
+        var remaining = dur - pos;
+        if (remaining < Duration.zero) remaining = Duration.zero;
+        return Text('-${_fmt(remaining)}', style: _timeStyle(Colors.white70));
+      },
+    );
+  }
+}

--- a/lib/modules/anime/widgets/tv_player_controls.dart
+++ b/lib/modules/anime/widgets/tv_player_controls.dart
@@ -7,10 +7,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
 import 'package:media_kit/media_kit.dart';
 
-/// A dedicated, Netflix-style controls overlay for the anime player on TV.
+/// A dedicated controls overlay for the anime player on TV.
 ///
-/// Only the essentials are on screen — play/pause, prev/next episode, a seek
-/// bar with times, and audio/subtitle access — everything else lives behind the
+/// Only the essentials are on screen - play/pause, prev/next episode, a seek
+/// bar with times, and audio/subtitle access - everything else lives behind the
 /// gear. Built for the d-pad: theme-coloured focus highlight on every control,
 /// the seek bar seeks a small fixed amount on Left/Right and lets Up/Down move
 /// focus away, and the reveal/auto-hide is driven by [revealControls] (bumped by
@@ -42,7 +42,7 @@ class TvPlayerControls extends StatefulWidget {
   final VoidCallback onSettings;
   final bool hasNext;
   final VoidCallback? onNext;
-  // Quality = the source video list (e.g. "1080p Sub"/"1080p Dub") — the real
+  // Quality = the source video list (e.g. "1080p Sub"/"1080p Dub") - the real
   // dub/sub control here. Rebuilt when [qualityListenable] fires.
   final Listenable qualityListenable;
   final List<TvTrackOption> Function() buildQualityOptions;
@@ -62,7 +62,7 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
   final FocusNode _playFocus = FocusNode(debugLabel: 'tvPlayerPlayPause');
   // Always in the tree, even while hidden (when the controls collapse to an
   // empty box and leave no focusable node). Focus parks here on hide so a key
-  // press can still wake the panel — otherwise, on a keyboard, once it hides
+  // press can still wake the panel - otherwise, on a keyboard, once it hides
   // there's nothing focused to receive the wake key.
   final FocusNode _rootFocus = FocusNode(debugLabel: 'tvPlayerRoot');
   static const _hideAfter = Duration(seconds: 4);
@@ -72,7 +72,7 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
     super.initState();
     widget.revealControls.addListener(_reveal);
     // Re-arm the hide timer on every key event (see _onAnyKey): a control's own
-    // handler consumes its key, so an ancestor Focus would never see it — a
+    // handler consumes its key, so an ancestor Focus would never see it - a
     // hardware-keyboard handler is the only spot that catches *all* presses.
     HardwareKeyboard.instance.addHandler(_onAnyKey);
     _startHideTimer();
@@ -103,7 +103,7 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
   }
 
   // True while the player is the topmost route. When a dialog (speed / settings)
-  // is open on top, the panel must not hide or touch focus — doing so steals
+  // is open on top, the panel must not hide or touch focus - doing so steals
   // focus out of the dialog and back to the play button behind it.
   bool get _isTopRoute => ModalRoute.of(context)?.isCurrent ?? true;
 
@@ -112,7 +112,7 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
     final wasHidden = !_visible;
     if (wasHidden) setState(() => _visible = true);
     // Always extend the hide timer (so a moving mouse keeps controls up), but
-    // only grab focus on the hidden→visible edge — otherwise a stream of mouse
+    // only grab focus on the hidden→visible edge - otherwise a stream of mouse
     // hover events would re-request focus every frame.
     _startHideTimer();
     if (wasHidden && !_scope.hasFocus && _isTopRoute) {
@@ -130,7 +130,7 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
 
   void _onHideTimer() {
     if (!mounted) return;
-    // A dialog is open on top — keep the panel and don't touch focus; re-arm so
+    // A dialog is open on top - keep the panel and don't touch focus; re-arm so
     // it hides once the player is back on top.
     if (!_isTopRoute) {
       _startHideTimer();
@@ -151,8 +151,8 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
   @override
   Widget build(BuildContext context) {
     final accent = Theme.of(context).colorScheme.primary;
-    // TV overscan-safe margins (~5% per side, Netflix-generous). Only the
-    // interactive controls/title are inset — the scrim stays full-bleed, per
+    // TV overscan-safe margins (~5% per side, generous). Only the
+    // interactive controls/title are inset - the scrim stays full-bleed, per
     // Android TV layout guidance.
     final size = MediaQuery.of(context).size;
     final safeH = size.width * 0.08;
@@ -160,7 +160,7 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
     // Back dismisses the visible control panel before it leaves the player:
     // block the pop while the panel shows and hide it instead; a second Back
     // (panel already hidden) exits normally. The on-screen back arrow still
-    // exits outright — it pops directly, bypassing this.
+    // exits outright - it pops directly, bypassing this.
     return PopScope(
       canPop: !_visible,
       onPopInvokedWithResult: (didPop, result) {
@@ -199,7 +199,7 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
           node: _scope,
       // Only build the controls (and their per-frame StreamBuilders) while
       // visible. Otherwise the seek/time streams rebuild ~4x/sec during
-      // playback and jank the Fire TV — hidden means nothing to render.
+      // playback and jank the Fire TV - hidden means nothing to render.
       child: !_visible
           ? const SizedBox.expand()
           : Stack(
@@ -242,7 +242,7 @@ class _TvPlayerControlsState extends State<TvPlayerControls> {
                       ),
                     ),
                     const SizedBox(width: 8),
-                    // Autoplay-next — YouTube-style labelled switch.
+                    // Autoplay-next labelled switch.
                     Consumer(
                       builder: (context, ref, _) {
                         final on = ref.watch(autoPlayNextEpisodeProvider);
@@ -418,8 +418,8 @@ class _TvFocusableState extends State<_TvFocusable> {
   }
 }
 
-/// Focusable play/pause button — highlighted when focused, and the default
-/// focus on reveal. OK on the seek bar also toggles it (Netflix convenience).
+/// Focusable play/pause button - highlighted when focused, and the default
+/// focus on reveal. OK on the seek bar also toggles it (a TV convenience).
 class _PlayPauseButton extends StatelessWidget {
   const _PlayPauseButton({
     required this.player,
@@ -516,7 +516,7 @@ class _PillBar extends StatelessWidget {
 
                 final groups = <List<Widget>>[];
 
-                // Quality group — the real dub/sub control.
+                // Quality group - the real dub/sub control.
                 if (quality.isNotEmpty) {
                   groups.add([
                     for (final q in quality)
@@ -530,7 +530,7 @@ class _PillBar extends StatelessWidget {
                   ]);
                 }
 
-                // Subtitle group — real tracks only, toggleable (re-clicking the
+                // Subtitle group - real tracks only, toggleable (re-clicking the
                 // selected one turns subtitles off). No separate "off" pill, and
                 // hidden entirely for sub-quality streams.
                 if (!subQualitySelected && subs.isNotEmpty) {
@@ -641,7 +641,7 @@ class _SpeedPill extends StatelessWidget {
 
 /// The playback-speed picker. Owns its focus containment: Up/Down move within
 /// the list and are *always* consumed (clamped at the ends), so d-pad focus
-/// can't escape past the edges to the controls behind the still-open dialog —
+/// can't escape past the edges to the controls behind the still-open dialog -
 /// which was letting the speed pill re-open a second dialog on top of this one.
 class _SpeedMenu extends StatefulWidget {
   const _SpeedMenu({
@@ -740,7 +740,7 @@ class _SpeedMenuState extends State<_SpeedMenu> {
                   },
                   child: Padding(
                     // Inset so the highlight is a rounded pill inside the
-                    // dialog — a full-bleed square looked broken on the last
+                    // dialog - a full-bleed square looked broken on the last
                     // row against the dialog's rounded corner.
                     padding: const EdgeInsets.symmetric(
                       horizontal: 8,
@@ -796,7 +796,7 @@ class _PillDivider extends StatelessWidget {
   }
 }
 
-/// A compact YouTube-style autoplay switch, focusable for the d-pad. Shared by
+/// A compact autoplay switch, focusable for the d-pad. Shared by
 /// the TV player and the mobile/desktop player so the toggle is visually
 /// identical across platforms.
 class AutoplayToggle extends StatefulWidget {
@@ -850,7 +850,7 @@ class AutoplayToggleState extends State<AutoplayToggle> {
 }
 
 /// A drawn play/pause autoplay toggle (no asset): a pill track with a circular
-/// black knob that slides right + shows ▶ when on, left + shows ⏸ when off —
+/// black knob that slides right + shows ▶ when on, left + shows ⏸ when off -
 /// matching the reference toggle style.
 class AutoplaySwitch extends StatelessWidget {
   const AutoplaySwitch({super.key, required this.on, required this.accent});
@@ -1091,7 +1091,7 @@ class _TvSeekBarState extends State<_TvSeekBar> {
             _seek(_stepFor(k));
             return KeyEventResult.handled;
           }
-          // OK/Select toggles play/pause (Netflix model — no separate button).
+          // OK/Select toggles play/pause (no separate button).
           if (event is KeyDownEvent && _isSelect(k)) {
             widget.player.playOrPause();
             return KeyEventResult.handled;
@@ -1145,7 +1145,7 @@ class _TvSeekBarState extends State<_TvSeekBar> {
                           ),
                         ),
                       ),
-                      // Scrubber handle at the current position when focused —
+                      // Scrubber handle at the current position when focused -
                       // the focus affordance instead of an outline.
                       if (_focused)
                         Positioned(
@@ -1215,8 +1215,7 @@ class _PositionText extends StatelessWidget {
   }
 }
 
-/// Right-side timestamp counts DOWN — time remaining (e.g. "-45:32"), like
-/// Netflix.
+/// Right-side timestamp counts DOWN, the time remaining (e.g. "-45:32").
 class _RemainingText extends StatelessWidget {
   const _RemainingText({required this.player});
   final Player player;

--- a/lib/modules/anime/widgets/tv_player_settings_panel.dart
+++ b/lib/modules/anime/widgets/tv_player_settings_panel.dart
@@ -6,13 +6,13 @@ import 'package:media_kit/media_kit.dart';
 import 'package:mangayomi/modules/more/settings/player/providers/player_decoder_state_provider.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 
-/// The YouTube-style settings panel that docks on the right of the TV player.
+/// The settings panel that docks on the right of the TV player.
 /// A navigable drill-down: a category list, and selecting one replaces it with
 /// that category's page (Back returns). Surfaces the player's existing quality /
-/// subtitle / audio widgets plus speed, shaders, decoder and mpv stats — all
+/// subtitle / audio widgets plus speed, shaders, decoder and mpv stats - all
 /// d-pad-focusable.
 /// One selectable option in a track/quality list: its label, whether it's the
-/// current selection, and the action to switch to it (no route pop — the panel
+/// current selection, and the action to switch to it (no route pop - the panel
 /// stays open).
 typedef TvTrackOptionData = ({String label, bool selected, VoidCallback onTap});
 
@@ -41,7 +41,7 @@ class TvPlayerSettingsPanel extends ConsumerStatefulWidget {
   // The header's focus node is owned by the player so it can be re-focused every
   // time the panel opens (autofocus only fires once per scope).
   final FocusNode headerFocusNode;
-  // Left out of the panel goes to the video — an explicit hand-off, because
+  // Left out of the panel goes to the video - an explicit hand-off, because
   // geometric directional focus across the split was losing focus entirely.
   final VoidCallback onExitLeft;
   final VoidCallback onClose;
@@ -69,8 +69,8 @@ class _TvPlayerSettingsPanelState extends ConsumerState<TvPlayerSettingsPanel> {
   static const _decoders = [
     ('auto', 'Auto (hardware)'),
     ('auto-copy', 'Auto-copy'),
-    ('mediacodec', 'MediaCodec — HW (Android)'),
-    ('mediacodec-copy', 'MediaCodec — HW+ (Android)'),
+    ('mediacodec', 'MediaCodec - HW (Android)'),
+    ('mediacodec-copy', 'MediaCodec - HW+ (Android)'),
     ('videotoolbox', 'VideoToolbox (Apple)'),
     ('videotoolbox-copy', 'VideoToolbox-copy (Apple)'),
     ('d3d11va', 'D3D11VA (Windows)'),

--- a/lib/modules/anime/widgets/tv_player_settings_panel.dart
+++ b/lib/modules/anime/widgets/tv_player_settings_panel.dart
@@ -1,0 +1,535 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:mangayomi/modules/more/settings/player/providers/player_decoder_state_provider.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+
+/// The YouTube-style settings panel that docks on the right of the TV player.
+/// A navigable drill-down: a category list, and selecting one replaces it with
+/// that category's page (Back returns). Surfaces the player's existing quality /
+/// subtitle / audio widgets plus speed, shaders, decoder and mpv stats — all
+/// d-pad-focusable.
+/// One selectable option in a track/quality list: its label, whether it's the
+/// current selection, and the action to switch to it (no route pop — the panel
+/// stays open).
+typedef TvTrackOptionData = ({String label, bool selected, VoidCallback onTap});
+
+class TvPlayerSettingsPanel extends ConsumerStatefulWidget {
+  const TvPlayerSettingsPanel({
+    super.key,
+    required this.player,
+    required this.speedListenable,
+    required this.onSetSpeed,
+    required this.selectedShaderListenable,
+    required this.qualityOptions,
+    required this.subtitleOptions,
+    required this.audioOptions,
+    required this.headerFocusNode,
+    required this.onExitLeft,
+    required this.onClose,
+  });
+
+  final Player player;
+  final ValueListenable<double> speedListenable;
+  final ValueChanged<double> onSetSpeed;
+  final ValueListenable<String> selectedShaderListenable;
+  final List<TvTrackOptionData> Function() qualityOptions;
+  final List<TvTrackOptionData> Function() subtitleOptions;
+  final List<TvTrackOptionData> Function() audioOptions;
+  // The header's focus node is owned by the player so it can be re-focused every
+  // time the panel opens (autofocus only fires once per scope).
+  final FocusNode headerFocusNode;
+  // Left out of the panel goes to the video — an explicit hand-off, because
+  // geometric directional focus across the split was losing focus entirely.
+  final VoidCallback onExitLeft;
+  final VoidCallback onClose;
+
+  @override
+  ConsumerState<TvPlayerSettingsPanel> createState() =>
+      _TvPlayerSettingsPanelState();
+}
+
+class _TvPlayerSettingsPanelState extends ConsumerState<TvPlayerSettingsPanel> {
+  static const _speeds = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+  static const _shaders = [
+    ('Anime4K: Mode A (Fast)', 'set_anime_a'),
+    ('Anime4K: Mode B (Fast)', 'set_anime_b'),
+    ('Anime4K: Mode C (Fast)', 'set_anime_c'),
+    ('Anime4K: Mode A (HQ)', 'set_anime_hq_a'),
+    ('Anime4K: Mode B (HQ)', 'set_anime_hq_b'),
+    ('Anime4K: Mode C (HQ)', 'set_anime_hq_c'),
+    ('AMD FSR', 'set_fsr'),
+    ('Luma Upscaling', 'set_luma'),
+    ('Qualcomm Snapdragon GSR', 'set_snapdragon'),
+    ('NVIDIA Image Scaling', 'set_nvidia'),
+    ('Off (clear shaders)', 'clear_anime'),
+  ];
+  static const _decoders = [
+    ('auto', 'Auto (hardware)'),
+    ('auto-copy', 'Auto-copy'),
+    ('mediacodec', 'MediaCodec — HW (Android)'),
+    ('mediacodec-copy', 'MediaCodec — HW+ (Android)'),
+    ('videotoolbox', 'VideoToolbox (Apple)'),
+    ('videotoolbox-copy', 'VideoToolbox-copy (Apple)'),
+    ('d3d11va', 'D3D11VA (Windows)'),
+    ('nvdec', 'NVDEC (CUDA)'),
+    ('no', 'Software (no hardware)'),
+  ];
+  static const _stats = [
+    ('Toggle overlay', 'stats/display-stats-toggle'),
+    ('General', 'stats/display-page-1'),
+    ('Frame timings', 'stats/display-page-2'),
+    ('Input cache', 'stats/display-page-3'),
+    ('Active filters', 'stats/display-page-4'),
+    ('Log', 'stats/display-page-5'),
+  ];
+
+  // null = the category list; otherwise the open category's key.
+  String? _open;
+
+  NativePlayer get _native => widget.player.platform as NativePlayer;
+
+  void _drill(String key) => setState(() => _open = key);
+
+  bool _handleBack() {
+    if (_open != null) {
+      setState(() => _open = null);
+      return true;
+    }
+    widget.onClose();
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = context.primaryColor;
+    final size = MediaQuery.of(context).size;
+    final width = (size.width * 0.26).clamp(300.0, 380.0);
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) _handleBack();
+      },
+      // Intercept Left before the default directional traversal (onKeyEvent
+      // runs ahead of Shortcuts/Actions) and hand focus to the video explicitly.
+      child: Focus(
+        canRequestFocus: false,
+        skipTraversal: true,
+        onKeyEvent: (node, event) {
+          if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+              event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+            widget.onExitLeft();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: FocusTraversalGroup(
+          child: Container(
+            width: width,
+            color: Theme.of(context).colorScheme.surface,
+            child: SafeArea(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _header(context),
+                  const Divider(height: 1),
+                  Expanded(
+                    child: _open == null
+                        ? _categoryList(context, accent)
+                        : _page(context, accent, _open!),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _header(BuildContext context) {
+    final title = _open == null ? 'Settings' : _titleFor(_open!);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(6, 8, 8, 4),
+      child: Row(
+        children: [
+          IconButton(
+            focusNode: widget.headerFocusNode,
+            onPressed: _handleBack,
+            icon: Icon(_open == null ? Icons.close : Icons.arrow_back),
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              title,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _titleFor(String key) => switch (key) {
+    'playback' => 'Playback speed',
+    'quality' => 'Quality',
+    'subtitles' => 'Subtitles',
+    'audio' => 'Audio',
+    'shaders' => 'Shaders',
+    'decoder' => 'Decoder',
+    'stats' => 'Stats for nerds',
+    _ => 'Settings',
+  };
+
+  Widget _categoryList(BuildContext context, Color accent) {
+    final entries = <(String, IconData, String)>[
+      ('playback', Icons.speed, 'Playback speed'),
+      ('quality', Icons.high_quality_outlined, 'Quality'),
+      ('subtitles', Icons.subtitles_outlined, 'Subtitles'),
+      ('audio', Icons.audiotrack_outlined, 'Audio'),
+      ('shaders', Icons.auto_awesome_outlined, 'Shaders'),
+      ('decoder', Icons.memory_outlined, 'Decoder'),
+      ('stats', Icons.insights_outlined, 'Stats for nerds'),
+    ];
+    return ListView(
+      children: [
+        for (final e in entries)
+          _NavRow(
+            accent: accent,
+            icon: e.$2,
+            label: e.$3,
+            trailing: const Icon(Icons.chevron_right, size: 20),
+            onTap: () => _drill(e.$1),
+          ),
+      ],
+    );
+  }
+
+  Widget _page(BuildContext context, Color accent, String key) {
+    switch (key) {
+      case 'playback':
+        return ValueListenableBuilder<double>(
+          valueListenable: widget.speedListenable,
+          builder: (context, rate, _) => ListView(
+            children: [
+              for (final s in _speeds)
+                _OptionRow(
+                  accent: accent,
+                  label: _fmtSpeed(s),
+                  selected: (s - rate).abs() < 0.001,
+                  onTap: () => widget.onSetSpeed(s),
+                ),
+            ],
+          ),
+        );
+      case 'quality':
+        return _trackList(accent, widget.qualityOptions(), 'No other quality');
+      case 'subtitles':
+        return _trackList(accent, widget.subtitleOptions(), 'No subtitles');
+      case 'audio':
+        return _trackList(accent, widget.audioOptions(), 'No audio tracks');
+      case 'shaders':
+        return ValueListenableBuilder<String>(
+          valueListenable: widget.selectedShaderListenable,
+          builder: (context, current, _) => ListView(
+            children: [
+              for (final sh in _shaders)
+                _OptionRow(
+                  accent: accent,
+                  label: sh.$1,
+                  selected: current == sh.$1,
+                  onTap: () =>
+                      _native.command(['script-message', sh.$2]),
+                ),
+            ],
+          ),
+        );
+      case 'decoder':
+        final currentHwdec = ref.watch(hwdecModeStateProvider());
+        return ListView(
+          children: [
+            for (final d in _decoders)
+              _OptionRow(
+                accent: accent,
+                label: d.$2,
+                selected: currentHwdec == d.$1,
+                onTap: () {
+                  ref.read(hwdecModeStateProvider().notifier).set(d.$1);
+                  // Live-switch mpv too, so it takes effect without a restart.
+                  _native.setProperty('hwdec', d.$1);
+                },
+              ),
+          ],
+        );
+      case 'stats':
+        return ListView(
+          children: [
+            for (final st in _stats)
+              _NavRow(
+                accent: accent,
+                icon: Icons.insights_outlined,
+                label: st.$1,
+                onTap: () => _native.command(['script-binding', st.$2]),
+              ),
+          ],
+        );
+      default:
+        return const SizedBox.shrink();
+    }
+  }
+
+  Widget _trackList(Color accent, List<TvTrackOptionData> options, String empty) {
+    if (options.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(empty, style: TextStyle(color: Theme.of(context).hintColor)),
+        ),
+      );
+    }
+    return ListView(
+      children: [
+        for (final o in options)
+          _OptionRow(
+            accent: accent,
+            label: o.label,
+            selected: o.selected,
+            onTap: o.onTap,
+          ),
+      ],
+    );
+  }
+
+  static String _fmtSpeed(double r) {
+    final s = r == r.roundToDouble() ? r.toStringAsFixed(0) : r.toString();
+    return '$s×';
+  }
+}
+
+/// A focusable navigation row (drills in or fires an action).
+class _NavRow extends StatefulWidget {
+  const _NavRow({
+    required this.accent,
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.trailing,
+  });
+  final Color accent;
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final Widget? trailing;
+
+  @override
+  State<_NavRow> createState() => _NavRowState();
+}
+
+class _NavRowState extends State<_NavRow> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
+          widget.onTap();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 13),
+          decoration: BoxDecoration(
+            color: _focused ? widget.accent.withValues(alpha: 0.18) : null,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            children: [
+              Icon(widget.icon, size: 20, color: widget.accent),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Text(
+                  widget.label,
+                  style: const TextStyle(fontSize: 15),
+                ),
+              ),
+              if (widget.trailing != null) widget.trailing!,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A focusable selectable option (a check marks the current one).
+class _OptionRow extends StatefulWidget {
+  const _OptionRow({
+    required this.accent,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+  final Color accent;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  State<_OptionRow> createState() => _OptionRowState();
+}
+
+class _OptionRowState extends State<_OptionRow> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
+          widget.onTap();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          decoration: BoxDecoration(
+            color: _focused ? widget.accent.withValues(alpha: 0.18) : null,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  widget.label,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: widget.selected
+                        ? FontWeight.w700
+                        : FontWeight.normal,
+                    color: widget.selected ? widget.accent : null,
+                  ),
+                ),
+              ),
+              if (widget.selected)
+                Icon(Icons.check, size: 20, color: widget.accent),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+bool _isSelect(LogicalKeyboardKey k) =>
+    k == LogicalKeyboardKey.select ||
+    k == LogicalKeyboardKey.enter ||
+    k == LogicalKeyboardKey.numpadEnter ||
+    k == LogicalKeyboardKey.gameButtonA ||
+    k == LogicalKeyboardKey.space;
+
+/// Wraps the docked video as a single focusable unit: a rounded accent ring
+/// when focused (reached by pressing Left out of the panel), and Select toggles
+/// play/pause. When focused it shows the current play/pause state in the centre
+/// so it's clear what Select will do (and that it changed).
+class TvVideoFocusFrame extends StatefulWidget {
+  const TvVideoFocusFrame({
+    super.key,
+    required this.accent,
+    required this.player,
+    required this.focusNode,
+    required this.onSelect,
+    required this.onExitRight,
+    required this.child,
+  });
+  final Color accent;
+  final Player player;
+  final FocusNode focusNode;
+  final VoidCallback onSelect;
+  // Right off the video hands focus back into the settings panel.
+  final VoidCallback onExitRight;
+  final Widget child;
+
+  @override
+  State<TvVideoFocusFrame> createState() => _TvVideoFocusFrameState();
+}
+
+class _TvVideoFocusFrameState extends State<TvVideoFocusFrame> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: widget.focusNode,
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent || event is KeyRepeatEvent) {
+          if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+            widget.onExitRight();
+            return KeyEventResult.handled;
+          }
+        }
+        if (event is KeyDownEvent && _isSelect(event.logicalKey)) {
+          widget.onSelect();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 130),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(
+            color: _focused ? widget.accent : Colors.transparent,
+            width: 3,
+          ),
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(11),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              widget.child,
+              if (_focused)
+                Center(
+                  child: StreamBuilder<bool>(
+                    stream: widget.player.stream.playing,
+                    initialData: widget.player.state.playing,
+                    builder: (context, snap) {
+                      final playing = snap.data ?? true;
+                      return DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.5),
+                          shape: BoxShape.circle,
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.all(14),
+                          child: Icon(
+                            playing ? Icons.pause : Icons.play_arrow,
+                            color: Colors.white,
+                            size: 40,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/browse/browse_screen.dart
+++ b/lib/modules/browse/browse_screen.dart
@@ -10,6 +10,7 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/modules/browse/extension/extension_screen.dart';
 import 'package:mangayomi/modules/browse/sources/sources_screen.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/library/widgets/search_text_form_field.dart';
 import 'package:mangayomi/services/fetch_sources_list.dart';
 import 'package:mangayomi/utils/item_type_localization.dart';
@@ -35,33 +36,39 @@ class _BrowseScreenState extends ConsumerState<BrowseScreen>
   late final hideItems = ref.read(hideItemsStateProvider);
   final _textEditingController = TextEditingController();
   late TabController _tabBarController;
+  late List<BrowseTab> _tabList;
 
-  late final List<BrowseTab> _tabList = [
-    if (!hideItems.contains("/MangaLibrary"))
+  // Hide manga & novel from Browse (sources + extensions) on the anime-only TV
+  // layout so only anime shows. Recomputed live so toggling "Anime only" updates
+  // the tabs without a restart. Defaults to isTv, user-overridable. See #729.
+  List<BrowseTab> _computeTabList(bool animeOnly) => [
+    if (!animeOnly && !hideItems.contains("/MangaLibrary"))
       BrowseTab(ItemType.manga, BrowseTabKind.sources),
     if (!hideItems.contains("/AnimeLibrary"))
       BrowseTab(ItemType.anime, BrowseTabKind.sources),
-    if (!hideItems.contains("/NovelLibrary"))
+    if (!animeOnly && !hideItems.contains("/NovelLibrary"))
       BrowseTab(ItemType.novel, BrowseTabKind.sources),
-
-    if (!hideItems.contains("/MangaLibrary"))
+    if (!animeOnly && !hideItems.contains("/MangaLibrary"))
       BrowseTab(ItemType.manga, BrowseTabKind.extensions),
     if (!hideItems.contains("/AnimeLibrary"))
       BrowseTab(ItemType.anime, BrowseTabKind.extensions),
-    if (!hideItems.contains("/NovelLibrary"))
+    if (!animeOnly && !hideItems.contains("/NovelLibrary"))
       BrowseTab(ItemType.novel, BrowseTabKind.extensions),
   ];
 
   @override
   void initState() {
     super.initState();
+    _tabList = _computeTabList(ref.read(animeOnlyTvModeProvider));
     _tabBarController = TabController(length: _tabList.length, vsync: this);
-    _tabBarController.addListener(() {
-      _chekPermission();
-      setState(() {
-        _textEditingController.clear();
-        _isSearch = false;
-      });
+    _tabBarController.addListener(_onTabChanged);
+  }
+
+  void _onTabChanged() {
+    _chekPermission();
+    setState(() {
+      _textEditingController.clear();
+      _isSearch = false;
     });
   }
 
@@ -79,6 +86,18 @@ class _BrowseScreenState extends ConsumerState<BrowseScreen>
   bool _isSearch = false;
   @override
   Widget build(BuildContext context) {
+    // Recompute the tab list live when "Anime only" flips; recreate the
+    // controller when the tab count changes.
+    final newTabs = _computeTabList(ref.watch(animeOnlyTvModeProvider));
+    if (newTabs.length != _tabList.length) {
+      _tabList = newTabs;
+      _tabBarController.removeListener(_onTabChanged);
+      _tabBarController.dispose();
+      _tabBarController = TabController(length: _tabList.length, vsync: this);
+      _tabBarController.addListener(_onTabChanged);
+    } else {
+      _tabList = newTabs;
+    }
     if (_tabList.isEmpty) {
       return SizedBox.shrink();
     }
@@ -88,7 +107,7 @@ class _BrowseScreenState extends ConsumerState<BrowseScreen>
     final l10n = l10nLocalizations(context)!;
     return DefaultTabController(
       animationDuration: Duration.zero,
-      length: 6,
+      length: _tabList.length,
       child: Scaffold(
         appBar: AppBar(
           elevation: 0,
@@ -116,6 +135,9 @@ class _BrowseScreenState extends ConsumerState<BrowseScreen>
                   )
                 : Row(
                     children: [
+                      // Feed entry point temporarily disabled in this build —
+                      // it crashes on first load and its focus needs work (#782).
+                      // The FeedScreen code is kept for when we resume it.
                       if (isExtensionTab)
                         IconButton(
                           onPressed: () {

--- a/lib/modules/browse/browse_screen.dart
+++ b/lib/modules/browse/browse_screen.dart
@@ -135,7 +135,7 @@ class _BrowseScreenState extends ConsumerState<BrowseScreen>
                   )
                 : Row(
                     children: [
-                      // Feed entry point temporarily disabled in this build —
+                      // Feed entry point temporarily disabled in this build -
                       // it crashes on first load and its focus needs work (#782).
                       // The FeedScreen code is kept for when we resume it.
                       if (isExtensionTab)

--- a/lib/modules/library/library_screen.dart
+++ b/lib/modules/library/library_screen.dart
@@ -92,7 +92,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
 
   Widget _buildWithSettings(Settings settings) {
     // On Android TV the anime library shows the dedicated rows-based home
-    // instead of the flat grid — a d-pad-first, cover-forward shelf. Toggleable
+    // instead of the flat grid - a d-pad-first, cover-forward shelf. Toggleable
     // via tvHomeStyleProvider; every other surface keeps the grid.
     if (isTv &&
         widget.itemType == ItemType.anime &&
@@ -379,7 +379,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         ),
         // A single category doesn't need the tab bar + TabBarView. The
         // TabBarView (a PageView) blocks directional d-pad focus from crossing
-        // into/out of the grid — which is why the anime tab couldn't reach the
+        // into/out of the grid - which is why the anime tab couldn't reach the
         // grid while Browse (a direct grid) works. So for one category, render
         // the grid directly like Browse; keep the tabs only for 2+ categories.
         body: tabCount <= 1

--- a/lib/modules/library/library_screen.dart
+++ b/lib/modules/library/library_screen.dart
@@ -6,6 +6,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/modules/library/tv_home/tv_anime_home_view.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/modules/library/providers/add_torrent.dart';
 import 'package:mangayomi/modules/library/providers/isar_providers.dart';
 import 'package:mangayomi/modules/library/providers/library_filter_provider.dart';
@@ -88,6 +91,14 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   }
 
   Widget _buildWithSettings(Settings settings) {
+    // On Android TV the anime library shows the dedicated rows-based home
+    // instead of the flat grid — a d-pad-first, cover-forward shelf. Toggleable
+    // via tvHomeStyleProvider; every other surface keeps the grid.
+    if (isTv &&
+        widget.itemType == ItemType.anime &&
+        ref.watch(tvHomeStyleProvider)) {
+      return TvAnimeHomeView(settings: settings);
+    }
     final categories = ref.watch(
       getMangaCategorieStreamProvider(itemType: widget.itemType),
     );
@@ -366,27 +377,36 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
               setState(() => _ignoreFiltersOnSearch = val),
           vsync: this,
         ),
-        body: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildCategoryTabs(
-              entr: entr,
-              withoutCategory: withoutCategory,
-              showNumbersOfItems: showNumbersOfItems,
-              badgeForCategory: badgeForCategory,
-            ),
-            Flexible(
-              child: TabBarView(
-                controller: tabBarController,
-                children: _buildCategoryBodies(
-                  entr: entr,
-                  withoutCategory: withoutCategory,
-                  bodyForCategory: bodyForCategory,
-                ),
+        // A single category doesn't need the tab bar + TabBarView. The
+        // TabBarView (a PageView) blocks directional d-pad focus from crossing
+        // into/out of the grid — which is why the anime tab couldn't reach the
+        // grid while Browse (a direct grid) works. So for one category, render
+        // the grid directly like Browse; keep the tabs only for 2+ categories.
+        body: tabCount <= 1
+            ? (withoutCategory.isEmpty && entr.isNotEmpty
+                  ? bodyForCategory(categoryId: entr.first.id!)
+                  : bodyForCategory())
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildCategoryTabs(
+                    entr: entr,
+                    withoutCategory: withoutCategory,
+                    showNumbersOfItems: showNumbersOfItems,
+                    badgeForCategory: badgeForCategory,
+                  ),
+                  Flexible(
+                    child: TabBarView(
+                      controller: tabBarController,
+                      children: _buildCategoryBodies(
+                        entr: entr,
+                        withoutCategory: withoutCategory,
+                        bodyForCategory: bodyForCategory,
+                      ),
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/modules/library/tv_home/tv_anime_home_view.dart
+++ b/lib/modules/library/tv_home/tv_anime_home_view.dart
@@ -1,0 +1,1768 @@
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/eval/model/m_bridge.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/category.dart';
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/models/history.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/models/update.dart';
+import 'package:mangayomi/modules/history/providers/isar_providers.dart';
+import 'package:mangayomi/modules/library/providers/isar_providers.dart';
+import 'package:mangayomi/modules/library/providers/library_filter_provider.dart';
+import 'package:mangayomi/modules/library/providers/library_state_provider.dart';
+import 'package:mangayomi/modules/library/widgets/library_entry_utils.dart';
+import 'package:mangayomi/modules/library/widgets/library_settings_sheet.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
+import 'package:mangayomi/modules/more/categories/providers/isar_providers.dart';
+import 'package:mangayomi/modules/more/categories/widgets/custom_textfield.dart';
+import 'package:mangayomi/modules/more/providers/downloaded_only_state_provider.dart';
+import 'package:mangayomi/modules/widgets/bottom_text_widget.dart';
+import 'package:mangayomi/modules/widgets/category_selection_dialog.dart';
+import 'package:mangayomi/modules/widgets/cover_view_widget.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
+import 'package:super_sliver_list/super_sliver_list.dart';
+
+// Poster width per density scale (0 compact · 1 comfortable · 2 large); row
+// height keeps a poster-plus-title aspect.
+/// Matches `GridViewWidget`'s TV default, so an untouched grid-size setting
+/// looks the same here as in the classic library.
+const double _defaultCardWidth = 150;
+
+/// Card width follows the library's own grid-size setting ("items per row",
+/// 0 = default) — the slider in the filter/sort/display sheet drives the TV
+/// home too, rather than the home keeping a private density of its own.
+double _cardWidth(BuildContext context, int gridSize) {
+  final size = MediaQuery.sizeOf(context);
+  final raw = gridSize <= 0
+      ? _defaultCardWidth
+      : (size.width - 44) / gridSize - 8;
+  // A rail is not a grid: cap the card so "1 per row" can't eat the screen.
+  final cap = ((size.height * 0.5) / 1.66).clamp(120.0, 400.0);
+  return raw.clamp(90.0, cap);
+}
+
+double _rowHeight(BuildContext context, int gridSize) =>
+    _cardWidth(context, gridSize) * 1.66;
+
+int _gridSize(WidgetRef ref) =>
+    ref.watch(libraryGridSizeStateProvider(itemType: ItemType.anime)) ?? 0;
+
+/// Mirrors GridViewWidget: 0 means "default", anything else is an exact number
+/// of columns.
+SliverGridDelegate _gridDelegate(int gridSize) => gridSize <= 0
+    ? const SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: _defaultCardWidth + 10,
+        childAspectRatio: 0.60,
+        mainAxisSpacing: 6,
+        crossAxisSpacing: 6,
+      )
+    : SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: gridSize,
+        childAspectRatio: 0.60,
+        mainAxisSpacing: 6,
+        crossAxisSpacing: 6,
+      );
+
+/// The episode to resume for [manga] — the last from watch history, else the
+/// first chapter.
+Chapter? _resumeChapter(Manga manga) {
+  final history = isar.historys.filter().mangaIdEqualTo(manga.id!).findAllSync();
+  if (history.isNotEmpty) {
+    history.first.chapter.loadSync();
+    final ch = history.first.chapter.value;
+    if (ch != null) return ch;
+  }
+  return manga.chapters.isNotEmpty ? manga.chapters.first : null;
+}
+
+String _fmtMs(int ms) {
+  final d = Duration(milliseconds: ms);
+  final s = (d.inSeconds % 60).toString().padLeft(2, '0');
+  return '${d.inMinutes}:$s';
+}
+
+/// TV-only, d-pad-first anime home. A hero (the thing you'll resume) plus
+/// horizontal rows — Continue Watching (from history), New Episodes (from the
+/// update feed), Recently Added, then one row per category. A top bar adds
+/// search and the library's own filter/sort/display sheet.
+/// Rendered only when `isTv` + `tvHomeStyle`.
+class TvAnimeHomeView extends ConsumerStatefulWidget {
+  const TvAnimeHomeView({super.key, required this.settings});
+
+  final Settings settings;
+
+  @override
+  ConsumerState<TvAnimeHomeView> createState() => _TvAnimeHomeViewState();
+}
+
+class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
+  final _searchController = TextEditingController();
+  String _query = '';
+  // Selected category filter: null = "All" (the curated home). A non-empty
+  // search query overrides this while active.
+  int? _selected;
+
+  // Each vertical section (top bar, pills, hero, each row) gets its own
+  // FocusScope. Up/Down move whole-section to whole-section — restoring each
+  // scope's remembered child — instead of Flutter's geometric directional
+  // focus, which skips items that aren't exactly aligned above/below.
+  final _scopeTopbar = FocusScopeNode(debugLabel: 'tvHomeTopbar');
+  final _scopePills = FocusScopeNode(debugLabel: 'tvHomePills');
+  final _scopeHero = FocusScopeNode(debugLabel: 'tvHomeHero');
+  final _scopeRows = List.generate(
+    12,
+    (i) => FocusScopeNode(debugLabel: 'tvHomeRow$i'),
+  );
+  // The search / category grid is a 2D section: it navigates internally and
+  // only hands off to the pills at its top edge.
+  final _scopeGrid = FocusScopeNode(debugLabel: 'tvHomeGrid');
+  List<FocusScopeNode> _order = const [];
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _scopeTopbar.dispose();
+    _scopePills.dispose();
+    _scopeHero.dispose();
+    _scopeGrid.dispose();
+    for (final s in _scopeRows) {
+      s.dispose();
+    }
+    super.dispose();
+  }
+
+  // Move focus between the ordered vertical sections on Up/Down. Defer to the
+  // default (geometric) focus at the edges and for the 2D grid views, which
+  // aren't registered in `_order`.
+  KeyEventResult _handleVertical(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    final k = event.logicalKey;
+    if (k != LogicalKeyboardKey.arrowDown && k != LogicalKeyboardKey.arrowUp) {
+      return KeyEventResult.ignored;
+    }
+    final cur = _order.indexWhere((s) => s.hasFocus);
+    if (cur == -1) return KeyEventResult.ignored;
+    final down = k == LogicalKeyboardKey.arrowDown;
+
+    // The grid is 2D — let it move between its own rows first; only when it
+    // can't (top/bottom edge) do we hop to the adjacent section.
+    if (identical(_order[cur], _scopeGrid)) {
+      final moved =
+          FocusManager.instance.primaryFocus?.focusInDirection(
+            down ? TraversalDirection.down : TraversalDirection.up,
+          ) ??
+          false;
+      if (moved) return KeyEventResult.handled;
+    }
+
+    final target = down ? cur + 1 : cur - 1;
+    if (target < 0 || target >= _order.length) return KeyEventResult.ignored;
+    // Column-preserving: land on the *same* card index in the target row so
+    // Up/Down keeps your horizontal position instead of snapping to card 1.
+    final curDesc = _order[cur].traversalDescendants.toList();
+    final col = curDesc.indexWhere((n) => n.hasPrimaryFocus);
+    // If the target has nothing focusable (e.g. a category you just created and
+    // haven't filled yet), stay put rather than dropping focus into a void.
+    _focusSection(_order[target], col < 0 ? 0 : col);
+    return KeyEventResult.handled;
+  }
+
+  /// Focus the card at [column] in a section (clamped) — always a visible child,
+  /// so a card/button shows the focus ring and the horizontal position carries
+  /// over. Returns false when the section has no focusable children.
+  bool _focusSection(FocusScopeNode scope, int column) {
+    final descendants = scope.traversalDescendants.toList();
+    if (descendants.isEmpty) return false;
+    descendants[column.clamp(0, descendants.length - 1)].requestFocus();
+    return true;
+  }
+
+  /// Synchronous read matching getAllMangaStreamProvider(categoryId: null) —
+  /// used to seed the first frame so the spinner never flashes for local data.
+  List<Manga> _favoriteAnimeSync() => isar.mangas
+      .filter()
+      .idIsNotNull()
+      .favoriteEqualTo(true)
+      .and()
+      .itemTypeEqualTo(ItemType.anime)
+      .findAllSync();
+
+  @override
+  Widget build(BuildContext context) {
+    final animeAsync = ref.watch(
+      getAllMangaStreamProvider(categoryId: null, itemType: ItemType.anime),
+    );
+    final catsAsync = ref.watch(
+      getMangaCategorieStreamProvider(itemType: ItemType.anime),
+    );
+
+    // Seed the first frame from a synchronous Isar read. A stream provider is
+    // AsyncLoading on its very first build — its fireImmediately value arrives a
+    // microtask later — so .when() flashed the spinner for one frame even though
+    // the (local) library data is available instantly. `asData` is null only on
+    // that first frame (a local Isar stream doesn't error), and the sync read
+    // covers it; the stream then drives live updates.
+    final allAnime = animeAsync.asData?.value ?? _favoriteAnimeSync();
+    return Scaffold(
+      body: Builder(
+        builder: (context) {
+          // A hidden category hides its entries, matching the library (a hidden
+          // category has no tab, and its titles aren't "Default" either). A
+          // title stays visible if it's uncategorised, or sits in at least one
+          // non-hidden category.
+          final allCats = catsAsync.asData?.value ?? const <Category>[];
+          final hiddenCats = allCats.where((c) => c.hide ?? false).toList()
+            ..sort((a, b) => (a.pos ?? 0).compareTo(b.pos ?? 0));
+          final hiddenCatIds = hiddenCats
+              .map((c) => c.id)
+              .whereType<int>()
+              .toSet();
+          final cats = allCats.where((c) => !(c.hide ?? false)).toList()
+            ..sort((a, b) => (a.pos ?? 0).compareTo(b.pos ?? 0));
+          final visible = hiddenCatIds.isEmpty
+              ? allAnime
+              : allAnime.where((m) {
+                  final mc = m.categories ?? const <int>[];
+                  return mc.isEmpty ||
+                      mc.any((id) => !hiddenCatIds.contains(id));
+                }).toList();
+
+          // Only a genuinely empty library short-circuits the whole screen. If
+          // everything is merely hidden, keep the pill bar on screen — holding
+          // OK on "All" is the way back, and _EmptyHome has no "All".
+          if (allAnime.isEmpty) return const _EmptyHome();
+
+          // The filter/sort/display sheet is the library's own, so its settings
+          // have to bite here too. Filters and the search box narrow every view;
+          // the sort order drives the grids, while the curated rows keep the
+          // ordering that gives them their meaning (last watched, newest
+          // episode, most recently added).
+          const it = ItemType.anime;
+          final settings = widget.settings;
+          final sortState = ref.watch(
+            sortLibraryMangaStateProvider(itemType: it, settings: settings),
+          );
+          final filtered = ref.watch(
+            filteredLibraryMangaProvider(
+              data: visible,
+              downloadFilterType: ref.watch(
+                mangaFilterDownloadedStateProvider(
+                  itemType: it,
+                  mangaList: visible,
+                  settings: settings,
+                ),
+              ),
+              unreadFilterType: ref.watch(
+                mangaFilterUnreadStateProvider(
+                  itemType: it,
+                  mangaList: visible,
+                  settings: settings,
+                ),
+              ),
+              startedFilterType: ref.watch(
+                mangaFilterStartedStateProvider(
+                  itemType: it,
+                  mangaList: visible,
+                  settings: settings,
+                ),
+              ),
+              bookmarkedFilterType: ref.watch(
+                mangaFilterBookmarkedStateProvider(
+                  itemType: it,
+                  mangaList: visible,
+                  settings: settings,
+                ),
+              ),
+              completedFilterType: ref.watch(
+                mangaFilterCompletedStateProvider(
+                  itemType: it,
+                  mangaList: visible,
+                  settings: settings,
+                ),
+              ),
+              trackingFilterType: ref.watch(
+                mangaFilterTrackingStateProvider(
+                  itemType: it,
+                  mangaList: visible,
+                  settings: settings,
+                ),
+              ),
+              sortType: sortState.index ?? 0,
+              downloadedOnly: ref.watch(downloadedOnlyStateProvider),
+              searchQuery: _query.trim(),
+              ignoreFiltersOnSearch: false,
+            ),
+          );
+          final entries = (sortState.reverse ?? false)
+              ? filtered.reversed.toList()
+              : filtered;
+
+          // Continue Watching = every anime you've actually played, from watch
+          // history, most-recently-watched first.
+          final historyIds =
+              (ref
+                          .watch(
+                            getAllHistoryStreamProvider(
+                              itemType: ItemType.anime,
+                            ),
+                          )
+                          .asData
+                          ?.value ??
+                      const <History>[])
+                  .map((h) => h.mangaId)
+                  .whereType<int>()
+                  .toSet();
+          // New Episodes = the library-update feed (new episodes a refresh
+          // detected), limited to unwatched ones.
+          final updatedIds =
+              (ref
+                          .watch(
+                            getAllUpdateStreamProvider(itemType: ItemType.anime),
+                          )
+                          .asData
+                          ?.value ??
+                      const <Update>[])
+                  .map((u) => u.mangaId)
+                  .whereType<int>()
+                  .toSet();
+
+          final continueList =
+              entries.where((m) => historyIds.contains(m.id)).toList()
+                ..sort((a, b) => (b.lastRead ?? 0).compareTo(a.lastRead ?? 0));
+          final newEpisodes =
+              entries
+                  .where(
+                    (m) =>
+                        updatedIds.contains(m.id) &&
+                        m.chapters.any((c) => !(c.isRead ?? true)),
+                  )
+                  .toList()
+                ..sort(
+                  (a, b) => (b.lastUpdate ?? 0).compareTo(a.lastUpdate ?? 0),
+                );
+          final recent = [...entries]
+            ..sort((a, b) => (b.dateAdded ?? 0).compareTo(a.dateAdded ?? 0));
+          final heroItems = (continueList.isNotEmpty ? continueList : recent)
+              .take(6)
+              .toList();
+
+          // If the selected category was removed, fall back to All.
+          final selectedId =
+              (_selected != null && cats.any((c) => c.id == _selected))
+              ? _selected
+              : null;
+
+          final q = _query.trim().toLowerCase();
+          final searching = q.isNotEmpty;
+
+          // Ordered vertical sections for whole-row Up/Down navigation. Top bar
+          // and pills are always first; the All view adds hero + one scope per
+          // row. Grid views leave the grid out (default 2D focus handles it).
+          final order = <FocusScopeNode>[_scopeTopbar, _scopePills];
+          Widget content;
+          if (visible.isEmpty) {
+            content = Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Every title sits in a hidden category.\n'
+                  'Hold OK on “All” to unhide one.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Theme.of(context).hintColor),
+                ),
+              ),
+            );
+          } else if (searching) {
+            // `entries` already has the query applied, in the sheet's sort
+            // order. A selected pill scopes the search to that category, the
+            // way searching inside a category tab does everywhere else — the
+            // library searches `getAllMangaStreamProvider(categoryId:)`, not
+            // the whole library.
+            final catName = selectedId == null
+                ? null
+                : cats
+                      .firstWhere(
+                        (c) => c.id == selectedId,
+                        orElse: () => cats.first,
+                      )
+                      .name;
+            final matches = selectedId == null
+                ? entries
+                : entries
+                      .where(
+                        (m) => (m.categories ?? const <int>[]).contains(
+                          selectedId,
+                        ),
+                      )
+                      .toList();
+            order.add(_scopeGrid);
+            content = FocusScope(
+              node: _scopeGrid,
+              child: _MangaGrid(
+                items: matches,
+                emptyLabel: catName == null
+                    ? 'No matching anime'
+                    : 'No matching anime in “$catName”',
+              ),
+            );
+          } else if (entries.isEmpty) {
+            content = Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'No anime matches the current filters.\n'
+                  'Change them from the button beside search.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Theme.of(context).hintColor),
+                ),
+              ),
+            );
+          } else if (selectedId == null) {
+            order.add(_scopeHero);
+            final rows = <Widget>[
+              FocusScope(node: _scopeHero, child: _TvHomeHero(items: heroItems)),
+            ];
+            var ri = 0;
+            void addRow(String title, List<Manga> items) {
+              if (ri >= _scopeRows.length) return; // scope pool exhausted
+              final scope = _scopeRows[ri++];
+              order.add(scope);
+              rows.add(
+                FocusScope(
+                  node: scope,
+                  child: _TvHomeRow(title: title, items: items),
+                ),
+              );
+            }
+
+            if (continueList.isNotEmpty) {
+              addRow('Continue Watching', continueList);
+            }
+            if (newEpisodes.isNotEmpty) addRow('New Episodes', newEpisodes);
+            addRow('Recently Added', recent);
+
+            // Genre rows — browse the library by genre (top few, ≥3 titles).
+            // The one place a title can appear in more than one row, so they're
+            // switchable from the filter/sort/display sheet.
+            if (ref.watch(tvHomeGenreRowsProvider)) {
+              final byGenre = <String, List<Manga>>{};
+              for (final m in entries) {
+                for (final g in (m.genre ?? const <String>[])) {
+                  final t = g.trim();
+                  if (t.isNotEmpty) (byGenre[t] ??= <Manga>[]).add(m);
+                }
+              }
+              final genreRows =
+                  byGenre.entries.where((e) => e.value.length >= 3).toList()
+                    ..sort((a, b) => b.value.length.compareTo(a.value.length));
+              for (final g in genreRows.take(6)) {
+                addRow(g.key, g.value);
+              }
+            }
+            content = ListView(
+              padding: const EdgeInsets.only(bottom: 28),
+              children: rows,
+            );
+          } else {
+            // Category view: a Continue Watching row scoped to *this* category,
+            // then the category's full grid.
+            final catName = cats
+                .firstWhere(
+                  (c) => c.id == selectedId,
+                  orElse: () => cats.first,
+                )
+                .name;
+            final inCat = entries
+                .where(
+                  (m) => (m.categories ?? const <int>[]).contains(selectedId),
+                )
+                .toList();
+            final catContinue =
+                inCat.where((m) => historyIds.contains(m.id)).toList()
+                  ..sort(
+                    (a, b) => (b.lastRead ?? 0).compareTo(a.lastRead ?? 0),
+                  );
+            // Same hero rule as All: what you'd resume, else what you added
+            // last — never "whatever the sort tab happens to put first".
+            final catRecent = [...inCat]
+              ..sort((a, b) => (b.dateAdded ?? 0).compareTo(a.dateAdded ?? 0));
+            final catHero = (catContinue.isNotEmpty ? catContinue : catRecent)
+                .take(6)
+                .toList();
+
+            if (inCat.isEmpty) {
+              order.add(_scopeGrid);
+              content = FocusScope(
+                node: _scopeGrid,
+                child: _MangaGrid(
+                  items: inCat,
+                  emptyLabel:
+                      'No anime in this category yet.\n'
+                      'Add titles to it from a title’s detail page.',
+                ),
+              );
+            } else {
+              // NestedScrollView, not a CustomScrollView: the hero and rail
+              // still scroll away, but the grid stays a real (lazy) box widget,
+              // so each part can own a FocusScope — a scope can't wrap a sliver.
+              // That keeps every section on `_handleVertical`'s column-preserving
+              // navigation instead of Flutter's geometric focus, which snaps to
+              // the first card whenever the rows don't line up.
+              order.add(_scopeHero);
+              if (catContinue.isNotEmpty) order.add(_scopeRows[0]);
+              order.add(_scopeGrid);
+              content = NestedScrollView(
+                headerSliverBuilder: (context, _) => [
+                  SliverToBoxAdapter(
+                    child: FocusScope(
+                      node: _scopeHero,
+                      child: _TvHomeHero(items: catHero),
+                    ),
+                  ),
+                  if (catContinue.isNotEmpty)
+                    SliverToBoxAdapter(
+                      child: FocusScope(
+                        node: _scopeRows[0],
+                        child: _TvHomeRow(
+                          title: 'Continue Watching',
+                          items: catContinue,
+                        ),
+                      ),
+                    ),
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(22, 16, 22, 8),
+                      child: Text(
+                        catName ?? '',
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+                // The grid keeps the sheet's sort order.
+                body: FocusScope(
+                  node: _scopeGrid,
+                  child: _MangaGrid(items: inCat),
+                ),
+              );
+            }
+          }
+          _order = order;
+
+          // Whatever is painted behind the pills — the colour the scrolling
+          // content has to dissolve into at the top of its viewport.
+          final pageBg = Theme.of(context).scaffoldBackgroundColor;
+          return Focus(
+            onKeyEvent: _handleVertical,
+            child: Column(
+              children: [
+                FocusScope(
+                  node: _scopeTopbar,
+                  child: _TvHomeTopBar(
+                    controller: _searchController,
+                    settings: settings,
+                    entries: entries,
+                    onChanged: (v) => setState(() => _query = v),
+                  ),
+                ),
+                FocusScope(
+                  node: _scopePills,
+                  child: _CategoryPills(
+                    selected: selectedId,
+                    categories: cats,
+                    hidden: hiddenCats,
+                    onSelect: (id) => setState(() => _selected = id),
+                  ),
+                ),
+                Expanded(
+                  child: Stack(
+                    children: [
+                      Positioned.fill(child: content),
+                      // The hero's backdrop is full-bleed, so scrolling it up
+                      // under the pills leaves the viewport's clip cutting
+                      // straight across it. The hero fades at its *own* top
+                      // edge, which by then is off-screen — so dissolve the
+                      // cut here, where it actually happens.
+                      Positioned(
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        height: 36,
+                        child: IgnorePointer(
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              gradient: LinearGradient(
+                                begin: Alignment.topCenter,
+                                end: Alignment.bottomCenter,
+                                colors: [
+                                  pageBg,
+                                  pageBg.withValues(alpha: 0),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Search field + card-density control. Sits above the rows; Up from the hero
+/// reaches it.
+class _TvHomeTopBar extends StatelessWidget {
+  const _TvHomeTopBar({
+    required this.controller,
+    required this.settings,
+    required this.entries,
+    required this.onChanged,
+  });
+  final TextEditingController controller;
+  final Settings settings;
+  final List<Manga> entries;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = context.primaryColor;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(22, 16, 22, 6),
+      child: Row(
+        children: [
+          Expanded(
+            // The text field owns Left/Right for the cursor; let Right escape to
+            // the size button once the cursor is at the end of the text.
+            child: Focus(
+              canRequestFocus: false,
+              skipTraversal: true,
+              onKeyEvent: (node, event) {
+                if (event is KeyDownEvent &&
+                    event.logicalKey == LogicalKeyboardKey.arrowRight) {
+                  final sel = controller.selection;
+                  final atEnd =
+                      !sel.isValid ||
+                      sel.baseOffset >= controller.text.length;
+                  if (atEnd) {
+                    FocusScope.of(
+                      context,
+                    ).focusInDirection(TraversalDirection.right);
+                    return KeyEventResult.handled;
+                  }
+                }
+                return KeyEventResult.ignored;
+              },
+              child: TextField(
+                controller: controller,
+                onChanged: onChanged,
+                textInputAction: TextInputAction.search,
+                onSubmitted: (_) => FocusScope.of(
+                  context,
+                ).focusInDirection(TraversalDirection.down),
+                decoration: InputDecoration(
+                isDense: true,
+                filled: true,
+                hintText: 'Search your anime',
+                prefixIcon: const Icon(Icons.search, size: 20),
+                contentPadding: const EdgeInsets.symmetric(
+                  vertical: 12,
+                  horizontal: 12,
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(26),
+                  borderSide: BorderSide.none,
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(26),
+                  borderSide: BorderSide(color: accent, width: 2),
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(26),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+            ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          _LibrarySettingsButton(settings: settings, entries: entries),
+        ],
+      ),
+    );
+  }
+}
+
+/// Opens the library's own filter/sort/display sheet — the same one the phone
+/// app uses, already d-pad traversable. Its grid-size slider is where card
+/// density now lives.
+class _LibrarySettingsButton extends ConsumerStatefulWidget {
+  const _LibrarySettingsButton({required this.settings, required this.entries});
+
+  final Settings settings;
+  final List<Manga> entries;
+
+  @override
+  ConsumerState<_LibrarySettingsButton> createState() =>
+      _LibrarySettingsButtonState();
+}
+
+class _LibrarySettingsButtonState extends ConsumerState<_LibrarySettingsButton>
+    with SingleTickerProviderStateMixin {
+  bool _focused = false;
+
+  void _open() => showLibrarySettingsSheet(
+    context: context,
+    vsync: this,
+    settings: widget.settings,
+    itemType: ItemType.anime,
+    entries: widget.entries,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = context.primaryColor;
+    return Focus(
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        // Opens on release: the sheet must not inherit the repeats of the press
+        // that opened it (SingleActivator activates on repeats).
+        if (event is KeyUpEvent && _isSelectKey(event.logicalKey)) {
+          _open();
+          return KeyEventResult.handled;
+        }
+        if (_isSelectKey(event.logicalKey)) return KeyEventResult.handled;
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: _open,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          padding: const EdgeInsets.all(11),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: _focused ? accent : accent.withValues(alpha: 0.12),
+          ),
+          child: Icon(
+            Icons.filter_list_sharp,
+            size: 22,
+            color: _focused ? Colors.white : accent,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Flat grid of a Manga list (leaf view — a plain grid navigates predictably).
+/// Shared by search results and a selected category.
+class _MangaGrid extends ConsumerWidget {
+  const _MangaGrid({required this.items, this.emptyLabel = ''});
+  final List<Manga> items;
+
+  /// Only reachable where [items] can legitimately be empty.
+  final String emptyLabel;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (items.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(emptyLabel, textAlign: TextAlign.center),
+        ),
+      );
+    }
+    return GridView.builder(
+      clipBehavior: Clip.none,
+      padding: const EdgeInsets.fromLTRB(18, 8, 18, 28),
+      gridDelegate: _gridDelegate(_gridSize(ref)),
+      itemCount: items.length,
+      itemBuilder: (context, index) => _TvHomeCard(manga: items[index]),
+    );
+  }
+}
+
+/// The top hero: a blurred cover backdrop (clipped so it can't bleed into the
+/// rows), darkened on the left for text and faded into the page background at
+/// the bottom for a clean seam. Poster + title + the autofocused Continue.
+/// Auto-rotating hero — cycles through the top few resume candidates with a
+/// crossfade, pausing while it (its Continue button) is focused.
+class _TvHomeHero extends StatefulWidget {
+  const _TvHomeHero({required this.items});
+  final List<Manga> items;
+
+  @override
+  State<_TvHomeHero> createState() => _TvHomeHeroState();
+}
+
+class _TvHomeHeroState extends State<_TvHomeHero>
+    with SingleTickerProviderStateMixin {
+  static const _dwell = Duration(seconds: 7);
+  int _index = 0;
+  late final AnimationController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    // One clock drives both the dwell timer and the progress indicator.
+    _ctrl = AnimationController(vsync: this, duration: _dwell)
+      ..addStatusListener((s) {
+        if (s == AnimationStatus.completed && mounted) {
+          setState(() => _index = (_index + 1) % widget.items.length);
+          _ctrl.forward(from: 0);
+        }
+      });
+    if (widget.items.length > 1) _ctrl.forward();
+  }
+
+  /// Pause the dwell while the hero is focused so it never rotates out from
+  /// under you; resume when focus leaves.
+  void _setPaused(bool paused) {
+    if (widget.items.length <= 1) return;
+    if (paused) {
+      _ctrl.stop();
+    } else if (!_ctrl.isAnimating) {
+      _ctrl.forward();
+    }
+  }
+
+  @override
+  void didUpdateWidget(_TvHomeHero old) {
+    super.didUpdateWidget(old);
+    if (_index >= widget.items.length) _index = 0;
+    if (widget.items.length > 1 && !_ctrl.isAnimating) _ctrl.forward();
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.items.isEmpty) return const SizedBox.shrink();
+    final manga = widget.items[_index.clamp(0, widget.items.length - 1)];
+    return Focus(
+      canRequestFocus: false,
+      skipTraversal: true,
+      onFocusChange: _setPaused,
+      child: Stack(
+        children: [
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 500),
+            child: _HeroContent(key: ValueKey(manga.id), manga: manga),
+          ),
+          if (widget.items.length > 1)
+            Positioned(
+              right: 34,
+              bottom: 26,
+              child: _RotationDots(
+                controller: _ctrl,
+                count: widget.items.length,
+                index: _index,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The rotation timer: the active item is a short bar that fills over the dwell
+/// time; the others are muted dots. Deliberately not a countdown number.
+class _RotationDots extends StatelessWidget {
+  const _RotationDots({
+    required this.controller,
+    required this.count,
+    required this.index,
+  });
+  final AnimationController controller;
+  final int count;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = context.primaryColor;
+    final muted = Colors.white.withValues(alpha: 0.28);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(count, (i) {
+        final active = i == index;
+        return Padding(
+          padding: const EdgeInsets.only(left: 6),
+          child: active
+              ? SizedBox(
+                  width: 24,
+                  height: 4,
+                  child: AnimatedBuilder(
+                    animation: controller,
+                    builder: (context, _) => ClipRRect(
+                      borderRadius: BorderRadius.circular(2),
+                      child: LinearProgressIndicator(
+                        value: controller.value,
+                        minHeight: 4,
+                        backgroundColor: muted,
+                        valueColor: AlwaysStoppedAnimation<Color>(accent),
+                      ),
+                    ),
+                  ),
+                )
+              : Container(
+                  width: 6,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: muted,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+        );
+      }),
+    );
+  }
+}
+
+class _HeroContent extends ConsumerWidget {
+  const _HeroContent({required this.manga, super.key});
+  final Manga manga;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final image = resolveCoverImage(manga, ref);
+    final total = manga.chapters.length;
+    final read = manga.chapters.where((c) => c.isRead ?? false).length;
+    final unread = manga.chapters.where((c) => !(c.isRead ?? true)).length;
+    final resume = _resumeChapter(manga);
+    final posMs = int.tryParse(resume?.lastPageRead ?? '') ?? 0;
+
+    // Series progress = watched / total (episode duration isn't reliably
+    // stored, so within-episode % isn't available).
+    final progress = (total > 0 && read > 0 && read < total)
+        ? read / total
+        : 0.0;
+    final hasBar = progress > 0;
+
+    final metaBits = <String>[
+      if ((resume?.name ?? '').isNotEmpty) resume!.name!,
+      if (posMs > 0) 'at ${_fmtMs(posMs)}',
+      if (unread > 0) '$unread new',
+      if ((manga.source ?? '').isNotEmpty) manga.source!,
+    ];
+    final genreBits = (manga.genre ?? const <String>[])
+        .where((g) => g.trim().isNotEmpty)
+        .take(3)
+        .toList();
+
+    return ClipRect(
+      child: SizedBox(
+        height: 330,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            // The backdrop fades its own alpha out into the rows below, rather
+            // than blending toward a background colour it would have to guess
+            // at. Its top edge is handled by the fade over the whole content
+            // viewport — that edge moves as the hero scrolls, this one doesn't.
+            ShaderMask(
+              blendMode: BlendMode.dstIn,
+              shaderCallback: (rect) => const LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                stops: [0.0, 0.72, 1.0],
+                colors: [Colors.white, Colors.white, Colors.transparent],
+              ).createShader(rect),
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  ImageFiltered(
+                    imageFilter: ui.ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+                    child: Image(image: image, fit: BoxFit.cover),
+                  ),
+                  // Darken the left so the title/summary stay readable.
+                  const DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.centerLeft,
+                        end: Alignment.centerRight,
+                        colors: [Color(0xDB000000), Color(0x40000000)],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(28, 26, 40, 28),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: AspectRatio(
+                      aspectRatio: 0.68,
+                      child: Image(image: image, fit: BoxFit.cover),
+                    ),
+                  ),
+                  const SizedBox(width: 24),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          manga.name ?? '',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 30,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        if (metaBits.isNotEmpty) ...[
+                          const SizedBox(height: 6),
+                          Text(
+                            metaBits.join('  ·  '),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.78),
+                              fontSize: 14,
+                            ),
+                          ),
+                        ],
+                        if (genreBits.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            genreBits.join('  ·  '),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.55),
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                        if (hasBar) ...[
+                          const SizedBox(height: 12),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: ClipRRect(
+                                  borderRadius: BorderRadius.circular(3),
+                                  child: LinearProgressIndicator(
+                                    value: progress,
+                                    minHeight: 5,
+                                    backgroundColor: Colors.white24,
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                      context.primaryColor,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 10),
+                              Text(
+                                '$read / $total',
+                                style: const TextStyle(
+                                  color: Colors.white70,
+                                  fontSize: 12,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                        if ((manga.description ?? '').trim().isNotEmpty) ...[
+                          const SizedBox(height: 12),
+                          Text(
+                            manga.description!.trim(),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.72),
+                              fontSize: 13,
+                              height: 1.35,
+                            ),
+                          ),
+                        ],
+                        const SizedBox(height: 16),
+                        _HeroContinueButton(manga: manga, chapter: resume),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The hero's Continue button — focusable, autofocused (the home's landing
+/// target), theme-accent when focused, OK/Select or tap to resume.
+class _HeroContinueButton extends StatefulWidget {
+  const _HeroContinueButton({required this.manga, this.chapter});
+  final Manga manga;
+  final Chapter? chapter;
+
+  @override
+  State<_HeroContinueButton> createState() => _HeroContinueButtonState();
+}
+
+class _HeroContinueButtonState extends State<_HeroContinueButton> {
+  bool _focused = false;
+
+  void _resume() {
+    (widget.chapter ?? _resumeChapter(widget.manga))?.pushToReaderView(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = context.primaryColor;
+    return Focus(
+      // Entry focus lives on the "All" pill; the hero must not steal it when
+      // switching back to All from a category view.
+      autofocus: false,
+      onFocusChange: (f) {
+        setState(() => _focused = f);
+        // When focus returns to the hero (e.g. scrolling up out of the rows),
+        // pull the page fully to the top so the whole poster is revealed
+        // instead of staying clipped under the first row.
+        if (f) {
+          Scrollable.maybeOf(context)?.position.animateTo(
+            0,
+            duration: const Duration(milliseconds: 260),
+            curve: Curves.easeOut,
+          );
+        }
+      },
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && _isSelectKey(event.logicalKey)) {
+          _resume();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: _resume,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 130),
+          curve: Curves.easeOut,
+          transform: Matrix4.identity()..scale(_focused ? 1.05 : 1.0),
+          transformAlignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 12),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(8),
+            color: _focused ? accent : Colors.white.withValues(alpha: 0.14),
+            border: Border.all(
+              color: _focused ? accent : Colors.white.withValues(alpha: 0.28),
+              width: 2,
+            ),
+          ),
+          child: const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.play_arrow, color: Colors.white),
+              SizedBox(width: 8),
+              Text(
+                'Continue',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 15,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A titled horizontal row of cover cards, sized by the current density scale.
+class _TvHomeRow extends ConsumerWidget {
+  const _TvHomeRow({required this.title, required this.items});
+  final String title;
+  final List<Manga> items;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final gridSize = _gridSize(ref);
+    final width = _cardWidth(context, gridSize);
+    final height = _rowHeight(context, gridSize);
+    return Padding(
+      padding: const EdgeInsets.only(top: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(22, 0, 22, 10),
+            child: Text(
+              title,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+            ),
+          ),
+          SizedBox(
+            height: height,
+            child: FocusTraversalGroup(
+              child: SuperListView.builder(
+                scrollDirection: Axis.horizontal,
+                clipBehavior: Clip.none,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                itemCount: items.length,
+                itemBuilder: (context, index) => SizedBox(
+                  width: width,
+                  child: _TvHomeCard(manga: items[index]),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The category filter bar under the search row: [All] + a pill per category +
+/// [+ Category]. Selecting sets the filter but keeps focus on the pill.
+class _CategoryPills extends StatefulWidget {
+  const _CategoryPills({
+    required this.selected,
+    required this.categories,
+    required this.hidden,
+    required this.onSelect,
+  });
+  final int? selected;
+  final List<Category> categories;
+  final List<Category> hidden;
+  final ValueChanged<int?> onSelect;
+
+  @override
+  State<_CategoryPills> createState() => _CategoryPillsState();
+}
+
+class _CategoryPillsState extends State<_CategoryPills> {
+  /// "All" is the one pill that always exists, so it's where focus lands when
+  /// the pill that had it leaves the tree — hiding it, or unhiding the last
+  /// hidden category and losing the Hidden pill with it.
+  final _allNode = FocusNode(debugLabel: 'tvPillAll');
+
+  @override
+  void dispose() {
+    _allNode.dispose();
+    super.dispose();
+  }
+
+  void _focusAll() {
+    Future<void>.microtask(() {
+      if (mounted) _allNode.requestFocus();
+    });
+  }
+
+  /// Hold OK on a category pill to hide it: the pill goes away and so do its
+  /// titles, matching what hiding does in the library. Unconfirmed, because the
+  /// toast that names the way back doubles as the undo prompt.
+  void _hide(Category category) {
+    isar.writeTxnSync(() => isar.categorys.putSync(category..hide = true));
+    if (widget.selected == category.id) widget.onSelect(null);
+    _focusAll();
+    botToast('Hid “${category.name}” · hold OK on “All” to unhide');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 42,
+      child: LayoutBuilder(
+        builder: (context, constraints) => SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: ConstrainedBox(
+            // minWidth = viewport, so the Row centers its pills when they fit
+            // and simply grows/scrolls when there are many categories.
+            constraints: BoxConstraints(minWidth: constraints.maxWidth),
+            child: FocusTraversalGroup(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _Pill(
+                    label: 'All',
+                    focusNode: _allNode,
+                    selected: widget.selected == null,
+                    autofocus: true,
+                    onTap: () => widget.onSelect(null),
+                    onLongPress: () =>
+                        _showHiddenCategoriesDialog(context, widget.hidden),
+                    onMenu: () =>
+                        _showHiddenCategoriesDialog(context, widget.hidden),
+                  ),
+                  for (final c in widget.categories)
+                    Padding(
+                      padding: const EdgeInsets.only(left: 8),
+                      child: _Pill(
+                        label: c.name ?? '',
+                        selected: widget.selected == c.id,
+                        onTap: () => widget.onSelect(c.id),
+                        onLongPress: () => _hide(c),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(left: 8),
+                    child: _Pill(
+                      label: 'Category',
+                      icon: Icons.add,
+                      onTap: () =>
+                          _showAddCategoryDialog(context, widget.categories),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A focusable filter pill: idle · focused (accent fill) · selected
+/// (accent-tinted) — three clearly distinct states for a d-pad across a room.
+class _Pill extends StatefulWidget {
+  const _Pill({
+    required this.label,
+    required this.onTap,
+    this.onLongPress,
+    this.onMenu,
+    this.icon,
+    this.focusNode,
+    this.selected = false,
+    this.autofocus = false,
+  });
+  final String label;
+  final IconData? icon;
+  final FocusNode? focusNode;
+  final bool selected;
+  final bool autofocus;
+  final VoidCallback onTap;
+  final VoidCallback? onLongPress;
+
+  /// Handled only while this pill has focus, so the remote's Menu button stays
+  /// free everywhere else — it reads as "options for the focused item", which
+  /// a cover will want.
+  final VoidCallback? onMenu;
+
+  @override
+  State<_Pill> createState() => _PillState();
+}
+
+class _PillState extends State<_Pill> {
+  bool _focused = false;
+  bool _held = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = context.primaryColor;
+    final bg = _focused
+        ? accent
+        : widget.selected
+        ? accent.withValues(alpha: 0.22)
+        : Theme.of(context).hintColor.withValues(alpha: 0.14);
+    final fg = _focused
+        ? Colors.white
+        : widget.selected
+        ? accent
+        : Theme.of(context).colorScheme.onSurface;
+    return Focus(
+      focusNode: widget.focusNode,
+      autofocus: widget.autofocus,
+      onFocusChange: (f) {
+        setState(() => _focused = f);
+        if (f && context.mounted && Scrollable.maybeOf(context) != null) {
+          Scrollable.ensureVisible(
+            context,
+            alignment: 0.5,
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOut,
+          );
+        }
+      },
+      onKeyEvent: (node, event) {
+        final onMenu = widget.onMenu;
+        if (onMenu != null &&
+            event is KeyDownEvent &&
+            event.logicalKey == LogicalKeyboardKey.contextMenu) {
+          onMenu();
+          return KeyEventResult.handled;
+        }
+        if (!_isSelectKey(event.logicalKey)) return KeyEventResult.ignored;
+        // A remote reports a held OK as key *repeats*, never as a pointer
+        // long-press. Both tap and hold resolve on release, so whatever a hold
+        // opens never inherits the rest of that press — a dialog raised on the
+        // first repeat would be driven by the repeats still to come.
+        if (event is KeyDownEvent) {
+          _held = false;
+          return KeyEventResult.handled;
+        }
+        if (event is KeyRepeatEvent) {
+          _held = true;
+          return KeyEventResult.handled;
+        }
+        if (event is KeyUpEvent) {
+          final longPress = widget.onLongPress;
+          if (_held && longPress != null) {
+            longPress();
+          } else {
+            widget.onTap();
+          }
+          _held = false;
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onTap,
+        onLongPress: widget.onLongPress,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 130),
+          curve: Curves.easeOut,
+          transform: Matrix4.identity()..scale(_focused ? 1.08 : 1.0),
+          transformAlignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 7),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(16),
+            color: bg,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (widget.icon != null) ...[
+                Icon(widget.icon, size: 14, color: fg),
+                const SizedBox(width: 4),
+              ],
+              Text(
+                widget.label,
+                style: TextStyle(
+                  color: fg,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Reuses the categories screen's add-category flow to create an anime category
+/// inline from the home.
+/// Has no chip, no icon, nothing on screen: a visible "Hidden" affordance would
+/// advertise the categories the user hid, which is most of what hiding is for.
+/// Reached from the "All" pill — hold OK on it, or press Menu while it's
+/// focused. Hiding leaves focus there, so the toast can name the way back.
+void _showHiddenCategoriesDialog(BuildContext context, List<Category> hidden) {
+  if (hidden.isEmpty) {
+    botToast('No hidden categories');
+    return;
+  }
+  showDialog(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: const Text('Hidden categories'),
+      content: SizedBox(
+        width: 380,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (var i = 0; i < hidden.length; i++)
+              ListTile(
+                autofocus: i == 0,
+                title: Text(hidden[i].name ?? ''),
+                trailing: const Icon(Icons.visibility_outlined),
+                onTap: () {
+                  isar.writeTxnSync(
+                    () => isar.categorys.putSync(hidden[i]..hide = false),
+                  );
+                  Navigator.pop(dialogContext);
+                },
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(dialogContext),
+          child: const Text('Close'),
+        ),
+      ],
+    ),
+  );
+}
+
+void _showAddCategoryDialog(BuildContext context, List<Category> existing) {
+  final controller = TextEditingController();
+  bool isExist = false;
+  showDialog(
+    context: context,
+    builder: (context) => StatefulBuilder(
+      builder: (context, setState) => AlertDialog(
+        title: const Text('New category'),
+        content: CustomTextFormField(
+          controller: controller,
+          entries: existing,
+          context: context,
+          exist: (v) => setState(() => isExist = v),
+          isExist: isExist,
+          val: (_) => setState(() {}),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: controller.text.trim().isEmpty || isExist
+                ? null
+                : () {
+                    final category = Category(
+                      forItemType: ItemType.anime,
+                      name: controller.text.trim(),
+                      updatedAt: DateTime.now().millisecondsSinceEpoch,
+                    );
+                    isar.writeTxnSync(() {
+                      isar.categorys.putSync(category..pos = category.id);
+                      final nulls = isar.categorys
+                          .filter()
+                          .posIsNull()
+                          .findAllSync();
+                      for (final c in nulls) {
+                        isar.categorys.putSync(c..pos = c.id);
+                      }
+                    });
+                    Navigator.pop(context);
+                  },
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// A cover card: reuses [CoverViewWidget] (focus ring + badges) and scrolls
+/// itself into view when focused (focus drives scroll). Select → detail.
+class _TvHomeCard extends ConsumerWidget {
+  const _TvHomeCard({required this.manga});
+  final Manga manga;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final total = manga.chapters.length;
+    final read = manga.chapters.where((c) => c.isRead ?? false).length;
+    final unread = manga.chapters.where((c) => !(c.isRead ?? true)).length;
+    // Series progress = episodes watched / total (episode duration isn't
+    // reliably stored, so within-episode progress isn't available).
+    final progress = (total > 0 && read > 0 && read < total)
+        ? read / total
+        : 0.0;
+    final source = manga.source ?? '';
+    return CoverViewWidget(
+      isComfortableGrid: true,
+      progress: progress,
+      bottomTextWidget: BottomTextWidget(
+        text: manga.name ?? '',
+        maxLines: 1,
+        isComfortableGrid: true,
+      ),
+      image: resolveCoverImage(manga, ref),
+      onFocusChange: (focused) {
+        if (focused && context.mounted) {
+          // Reveal the focused card in both the row (horizontal) and the page
+          // (vertical) — one call walks up every enclosing scrollable.
+          Scrollable.ensureVisible(
+            context,
+            alignment: 0.5,
+            duration: const Duration(milliseconds: 220),
+            curve: Curves.easeOut,
+          );
+        }
+      },
+      onTap: () => onTapEntry(
+        isLongPressed: false,
+        ref: ref,
+        context: context,
+        entry: manga,
+      ),
+      // Long-press (hold OK on a remote) → assign this title to categories.
+      onLongPress: () => showCategorySelectionDialog(
+        context: context,
+        ref: ref,
+        itemType: ItemType.anime,
+        singleManga: manga,
+      ),
+      children: [
+        if (unread > 0)
+          Positioned(
+            top: 0,
+            left: 0,
+            child: Padding(
+              padding: const EdgeInsets.all(4),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+                decoration: BoxDecoration(
+                  color: context.primaryColor,
+                  borderRadius: BorderRadius.circular(3),
+                ),
+                child: Text(
+                  '$unread',
+                  style: TextStyle(
+                    color: context.dynamicBlackWhiteColor,
+                    fontSize: 11,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        if (source.isNotEmpty)
+          Positioned(
+            bottom: 0,
+            left: 0,
+            child: Padding(
+              padding: const EdgeInsets.all(4),
+              child: Container(
+                constraints: const BoxConstraints(maxWidth: 92),
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).cardColor,
+                  borderRadius: const BorderRadius.only(
+                    topRight: Radius.circular(3),
+                  ),
+                ),
+                child: Text(
+                  source,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontSize: 9),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// Shown when the anime library is empty — carries a *focusable* action so the
+/// content always has a focus target (otherwise the empty home traps the d-pad
+/// with nothing to move Left from to reach the rail).
+class _EmptyHome extends StatefulWidget {
+  const _EmptyHome();
+
+  @override
+  State<_EmptyHome> createState() => _EmptyHomeState();
+}
+
+class _EmptyHomeState extends State<_EmptyHome> {
+  bool _focused = false;
+
+  void _browse() => context.go('/browse');
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = context.primaryColor;
+    final hint = Theme.of(context).hintColor;
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.video_library_outlined, size: 56, color: accent),
+          const SizedBox(height: 16),
+          const Text(
+            'Your anime library is empty',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Add anime from Browse to fill your home',
+            style: TextStyle(color: hint),
+          ),
+          const SizedBox(height: 22),
+          Focus(
+            autofocus: true,
+            onFocusChange: (f) => setState(() => _focused = f),
+            onKeyEvent: (node, event) {
+              if (event is KeyDownEvent && _isSelectKey(event.logicalKey)) {
+                _browse();
+                return KeyEventResult.handled;
+              }
+              return KeyEventResult.ignored;
+            },
+            child: GestureDetector(
+              onTap: _browse,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 120),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 26,
+                  vertical: 13,
+                ),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(28),
+                  color: _focused ? accent : accent.withValues(alpha: 0.12),
+                  border: Border.all(
+                    color: _focused ? accent : accent.withValues(alpha: 0.5),
+                    width: 1.5,
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.explore_outlined,
+                      color: _focused ? Colors.white : accent,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Browse anime',
+                      style: TextStyle(
+                        color: _focused ? Colors.white : accent,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+bool _isSelectKey(LogicalKeyboardKey k) =>
+    k == LogicalKeyboardKey.select ||
+    k == LogicalKeyboardKey.enter ||
+    k == LogicalKeyboardKey.numpadEnter ||
+    k == LogicalKeyboardKey.gameButtonA ||
+    k == LogicalKeyboardKey.space;

--- a/lib/modules/library/tv_home/tv_anime_home_view.dart
+++ b/lib/modules/library/tv_home/tv_anime_home_view.dart
@@ -36,7 +36,7 @@ import 'package:super_sliver_list/super_sliver_list.dart';
 const double _defaultCardWidth = 150;
 
 /// Card width follows the library's own grid-size setting ("items per row",
-/// 0 = default) — the slider in the filter/sort/display sheet drives the TV
+/// 0 = default) - the slider in the filter/sort/display sheet drives the TV
 /// home too, rather than the home keeping a private density of its own.
 double _cardWidth(BuildContext context, int gridSize) {
   final size = MediaQuery.sizeOf(context);
@@ -70,7 +70,7 @@ SliverGridDelegate _gridDelegate(int gridSize) => gridSize <= 0
         crossAxisSpacing: 6,
       );
 
-/// The episode to resume for [manga] — the last from watch history, else the
+/// The episode to resume for [manga] - the last from watch history, else the
 /// first chapter.
 Chapter? _resumeChapter(Manga manga) {
   final history = isar.historys.filter().mangaIdEqualTo(manga.id!).findAllSync();
@@ -89,7 +89,7 @@ String _fmtMs(int ms) {
 }
 
 /// TV-only, d-pad-first anime home. A hero (the thing you'll resume) plus
-/// horizontal rows — Continue Watching (from history), New Episodes (from the
+/// horizontal rows - Continue Watching (from history), New Episodes (from the
 /// update feed), Recently Added, then one row per category. A top bar adds
 /// search and the library's own filter/sort/display sheet.
 /// Rendered only when `isTv` + `tvHomeStyle`.
@@ -110,8 +110,8 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
   int? _selected;
 
   // Each vertical section (top bar, pills, hero, each row) gets its own
-  // FocusScope. Up/Down move whole-section to whole-section — restoring each
-  // scope's remembered child — instead of Flutter's geometric directional
+  // FocusScope. Up/Down move whole-section to whole-section - restoring each
+  // scope's remembered child - instead of Flutter's geometric directional
   // focus, which skips items that aren't exactly aligned above/below.
   final _scopeTopbar = FocusScopeNode(debugLabel: 'tvHomeTopbar');
   final _scopePills = FocusScopeNode(debugLabel: 'tvHomePills');
@@ -153,7 +153,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
     if (cur == -1) return KeyEventResult.ignored;
     final down = k == LogicalKeyboardKey.arrowDown;
 
-    // The grid is 2D — let it move between its own rows first; only when it
+    // The grid is 2D - let it move between its own rows first; only when it
     // can't (top/bottom edge) do we hop to the adjacent section.
     if (identical(_order[cur], _scopeGrid)) {
       final moved =
@@ -176,7 +176,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
     return KeyEventResult.handled;
   }
 
-  /// Focus the card at [column] in a section (clamped) — always a visible child,
+  /// Focus the card at [column] in a section (clamped) - always a visible child,
   /// so a card/button shows the focus ring and the horizontal position carries
   /// over. Returns false when the section has no focusable children.
   bool _focusSection(FocusScopeNode scope, int column) {
@@ -186,7 +186,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
     return true;
   }
 
-  /// Synchronous read matching getAllMangaStreamProvider(categoryId: null) —
+  /// Synchronous read matching getAllMangaStreamProvider(categoryId: null) -
   /// used to seed the first frame so the spinner never flashes for local data.
   List<Manga> _favoriteAnimeSync() => isar.mangas
       .filter()
@@ -206,8 +206,8 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
     );
 
     // Seed the first frame from a synchronous Isar read. A stream provider is
-    // AsyncLoading on its very first build — its fireImmediately value arrives a
-    // microtask later — so .when() flashed the spinner for one frame even though
+    // AsyncLoading on its very first build - its fireImmediately value arrives a
+    // microtask later - so .when() flashed the spinner for one frame even though
     // the (local) library data is available instantly. `asData` is null only on
     // that first frame (a local Isar stream doesn't error), and the sync read
     // covers it; the stream then drives live updates.
@@ -237,7 +237,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
                 }).toList();
 
           // Only a genuinely empty library short-circuits the whole screen. If
-          // everything is merely hidden, keep the pill bar on screen — holding
+          // everything is merely hidden, keep the pill bar on screen - holding
           // OK on "All" is the way back, and _EmptyHome has no "All".
           if (allAnime.isEmpty) return const _EmptyHome();
 
@@ -384,7 +384,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
           } else if (searching) {
             // `entries` already has the query applied, in the sheet's sort
             // order. A selected pill scopes the search to that category, the
-            // way searching inside a category tab does everywhere else — the
+            // way searching inside a category tab does everywhere else - the
             // library searches `getAllMangaStreamProvider(categoryId:)`, not
             // the whole library.
             final catName = selectedId == null
@@ -450,7 +450,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
             if (newEpisodes.isNotEmpty) addRow('New Episodes', newEpisodes);
             addRow('Recently Added', recent);
 
-            // Genre rows — browse the library by genre (top few, ≥3 titles).
+            // Genre rows - browse the library by genre (top few, ≥3 titles).
             // The one place a title can appear in more than one row, so they're
             // switchable from the filter/sort/display sheet.
             if (ref.watch(tvHomeGenreRowsProvider)) {
@@ -492,7 +492,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
                     (a, b) => (b.lastRead ?? 0).compareTo(a.lastRead ?? 0),
                   );
             // Same hero rule as All: what you'd resume, else what you added
-            // last — never "whatever the sort tab happens to put first".
+            // last - never "whatever the sort tab happens to put first".
             final catRecent = [...inCat]
               ..sort((a, b) => (b.dateAdded ?? 0).compareTo(a.dateAdded ?? 0));
             final catHero = (catContinue.isNotEmpty ? catContinue : catRecent)
@@ -513,7 +513,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
             } else {
               // NestedScrollView, not a CustomScrollView: the hero and rail
               // still scroll away, but the grid stays a real (lazy) box widget,
-              // so each part can own a FocusScope — a scope can't wrap a sliver.
+              // so each part can own a FocusScope - a scope can't wrap a sliver.
               // That keeps every section on `_handleVertical`'s column-preserving
               // navigation instead of Flutter's geometric focus, which snaps to
               // the first card whenever the rows don't line up.
@@ -561,7 +561,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
           }
           _order = order;
 
-          // Whatever is painted behind the pills — the colour the scrolling
+          // Whatever is painted behind the pills - the colour the scrolling
           // content has to dissolve into at the top of its viewport.
           final pageBg = Theme.of(context).scaffoldBackgroundColor;
           return Focus(
@@ -593,7 +593,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
                       // The hero's backdrop is full-bleed, so scrolling it up
                       // under the pills leaves the viewport's clip cutting
                       // straight across it. The hero fades at its *own* top
-                      // edge, which by then is off-screen — so dissolve the
+                      // edge, which by then is off-screen - so dissolve the
                       // cut here, where it actually happens.
                       Positioned(
                         top: 0,
@@ -710,7 +710,7 @@ class _TvHomeTopBar extends StatelessWidget {
   }
 }
 
-/// Opens the library's own filter/sort/display sheet — the same one the phone
+/// Opens the library's own filter/sort/display sheet - the same one the phone
 /// app uses, already d-pad traversable. Its grid-size slider is where card
 /// density now lives.
 class _LibrarySettingsButton extends ConsumerStatefulWidget {
@@ -771,7 +771,7 @@ class _LibrarySettingsButtonState extends ConsumerState<_LibrarySettingsButton>
   }
 }
 
-/// Flat grid of a Manga list (leaf view — a plain grid navigates predictably).
+/// Flat grid of a Manga list (leaf view - a plain grid navigates predictably).
 /// Shared by search results and a selected category.
 class _MangaGrid extends ConsumerWidget {
   const _MangaGrid({required this.items, this.emptyLabel = ''});
@@ -803,7 +803,7 @@ class _MangaGrid extends ConsumerWidget {
 /// The top hero: a blurred cover backdrop (clipped so it can't bleed into the
 /// rows), darkened on the left for text and faded into the page background at
 /// the bottom for a clean seam. Poster + title + the autofocused Continue.
-/// Auto-rotating hero — cycles through the top few resume candidates with a
+/// Auto-rotating hero - cycles through the top few resume candidates with a
 /// crossfade, pausing while it (its Continue button) is focused.
 class _TvHomeHero extends StatefulWidget {
   const _TvHomeHero({required this.items});
@@ -980,7 +980,7 @@ class _HeroContent extends ConsumerWidget {
             // The backdrop fades its own alpha out into the rows below, rather
             // than blending toward a background colour it would have to guess
             // at. Its top edge is handled by the fade over the whole content
-            // viewport — that edge moves as the hero scrolls, this one doesn't.
+            // viewport - that edge moves as the hero scrolls, this one doesn't.
             ShaderMask(
               blendMode: BlendMode.dstIn,
               shaderCallback: (rect) => const LinearGradient(
@@ -1118,7 +1118,7 @@ class _HeroContent extends ConsumerWidget {
   }
 }
 
-/// The hero's Continue button — focusable, autofocused (the home's landing
+/// The hero's Continue button - focusable, autofocused (the home's landing
 /// target), theme-accent when focused, OK/Select or tap to resume.
 class _HeroContinueButton extends StatefulWidget {
   const _HeroContinueButton({required this.manga, this.chapter});
@@ -1264,7 +1264,7 @@ class _CategoryPills extends StatefulWidget {
 
 class _CategoryPillsState extends State<_CategoryPills> {
   /// "All" is the one pill that always exists, so it's where focus lands when
-  /// the pill that had it leaves the tree — hiding it, or unhiding the last
+  /// the pill that had it leaves the tree - hiding it, or unhiding the last
   /// hidden category and losing the Hidden pill with it.
   final _allNode = FocusNode(debugLabel: 'tvPillAll');
 
@@ -1346,7 +1346,7 @@ class _CategoryPillsState extends State<_CategoryPills> {
 }
 
 /// A focusable filter pill: idle · focused (accent fill) · selected
-/// (accent-tinted) — three clearly distinct states for a d-pad across a room.
+/// (accent-tinted) - three clearly distinct states for a d-pad across a room.
 class _Pill extends StatefulWidget {
   const _Pill({
     required this.label,
@@ -1367,7 +1367,7 @@ class _Pill extends StatefulWidget {
   final VoidCallback? onLongPress;
 
   /// Handled only while this pill has focus, so the remote's Menu button stays
-  /// free everywhere else — it reads as "options for the focused item", which
+  /// free everywhere else - it reads as "options for the focused item", which
   /// a cover will want.
   final VoidCallback? onMenu;
 
@@ -1417,7 +1417,7 @@ class _PillState extends State<_Pill> {
         if (!_isSelectKey(event.logicalKey)) return KeyEventResult.ignored;
         // A remote reports a held OK as key *repeats*, never as a pointer
         // long-press. Both tap and hold resolve on release, so whatever a hold
-        // opens never inherits the rest of that press — a dialog raised on the
+        // opens never inherits the rest of that press - a dialog raised on the
         // first repeat would be driven by the repeats still to come.
         if (event is KeyDownEvent) {
           _held = false;
@@ -1479,7 +1479,7 @@ class _PillState extends State<_Pill> {
 /// inline from the home.
 /// Has no chip, no icon, nothing on screen: a visible "Hidden" affordance would
 /// advertise the categories the user hid, which is most of what hiding is for.
-/// Reached from the "All" pill — hold OK on it, or press Menu while it's
+/// Reached from the "All" pill - hold OK on it, or press Menu while it's
 /// focused. Hiding leaves focus there, so the toast can name the way back.
 void _showHiddenCategoriesDialog(BuildContext context, List<Category> hidden) {
   if (hidden.isEmpty) {
@@ -1599,7 +1599,7 @@ class _TvHomeCard extends ConsumerWidget {
       onFocusChange: (focused) {
         if (focused && context.mounted) {
           // Reveal the focused card in both the row (horizontal) and the page
-          // (vertical) — one call walks up every enclosing scrollable.
+          // (vertical) - one call walks up every enclosing scrollable.
           Scrollable.ensureVisible(
             context,
             alignment: 0.5,
@@ -1673,7 +1673,7 @@ class _TvHomeCard extends ConsumerWidget {
   }
 }
 
-/// Shown when the anime library is empty — carries a *focusable* action so the
+/// Shown when the anime library is empty - carries a *focusable* action so the
 /// content always has a focus target (otherwise the empty home traps the d-pad
 /// with nothing to move Left from to reach the rail).
 class _EmptyHome extends StatefulWidget {

--- a/lib/modules/library/tv_home/tv_anime_home_view.dart
+++ b/lib/modules/library/tv_home/tv_anime_home_view.dart
@@ -73,7 +73,10 @@ SliverGridDelegate _gridDelegate(int gridSize) => gridSize <= 0
 /// The episode to resume for [manga] - the last from watch history, else the
 /// first chapter.
 Chapter? _resumeChapter(Manga manga) {
-  final history = isar.historys.filter().mangaIdEqualTo(manga.id!).findAllSync();
+  final history = isar.historys
+      .filter()
+      .mangaIdEqualTo(manga.id!)
+      .findAllSync();
   if (history.isNotEmpty) {
     history.first.chapter.loadSync();
     final ch = history.first.chapter.value;
@@ -326,7 +329,9 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
           final updatedIds =
               (ref
                           .watch(
-                            getAllUpdateStreamProvider(itemType: ItemType.anime),
+                            getAllUpdateStreamProvider(
+                              itemType: ItemType.anime,
+                            ),
                           )
                           .asData
                           ?.value ??
@@ -429,7 +434,10 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
           } else if (selectedId == null) {
             order.add(_scopeHero);
             final rows = <Widget>[
-              FocusScope(node: _scopeHero, child: _TvHomeHero(items: heroItems)),
+              FocusScope(
+                node: _scopeHero,
+                child: _TvHomeHero(items: heroItems),
+              ),
             ];
             var ri = 0;
             void addRow(String title, List<Manga> items) {
@@ -476,10 +484,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
             // Category view: a Continue Watching row scoped to *this* category,
             // then the category's full grid.
             final catName = cats
-                .firstWhere(
-                  (c) => c.id == selectedId,
-                  orElse: () => cats.first,
-                )
+                .firstWhere((c) => c.id == selectedId, orElse: () => cats.first)
                 .name;
             final inCat = entries
                 .where(
@@ -487,10 +492,9 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
                 )
                 .toList();
             final catContinue =
-                inCat.where((m) => historyIds.contains(m.id)).toList()
-                  ..sort(
-                    (a, b) => (b.lastRead ?? 0).compareTo(a.lastRead ?? 0),
-                  );
+                inCat.where((m) => historyIds.contains(m.id)).toList()..sort(
+                  (a, b) => (b.lastRead ?? 0).compareTo(a.lastRead ?? 0),
+                );
             // Same hero rule as All: what you'd resume, else what you added
             // last - never "whatever the sort tab happens to put first".
             final catRecent = [...inCat]
@@ -606,10 +610,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
                               gradient: LinearGradient(
                                 begin: Alignment.topCenter,
                                 end: Alignment.bottomCenter,
-                                colors: [
-                                  pageBg,
-                                  pageBg.withValues(alpha: 0),
-                                ],
+                                colors: [pageBg, pageBg.withValues(alpha: 0)],
                               ),
                             ),
                           ),
@@ -659,8 +660,7 @@ class _TvHomeTopBar extends StatelessWidget {
                     event.logicalKey == LogicalKeyboardKey.arrowRight) {
                   final sel = controller.selection;
                   final atEnd =
-                      !sel.isValid ||
-                      sel.baseOffset >= controller.text.length;
+                      !sel.isValid || sel.baseOffset >= controller.text.length;
                   if (atEnd) {
                     FocusScope.of(
                       context,
@@ -678,28 +678,28 @@ class _TvHomeTopBar extends StatelessWidget {
                   context,
                 ).focusInDirection(TraversalDirection.down),
                 decoration: InputDecoration(
-                isDense: true,
-                filled: true,
-                hintText: 'Search your anime',
-                prefixIcon: const Icon(Icons.search, size: 20),
-                contentPadding: const EdgeInsets.symmetric(
-                  vertical: 12,
-                  horizontal: 12,
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(26),
-                  borderSide: BorderSide.none,
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(26),
-                  borderSide: BorderSide(color: accent, width: 2),
-                ),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(26),
-                  borderSide: BorderSide.none,
+                  isDense: true,
+                  filled: true,
+                  hintText: 'Search your anime',
+                  prefixIcon: const Icon(Icons.search, size: 20),
+                  contentPadding: const EdgeInsets.symmetric(
+                    vertical: 12,
+                    horizontal: 12,
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(26),
+                    borderSide: BorderSide.none,
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(26),
+                    borderSide: BorderSide(color: accent, width: 2),
+                  ),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(26),
+                    borderSide: BorderSide.none,
+                  ),
                 ),
               ),
-            ),
             ),
           ),
           const SizedBox(width: 12),
@@ -1138,6 +1138,8 @@ class _HeroContinueButtonState extends State<_HeroContinueButton> {
 
   @override
   Widget build(BuildContext context) {
+    // Matrix4.scale is deprecated in favour of the explicit per-axis form.
+    final pop = _focused ? 1.05 : 1.0;
     final accent = context.primaryColor;
     return Focus(
       // Entry focus lives on the "All" pill; the hero must not steal it when
@@ -1168,7 +1170,7 @@ class _HeroContinueButtonState extends State<_HeroContinueButton> {
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 130),
           curve: Curves.easeOut,
-          transform: Matrix4.identity()..scale(_focused ? 1.05 : 1.0),
+          transform: Matrix4.identity()..scaleByDouble(pop, pop, pop, 1),
           transformAlignment: Alignment.center,
           padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 12),
           decoration: BoxDecoration(
@@ -1381,6 +1383,8 @@ class _PillState extends State<_Pill> {
 
   @override
   Widget build(BuildContext context) {
+    // Matrix4.scale is deprecated in favour of the explicit per-axis form.
+    final pop = _focused ? 1.08 : 1.0;
     final accent = context.primaryColor;
     final bg = _focused
         ? accent
@@ -1445,7 +1449,7 @@ class _PillState extends State<_Pill> {
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 130),
           curve: Curves.easeOut,
-          transform: Matrix4.identity()..scale(_focused ? 1.08 : 1.0),
+          transform: Matrix4.identity()..scaleByDouble(pop, pop, pop, 1),
           transformAlignment: Alignment.center,
           padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 7),
           decoration: BoxDecoration(

--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -5,6 +5,7 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/library/widgets/continue_reader_button.dart';
 import 'package:mangayomi/modules/manga/detail/providers/state_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/modules/library/widgets/library_entry_utils.dart';
 import 'package:mangayomi/modules/widgets/bottom_text_widget.dart';
 import 'package:mangayomi/modules/widgets/cover_view_widget.dart';
@@ -16,6 +17,7 @@ class LibraryGridViewWidget extends StatefulWidget {
   final Set<int> mangaIdsList;
   final List<Manga> entriesManga;
   final bool language;
+  final bool sourceBadge;
   final bool downloadedChapter;
   final bool continueReaderBtn;
   final bool localSource;
@@ -26,6 +28,7 @@ class LibraryGridViewWidget extends StatefulWidget {
     required this.isCoverOnlyGrid,
     this.isComfortableGrid = false,
     required this.language,
+    this.sourceBadge = false,
     required this.downloadedChapter,
     required this.continueReaderBtn,
     required this.mangaIdsList,
@@ -57,6 +60,9 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
             return Padding(
               padding: const EdgeInsets.all(2),
               child: CoverViewWidget(
+                // On TV, make the first cover the content's focus target so the
+                // d-pad reliably lands on the grid (not the app bar).
+                autofocus: isTv && index == 0,
                 isLongPressed: widget.mangaIdsList.contains(entry.id),
                 isComfortableGrid: widget.isComfortableGrid,
                 bottomTextWidget: BottomTextWidget(
@@ -153,6 +159,35 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                       child: Padding(
                         padding: const EdgeInsets.all(9),
                         child: ContinueReaderButton(entry: entry),
+                      ),
+                    ),
+
+                  // ── Bottom-left: Source ──
+                  if (widget.sourceBadge && (entry.source ?? '').isNotEmpty)
+                    Positioned(
+                      bottom: 0,
+                      left: 0,
+                      child: Padding(
+                        padding: const EdgeInsets.all(5),
+                        child: Container(
+                          constraints: const BoxConstraints(maxWidth: 96),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 4,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: context.themeData.cardColor,
+                            borderRadius: const BorderRadius.only(
+                              topRight: Radius.circular(3),
+                            ),
+                          ),
+                          child: Text(
+                            entry.source!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(fontSize: 10),
+                          ),
+                        ),
                       ),
                     ),
                 ],

--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -45,7 +45,6 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
   Widget build(BuildContext context) {
     return Consumer(
       builder: (context, ref, child) {
-        final isLongPressed = ref.watch(isLongPressedStateProvider);
         final gridSize = ref.watch(
           libraryGridSizeStateProvider(itemType: widget.itemType),
         );
@@ -55,143 +54,118 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
           itemCount: widget.entriesManga.length,
           itemBuilder: (context, index) {
             final entry = widget.entriesManga[index];
-            final isLocalArchive = entry.isLocalArchive ?? false;
-
-            return Padding(
-              padding: const EdgeInsets.all(2),
-              child: CoverViewWidget(
-                // On TV, make the first cover the content's focus target so the
-                // d-pad reliably lands on the grid (not the app bar).
-                autofocus: isTv && index == 0,
-                isLongPressed: widget.mangaIdsList.contains(entry.id),
-                isComfortableGrid: widget.isComfortableGrid,
-                bottomTextWidget: BottomTextWidget(
-                  maxLines: 1,
-                  text: entry.name!,
-                  isComfortableGrid: widget.isComfortableGrid,
-                ),
-                image: resolveCoverImage(entry, ref),
-                onTap: () => onTapEntry(
-                  isLongPressed: isLongPressed,
-                  ref: ref,
-                  context: context,
-                  entry: entry,
-                ),
-                onLongPress: () =>
-                    handleLongOrSecondaryTap(isLongPressed, ref, entry),
-                onSecondaryTap: () =>
-                    handleLongOrSecondaryTap(isLongPressed, ref, entry),
-                children: [
-                  Stack(
+            return Consumer(
+              builder: (context, ref, child) {
+                final isLongPressed = ref.watch(isLongPressedStateProvider);
+                return Padding(
+                  padding: const EdgeInsets.all(2),
+                  child: CoverViewWidget(
+                    // On TV, make the first cover the content's focus target so the
+                    // d-pad reliably lands on the grid (not the app bar).
+                    autofocus: isTv && index == 0,
+                    isLongPressed: widget.mangaIdsList.contains(entry.id),
+                    isComfortableGrid: widget.isComfortableGrid,
+                    bottomTextWidget: BottomTextWidget(
+                      maxLines: 1,
+                      text: entry.name!,
+                      isComfortableGrid: widget.isComfortableGrid,
+                    ),
+                    image: resolveCoverImage(entry, ref),
+                    onTap: () => onTapEntry(
+                      isLongPressed: isLongPressed,
+                      ref: ref,
+                      context: context,
+                      entry: entry,
+                    ),
+                    onLongPress: () =>
+                        handleLongOrSecondaryTap(isLongPressed, ref, entry),
+                    onSecondaryTap: () =>
+                        handleLongOrSecondaryTap(isLongPressed, ref, entry),
                     children: [
-                      // ── Top-left: Local + download count + unread count ──
-                      Positioned(
-                        top: 0,
-                        left: 0,
-                        child: Padding(
-                          padding: const EdgeInsets.all(5),
-                          child: Container(
-                            decoration: BoxDecoration(
-                              borderRadius: BorderRadius.circular(3),
-                              color: context.primaryColor,
-                            ),
-                            child: Row(
-                              children: [
-                                if (widget.localSource && isLocalArchive)
-                                  const EntryBadgeChip(label: 'Local'),
-                                Padding(
-                                  padding: const EdgeInsets.only(right: 5),
-                                  child: Row(
-                                    children: [
-                                      if (widget.downloadedChapter)
-                                        DownloadCountBadge(entry: entry),
-                                      Padding(
-                                        padding: const EdgeInsets.only(left: 3),
-                                        child: Text(
-                                          entry.chapters
-                                              .where((e) => !e.isRead!)
-                                              .length
-                                              .toString(),
-                                          style: TextStyle(
-                                            color:
-                                                context.dynamicBlackWhiteColor,
-                                          ),
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ],
+                      Stack(
+                        children: [
+                          // ── Top-left: Local + download count + unread count ──
+                          Positioned(
+                            top: 0,
+                            left: 0,
+                            child: Padding(
+                              padding: const EdgeInsets.all(5),
+                              child: LibraryBadgeWidget(
+                                entry: entry,
+                                showLocal: widget.localSource,
+                                showDownloaded: widget.downloadedChapter,
+                              ),
                             ),
                           ),
-                        ),
+
+                          // ── Top-right: Language ──
+                          if (widget.language &&
+                              (entry.lang?.isNotEmpty ?? false))
+                            Positioned(
+                              top: 0,
+                              right: 0,
+                              child: Padding(
+                                padding: const EdgeInsets.all(5),
+                                child: Container(
+                                  color: context.themeData.cardColor,
+                                  child: EntryBadgeChip(
+                                    label: entry.lang!.toUpperCase(),
+                                    borderRadius: const BorderRadius.only(
+                                      topLeft: Radius.circular(3),
+                                      bottomLeft: Radius.circular(3),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                        ],
                       ),
 
-                      // ── Top-right: Language ──
-                      if (widget.language && (entry.lang?.isNotEmpty ?? false))
+                      if (!widget.isComfortableGrid && !widget.isCoverOnlyGrid)
+                        BottomTextWidget(text: entry.name!),
+
+                      if (widget.continueReaderBtn)
                         Positioned(
-                          top: 0,
+                          bottom: 0,
                           right: 0,
+                          child: Padding(
+                            padding: const EdgeInsets.all(9),
+                            child: ContinueReaderButton(entry: entry),
+                          ),
+                        ),
+
+                      // ── Bottom-left: Source ──
+                      if (widget.sourceBadge && (entry.source ?? '').isNotEmpty)
+                        Positioned(
+                          bottom: 0,
+                          left: 0,
                           child: Padding(
                             padding: const EdgeInsets.all(5),
                             child: Container(
-                              color: context.themeData.cardColor,
-                              child: EntryBadgeChip(
-                                label: entry.lang!.toUpperCase(),
+                              constraints: const BoxConstraints(maxWidth: 96),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 4,
+                                vertical: 2,
+                              ),
+                              decoration: BoxDecoration(
+                                color: context.themeData.cardColor,
                                 borderRadius: const BorderRadius.only(
-                                  topLeft: Radius.circular(3),
-                                  bottomLeft: Radius.circular(3),
+                                  topRight: Radius.circular(3),
                                 ),
+                              ),
+                              child: Text(
+                                entry.source!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(fontSize: 10),
                               ),
                             ),
                           ),
                         ),
                     ],
                   ),
-
-                  if (!widget.isComfortableGrid && !widget.isCoverOnlyGrid)
-                    BottomTextWidget(text: entry.name!),
-
-                  if (widget.continueReaderBtn)
-                    Positioned(
-                      bottom: 0,
-                      right: 0,
-                      child: Padding(
-                        padding: const EdgeInsets.all(9),
-                        child: ContinueReaderButton(entry: entry),
-                      ),
-                    ),
-
-                  // ── Bottom-left: Source ──
-                  if (widget.sourceBadge && (entry.source ?? '').isNotEmpty)
-                    Positioned(
-                      bottom: 0,
-                      left: 0,
-                      child: Padding(
-                        padding: const EdgeInsets.all(5),
-                        child: Container(
-                          constraints: const BoxConstraints(maxWidth: 96),
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 4,
-                            vertical: 2,
-                          ),
-                          decoration: BoxDecoration(
-                            color: context.themeData.cardColor,
-                            borderRadius: const BorderRadius.only(
-                              topRight: Radius.circular(3),
-                            ),
-                          ),
-                          child: Text(
-                            entry.source!,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(fontSize: 10),
-                          ),
-                        ),
-                      ),
-                    ),
-                ],
-              ),
+                );
+              },
             );
           },
         );

--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -45,6 +45,7 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
   Widget build(BuildContext context) {
     return Consumer(
       builder: (context, ref, child) {
+        final isLongPressed = ref.watch(isLongPressedStateProvider);
         final gridSize = ref.watch(
           libraryGridSizeStateProvider(itemType: widget.itemType),
         );
@@ -54,118 +55,143 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
           itemCount: widget.entriesManga.length,
           itemBuilder: (context, index) {
             final entry = widget.entriesManga[index];
-            return Consumer(
-              builder: (context, ref, child) {
-                final isLongPressed = ref.watch(isLongPressedStateProvider);
-                return Padding(
-                  padding: const EdgeInsets.all(2),
-                  child: CoverViewWidget(
-                    // On TV, make the first cover the content's focus target so the
-                    // d-pad reliably lands on the grid (not the app bar).
-                    autofocus: isTv && index == 0,
-                    isLongPressed: widget.mangaIdsList.contains(entry.id),
-                    isComfortableGrid: widget.isComfortableGrid,
-                    bottomTextWidget: BottomTextWidget(
-                      maxLines: 1,
-                      text: entry.name!,
-                      isComfortableGrid: widget.isComfortableGrid,
-                    ),
-                    image: resolveCoverImage(entry, ref),
-                    onTap: () => onTapEntry(
-                      isLongPressed: isLongPressed,
-                      ref: ref,
-                      context: context,
-                      entry: entry,
-                    ),
-                    onLongPress: () =>
-                        handleLongOrSecondaryTap(isLongPressed, ref, entry),
-                    onSecondaryTap: () =>
-                        handleLongOrSecondaryTap(isLongPressed, ref, entry),
-                    children: [
-                      Stack(
-                        children: [
-                          // ── Top-left: Local + download count + unread count ──
-                          Positioned(
-                            top: 0,
-                            left: 0,
-                            child: Padding(
-                              padding: const EdgeInsets.all(5),
-                              child: LibraryBadgeWidget(
-                                entry: entry,
-                                showLocal: widget.localSource,
-                                showDownloaded: widget.downloadedChapter,
-                              ),
-                            ),
-                          ),
+            final isLocalArchive = entry.isLocalArchive ?? false;
 
-                          // ── Top-right: Language ──
-                          if (widget.language &&
-                              (entry.lang?.isNotEmpty ?? false))
-                            Positioned(
-                              top: 0,
-                              right: 0,
-                              child: Padding(
-                                padding: const EdgeInsets.all(5),
-                                child: Container(
-                                  color: context.themeData.cardColor,
-                                  child: EntryBadgeChip(
-                                    label: entry.lang!.toUpperCase(),
-                                    borderRadius: const BorderRadius.only(
-                                      topLeft: Radius.circular(3),
-                                      bottomLeft: Radius.circular(3),
-                                    ),
+            return Padding(
+              padding: const EdgeInsets.all(2),
+              child: CoverViewWidget(
+                // On TV, make the first cover the content's focus target so the
+                // d-pad reliably lands on the grid (not the app bar).
+                autofocus: isTv && index == 0,
+                isLongPressed: widget.mangaIdsList.contains(entry.id),
+                isComfortableGrid: widget.isComfortableGrid,
+                bottomTextWidget: BottomTextWidget(
+                  maxLines: 1,
+                  text: entry.name!,
+                  isComfortableGrid: widget.isComfortableGrid,
+                ),
+                image: resolveCoverImage(entry, ref),
+                onTap: () => onTapEntry(
+                  isLongPressed: isLongPressed,
+                  ref: ref,
+                  context: context,
+                  entry: entry,
+                ),
+                onLongPress: () =>
+                    handleLongOrSecondaryTap(isLongPressed, ref, entry),
+                onSecondaryTap: () =>
+                    handleLongOrSecondaryTap(isLongPressed, ref, entry),
+                children: [
+                  Stack(
+                    children: [
+                      // ── Top-left: Local + download count + unread count ──
+                      Positioned(
+                        top: 0,
+                        left: 0,
+                        child: Padding(
+                          padding: const EdgeInsets.all(5),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(3),
+                              color: context.primaryColor,
+                            ),
+                            child: Row(
+                              children: [
+                                if (widget.localSource && isLocalArchive)
+                                  const EntryBadgeChip(label: 'Local'),
+                                Padding(
+                                  padding: const EdgeInsets.only(right: 5),
+                                  child: Row(
+                                    children: [
+                                      if (widget.downloadedChapter)
+                                        DownloadCountBadge(entry: entry),
+                                      Padding(
+                                        padding: const EdgeInsets.only(left: 3),
+                                        child: Text(
+                                          entry.chapters
+                                              .where((e) => !e.isRead!)
+                                              .length
+                                              .toString(),
+                                          style: TextStyle(
+                                            color:
+                                                context.dynamicBlackWhiteColor,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
                                   ),
                                 ),
-                              ),
+                              ],
                             ),
-                        ],
-                      ),
-
-                      if (!widget.isComfortableGrid && !widget.isCoverOnlyGrid)
-                        BottomTextWidget(text: entry.name!),
-
-                      if (widget.continueReaderBtn)
-                        Positioned(
-                          bottom: 0,
-                          right: 0,
-                          child: Padding(
-                            padding: const EdgeInsets.all(9),
-                            child: ContinueReaderButton(entry: entry),
                           ),
                         ),
+                      ),
 
-                      // ── Bottom-left: Source ──
-                      if (widget.sourceBadge && (entry.source ?? '').isNotEmpty)
+                      // ── Top-right: Language ──
+                      if (widget.language && (entry.lang?.isNotEmpty ?? false))
                         Positioned(
-                          bottom: 0,
-                          left: 0,
+                          top: 0,
+                          right: 0,
                           child: Padding(
                             padding: const EdgeInsets.all(5),
                             child: Container(
-                              constraints: const BoxConstraints(maxWidth: 96),
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 4,
-                                vertical: 2,
-                              ),
-                              decoration: BoxDecoration(
-                                color: context.themeData.cardColor,
+                              color: context.themeData.cardColor,
+                              child: EntryBadgeChip(
+                                label: entry.lang!.toUpperCase(),
                                 borderRadius: const BorderRadius.only(
-                                  topRight: Radius.circular(3),
+                                  topLeft: Radius.circular(3),
+                                  bottomLeft: Radius.circular(3),
                                 ),
-                              ),
-                              child: Text(
-                                entry.source!,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(fontSize: 10),
                               ),
                             ),
                           ),
                         ),
                     ],
                   ),
-                );
-              },
+
+                  if (!widget.isComfortableGrid && !widget.isCoverOnlyGrid)
+                    BottomTextWidget(text: entry.name!),
+
+                  if (widget.continueReaderBtn)
+                    Positioned(
+                      bottom: 0,
+                      right: 0,
+                      child: Padding(
+                        padding: const EdgeInsets.all(9),
+                        child: ContinueReaderButton(entry: entry),
+                      ),
+                    ),
+
+                  // ── Bottom-left: Source ──
+                  if (widget.sourceBadge && (entry.source ?? '').isNotEmpty)
+                    Positioned(
+                      bottom: 0,
+                      left: 0,
+                      child: Padding(
+                        padding: const EdgeInsets.all(5),
+                        child: Container(
+                          constraints: const BoxConstraints(maxWidth: 96),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 4,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: context.themeData.cardColor,
+                            borderRadius: const BorderRadius.only(
+                              topRight: Radius.circular(3),
+                            ),
+                          ),
+                          child: Text(
+                            entry.source!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(fontSize: 10),
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
             );
           },
         );

--- a/lib/modules/library/widgets/library_settings_sheet.dart
+++ b/lib/modules/library/widgets/library_settings_sheet.dart
@@ -4,11 +4,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/library/providers/library_state_provider.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/chapter_filter_list_tile_widget.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/chapter_sort_list_tile_widget.dart';
 import 'package:mangayomi/modules/widgets/custom_draggable_tabbar.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
 /// Shows the library filter/sort/display settings sheet.
 void showLibrarySettingsSheet({
@@ -461,6 +463,28 @@ class _DisplayTab extends ConsumerWidget {
               ],
             ),
           ),
+
+          // TV home section — only the anime home has these rows.
+          if (isTv && itemType == ItemType.anime) ...[
+            Padding(
+              padding: const EdgeInsets.only(left: 20, right: 20, top: 10),
+              child: Row(children: [const Text('Rows')]),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(top: 5),
+              child: Column(
+                children: [
+                  ListTileChapterFilter(
+                    label: 'Genre rows',
+                    type: ref.watch(tvHomeGenreRowsProvider) ? 1 : 0,
+                    onTap: () => ref
+                        .read(tvHomeGenreRowsProvider.notifier)
+                        .set(!ref.read(tvHomeGenreRowsProvider)),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/modules/library/widgets/library_settings_sheet.dart
+++ b/lib/modules/library/widgets/library_settings_sheet.dart
@@ -464,7 +464,7 @@ class _DisplayTab extends ConsumerWidget {
             ),
           ),
 
-          // TV home section — only the anime home has these rows.
+          // TV home section - only the anime home has these rows.
           if (isTv && itemType == ItemType.anime) ...[
             Padding(
               padding: const EdgeInsets.only(left: 20, right: 20, top: 10),

--- a/lib/modules/main_view/main_screen.dart
+++ b/lib/modules/main_view/main_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -18,6 +19,7 @@ import 'package:mangayomi/modules/more/settings/sync/providers/sync_providers.da
 import 'package:mangayomi/modules/widgets/loading_icon.dart';
 import 'package:mangayomi/services/fetch_item_sources.dart';
 import 'package:mangayomi/modules/main_view/providers/migration.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/about/providers/check_for_update.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/auto_backup.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -29,6 +31,11 @@ import 'package:mangayomi/modules/manga/detail/providers/state_providers.dart';
 import 'package:mangayomi/modules/more/providers/incognito_mode_state_provider.dart';
 
 final libLocationRegex = RegExp(r"^/(Manga|Anime|Novel)Library$");
+
+/// Nav destinations kept off the anime-only TV layout (the manga & novel
+/// libraries). True means "keep this destination".
+bool _isNotHiddenLibOnTv(String nav) =>
+    nav != "/MangaLibrary" && nav != "/NovelLibrary";
 
 class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({super.key, required this.child});
@@ -87,9 +94,12 @@ class _MainScreenState extends ConsumerState<MainScreen> {
         .autoSyncFrequency;
     final hiddenItems = ref.read(hideItemsStateProvider);
 
-    _defaultLocation = _navigationOrder
-        .where((e) => !hiddenItems.contains(e))
-        .first;
+    // On the anime-only TV layout, never land on a hidden manga/novel library.
+    final order = ref.read(animeOnlyTvModeProvider)
+        ? _navigationOrder.where(_isNotHiddenLibOnTv).toList()
+        : _navigationOrder;
+    final visible = order.where((e) => !hiddenItems.contains(e)).toList();
+    _defaultLocation = visible.isNotEmpty ? visible.first : "/AnimeLibrary";
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -209,6 +219,11 @@ class _MainScreenState extends ConsumerState<MainScreen> {
                   : navigationOrder
                         .where((nav) => !hideItems.contains(nav))
                         .toList();
+
+              // Anime-only TV layout: drop the manga & novel library tabs.
+              if (ref.watch(animeOnlyTvModeProvider)) {
+                dest = dest.where(_isNotHiddenLibOnTv).toList();
+              }
 
               if (mergeLibraryNavMobile && !context.isTablet && !isLibSwitch) {
                 dest = dest
@@ -622,7 +637,7 @@ class _IncognitoModeBar extends StatelessWidget {
   }
 }
 
-class _TabletLayout extends StatelessWidget {
+class _TabletLayout extends StatefulWidget {
   const _TabletLayout({
     required this.isLongPressed,
     required this.location,
@@ -649,13 +664,131 @@ class _TabletLayout extends StatelessWidget {
   buildNavigationWidgetsDesktop;
 
   @override
+  State<_TabletLayout> createState() => _TabletLayoutState();
+}
+
+class _TabletLayoutState extends State<_TabletLayout> {
+  // Explicit focus scopes for the rail and the routed content, used on Android
+  // TV only. Directional (d-pad) focus traversal doesn't cross into the rail —
+  // the routed page lives in its own FocusScope and arrows only move focus
+  // within it — so we move focus between the two scopes ourselves. A scope
+  // wraps the whole rail because NavigationRail doesn't expose its
+  // destinations' focus nodes.
+  final FocusScopeNode _railScope = FocusScopeNode(debugLabel: 'navRailScope');
+  final FocusScopeNode _contentScope = FocusScopeNode(
+    debugLabel: 'navContentScope',
+  );
+  bool _didAutofocusRail = false;
+
+  @override
+  void dispose() {
+    _railScope.dispose();
+    _contentScope.dispose();
+    super.dispose();
+  }
+
+  // TV d-pad crossing: LEFT that can't move any further inside the content
+  // pulls focus onto the rail; RIGHT from the rail dives into the content.
+  // Other keys (up/down/select) fall through to the default handler. Only
+  // active while the rail is visible (library tabs), never in the reader.
+  KeyEventResult _handleTvKey(KeyEvent event, bool railVisible) {
+    if (!railVisible) return KeyEventResult.ignored;
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    final key = event.logicalKey;
+    if (key == LogicalKeyboardKey.arrowLeft) {
+      if (_railScope.hasFocus) return KeyEventResult.ignored;
+      final current = FocusManager.instance.primaryFocus;
+      final moved = current?.focusInDirection(TraversalDirection.left) ?? false;
+      if (!moved) _railScope.requestFocus();
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowRight && _railScope.hasFocus) {
+      // Focus the content scope — it restores its focusedChild, which for the
+      // library grid is the first cover (autofocused on TV). That fixes both
+      // "focus never lands on the grid" and the anime-tab "hold Left to reach
+      // the rail" (Left from a cover reaches the rail in one press).
+      _contentScope.requestFocus();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final destinations = buildNavigationWidgetsDesktop(ref, dest, context);
-    return Row(
+    final destinations = widget.buildNavigationWidgetsDesktop(
+      widget.ref,
+      widget.dest,
+      context,
+    );
+    final railWidth = _getNavigationRailWidth(
+      widget.isLongPressed,
+      widget.location,
+    );
+    final railVisible = railWidth > 0;
+
+    // On a TV, open with the tab rail focused so the user lands on the tabs and
+    // dives into content with RIGHT. One-shot per mount.
+    if (isTv && railVisible && !_didAutofocusRail) {
+      _didAutofocusRail = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _railScope.requestFocus();
+      });
+    }
+
+    Widget navRail = NavigationRail(
+      labelType: NavigationRailLabelType.all,
+      useIndicator: true,
+      // The Android TV experience is still beta — flag it in the rail.
+      leading: isTv
+          ? Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 8,
+                  vertical: 3,
+                ),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: const Text(
+                  'BETA',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 10,
+                    fontWeight: FontWeight.bold,
+                    letterSpacing: 1.5,
+                  ),
+                ),
+              ),
+            )
+          : null,
+      destinations: destinations,
+      selectedIndex:
+          (widget.currentIndex >= 0 &&
+              widget.currentIndex < destinations.length)
+          ? widget.currentIndex
+          : 0,
+      onDestinationSelected: (newIndex) {
+        widget.route.go(widget.dest[newIndex]);
+      },
+    );
+    if (isTv) {
+      navRail = FocusScope(node: _railScope, child: navRail);
+    }
+
+    Widget content = widget.child;
+    if (isTv) {
+      content = FocusScope(node: _contentScope, child: content);
+    }
+
+    Widget row = Row(
       children: [
         AnimatedContainer(
           duration: const Duration(milliseconds: 0),
-          width: _getNavigationRailWidth(isLongPressed, location),
+          width: railWidth,
           child: Stack(
             children: [
               NavigationRailTheme(
@@ -664,25 +797,38 @@ class _TabletLayout extends StatelessWidget {
                     borderRadius: BorderRadius.circular(30),
                   ),
                 ),
-                child: NavigationRail(
-                  labelType: NavigationRailLabelType.all,
-                  useIndicator: true,
-                  destinations: destinations,
-                  selectedIndex:
-                      (currentIndex >= 0 && currentIndex < destinations.length)
-                      ? currentIndex
-                      : 0,
-                  onDestinationSelected: (newIndex) {
-                    route.go(dest[newIndex]);
-                  },
+                // On Android TV the rail destination's default d-pad focus
+                // overlay is too faint to see from across a room. The
+                // destination InkResponse draws its focus highlight from the
+                // ambient Theme.focusColor, so a bold primary-tinted focusColor
+                // makes the focused tab clearly visible. No-op off TV.
+                child: Theme(
+                  data: Theme.of(context).copyWith(
+                    focusColor: isTv
+                        ? context.primaryColor.withValues(alpha: 0.45)
+                        : Theme.of(context).focusColor,
+                  ),
+                  child: navRail,
                 ),
               ),
             ],
           ),
         ),
-        Expanded(child: child),
+        Expanded(child: content),
       ],
     );
+
+    // Wrap in a non-focusable key handler on TV so we can move focus across the
+    // rail/content scope boundary that directional traversal won't cross.
+    if (isTv) {
+      row = Focus(
+        canRequestFocus: false,
+        skipTraversal: true,
+        onKeyEvent: (node, event) => _handleTvKey(event, railVisible),
+        child: row,
+      );
+    }
+    return row;
   }
 
   static double _getNavigationRailWidth(bool isLongPressed, String? location) {

--- a/lib/modules/main_view/main_screen.dart
+++ b/lib/modules/main_view/main_screen.dart
@@ -669,9 +669,9 @@ class _TabletLayout extends StatefulWidget {
 
 class _TabletLayoutState extends State<_TabletLayout> {
   // Explicit focus scopes for the rail and the routed content, used on Android
-  // TV only. Directional (d-pad) focus traversal doesn't cross into the rail —
+  // TV only. Directional (d-pad) focus traversal doesn't cross into the rail -
   // the routed page lives in its own FocusScope and arrows only move focus
-  // within it — so we move focus between the two scopes ourselves. A scope
+  // within it - so we move focus between the two scopes ourselves. A scope
   // wraps the whole rail because NavigationRail doesn't expose its
   // destinations' focus nodes.
   final FocusScopeNode _railScope = FocusScopeNode(debugLabel: 'navRailScope');
@@ -705,7 +705,7 @@ class _TabletLayoutState extends State<_TabletLayout> {
       return KeyEventResult.handled;
     }
     if (key == LogicalKeyboardKey.arrowRight && _railScope.hasFocus) {
-      // Focus the content scope — it restores its focusedChild, which for the
+      // Focus the content scope - it restores its focusedChild, which for the
       // library grid is the first cover (autofocused on TV). That fixes both
       // "focus never lands on the grid" and the anime-tab "hold Left to reach
       // the rail" (Left from a cover reaches the rail in one press).
@@ -740,7 +740,7 @@ class _TabletLayoutState extends State<_TabletLayout> {
     Widget navRail = NavigationRail(
       labelType: NavigationRailLabelType.all,
       useIndicator: true,
-      // The Android TV experience is still beta — flag it in the rail.
+      // The Android TV experience is still beta - flag it in the rail.
       leading: isTv
           ? Padding(
               padding: const EdgeInsets.symmetric(vertical: 12),

--- a/lib/modules/main_view/providers/tv_mode_provider.dart
+++ b/lib/modules/main_view/providers/tv_mode_provider.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
+
+/// Hive box + key for the user's explicit anime-only-layout override.
+/// A stored `bool` forces it on/off; absent means "auto" (follow [isTv]).
+const _boxName = 'tv_prefs';
+const _overrideKey = 'anime_only_override';
+const _playerStyleKey = 'tv_player_style';
+const _homeStyleKey = 'tv_home_style';
+const _genreRowsKey = 'tv_home_genre_rows';
+
+/// Opens the backing box. Called once at startup.
+Future<void> openTvPrefsBox() async {
+  if (!Hive.isBoxOpen(_boxName)) {
+    await Hive.openBox(_boxName);
+  }
+}
+
+/// Whether to show the anime-only TV layout (manga + novel libraries hidden,
+/// anime-first). Defaults to [isTv] — i.e. on for Android TV, off everywhere
+/// else — and can be explicitly overridden by the user as an escape hatch, so
+/// a wrong detection can never strand someone with manga hidden.
+final animeOnlyTvModeProvider = NotifierProvider<AnimeOnlyTvMode, bool>(
+  AnimeOnlyTvMode.new,
+);
+
+class AnimeOnlyTvMode extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final override = Hive.box(_boxName).get(_overrideKey);
+      if (override is bool) return override;
+    }
+    return isTv;
+  }
+
+  /// Explicitly turns the anime-only layout on/off and persists the choice.
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_overrideKey, value);
+    }
+  }
+}
+
+/// Which controls to use for the anime player on TV: `true` = the dedicated
+/// Netflix-style TV player (default), `false` = the original desktop player.
+/// Only consulted when [isTv]; phones/desktops are unaffected.
+final tvPlayerStyleProvider = NotifierProvider<TvPlayerStyle, bool>(
+  TvPlayerStyle.new,
+);
+
+class TvPlayerStyle extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final v = Hive.box(_boxName).get(_playerStyleKey);
+      if (v is bool) return v;
+    }
+    return true; // default: TV player
+  }
+
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_playerStyleKey, value);
+    }
+  }
+}
+
+/// Which anime library "home" to show on TV: `true` = the dedicated rows-based
+/// TV home (hero + Continue / New Episodes / Recently Added / category rows),
+/// `false` = the classic cover grid. Only consulted when [isTv]; phones and
+/// desktops always get the grid.
+final tvHomeStyleProvider = NotifierProvider<TvHomeStyle, bool>(
+  TvHomeStyle.new,
+);
+
+class TvHomeStyle extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final v = Hive.box(_boxName).get(_homeStyleKey);
+      if (v is bool) return v;
+    }
+    return isTv; // default: rows home on TV, grid everywhere else
+  }
+
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_homeStyleKey, value);
+    }
+  }
+}
+
+/// Whether the TV home shows its genre rows. They're the one place a title can
+/// appear more than once, so anyone who finds that repetitive can switch them
+/// off from the filter/sort/display sheet. On by default.
+final tvHomeGenreRowsProvider = NotifierProvider<TvHomeGenreRows, bool>(
+  TvHomeGenreRows.new,
+);
+
+class TvHomeGenreRows extends Notifier<bool> {
+  @override
+  bool build() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final v = Hive.box(_boxName).get(_genreRowsKey);
+      if (v is bool) return v;
+    }
+    return true;
+  }
+
+  void set(bool value) {
+    state = value;
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_genreRowsKey, value);
+    }
+  }
+}

--- a/lib/modules/main_view/providers/tv_mode_provider.dart
+++ b/lib/modules/main_view/providers/tv_mode_provider.dart
@@ -1,21 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hive/hive.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
 
-/// Hive box + key for the user's explicit anime-only-layout override.
-/// A stored `bool` forces it on/off; absent means "auto" (follow [isTv]).
-const _boxName = 'tv_prefs';
-const _overrideKey = 'anime_only_override';
-const _playerStyleKey = 'tv_player_style';
-const _homeStyleKey = 'tv_home_style';
-const _genreRowsKey = 'tv_home_genre_rows';
-
-/// Opens the backing box. Called once at startup.
-Future<void> openTvPrefsBox() async {
-  if (!Hive.isBoxOpen(_boxName)) {
-    await Hive.openBox(_boxName);
-  }
-}
+// Android TV preferences, stored on the Settings collection. A null field means
+// "auto" (follow the default below); a stored bool is an explicit override.
 
 /// Whether to show the anime-only TV layout (manga + novel libraries hidden,
 /// anime-first). Defaults to [isTv] - i.e. on for Android TV, off everywhere
@@ -27,45 +16,29 @@ final animeOnlyTvModeProvider = NotifierProvider<AnimeOnlyTvMode, bool>(
 
 class AnimeOnlyTvMode extends Notifier<bool> {
   @override
-  bool build() {
-    if (Hive.isBoxOpen(_boxName)) {
-      final override = Hive.box(_boxName).get(_overrideKey);
-      if (override is bool) return override;
-    }
-    return isTv;
-  }
+  bool build() => isar.settings.getSync(227)?.tvAnimeOnlyOverride ?? isTv;
 
   /// Explicitly turns the anime-only layout on/off and persists the choice.
   void set(bool value) {
     state = value;
-    if (Hive.isBoxOpen(_boxName)) {
-      Hive.box(_boxName).put(_overrideKey, value);
-    }
+    _writeTvPref((s) => s.tvAnimeOnlyOverride = value);
   }
 }
 
-/// Which controls to use for the anime player on TV: `true` = the dedicated
-/// dedicated TV player (default), `false` = the original desktop player.
-/// Only consulted when [isTv]; phones/desktops are unaffected.
+/// Which controls to use for the anime player on TV: `true` = the dedicated TV
+/// player (default), `false` = the original desktop player. Only consulted when
+/// [isTv]; phones/desktops are unaffected.
 final tvPlayerStyleProvider = NotifierProvider<TvPlayerStyle, bool>(
   TvPlayerStyle.new,
 );
 
 class TvPlayerStyle extends Notifier<bool> {
   @override
-  bool build() {
-    if (Hive.isBoxOpen(_boxName)) {
-      final v = Hive.box(_boxName).get(_playerStyleKey);
-      if (v is bool) return v;
-    }
-    return true; // default: TV player
-  }
+  bool build() => isar.settings.getSync(227)?.tvPlayerStyle ?? true;
 
   void set(bool value) {
     state = value;
-    if (Hive.isBoxOpen(_boxName)) {
-      Hive.box(_boxName).put(_playerStyleKey, value);
-    }
+    _writeTvPref((s) => s.tvPlayerStyle = value);
   }
 }
 
@@ -79,19 +52,11 @@ final tvHomeStyleProvider = NotifierProvider<TvHomeStyle, bool>(
 
 class TvHomeStyle extends Notifier<bool> {
   @override
-  bool build() {
-    if (Hive.isBoxOpen(_boxName)) {
-      final v = Hive.box(_boxName).get(_homeStyleKey);
-      if (v is bool) return v;
-    }
-    return isTv; // default: rows home on TV, grid everywhere else
-  }
+  bool build() => isar.settings.getSync(227)?.tvHomeStyle ?? isTv;
 
   void set(bool value) {
     state = value;
-    if (Hive.isBoxOpen(_boxName)) {
-      Hive.box(_boxName).put(_homeStyleKey, value);
-    }
+    _writeTvPref((s) => s.tvHomeStyle = value);
   }
 }
 
@@ -104,18 +69,21 @@ final tvHomeGenreRowsProvider = NotifierProvider<TvHomeGenreRows, bool>(
 
 class TvHomeGenreRows extends Notifier<bool> {
   @override
-  bool build() {
-    if (Hive.isBoxOpen(_boxName)) {
-      final v = Hive.box(_boxName).get(_genreRowsKey);
-      if (v is bool) return v;
-    }
-    return true;
-  }
+  bool build() => isar.settings.getSync(227)?.tvHomeGenreRows ?? true;
 
   void set(bool value) {
     state = value;
-    if (Hive.isBoxOpen(_boxName)) {
-      Hive.box(_boxName).put(_genreRowsKey, value);
-    }
+    _writeTvPref((s) => s.tvHomeGenreRows = value);
   }
+}
+
+/// Applies [mutate] to the Settings singleton and persists it.
+void _writeTvPref(void Function(Settings) mutate) {
+  isar.writeTxnSync(() {
+    final settings = isar.settings.getSync(227);
+    if (settings != null) {
+      mutate(settings);
+      isar.settings.putSync(settings);
+    }
+  });
 }

--- a/lib/modules/main_view/providers/tv_mode_provider.dart
+++ b/lib/modules/main_view/providers/tv_mode_provider.dart
@@ -18,8 +18,8 @@ Future<void> openTvPrefsBox() async {
 }
 
 /// Whether to show the anime-only TV layout (manga + novel libraries hidden,
-/// anime-first). Defaults to [isTv] — i.e. on for Android TV, off everywhere
-/// else — and can be explicitly overridden by the user as an escape hatch, so
+/// anime-first). Defaults to [isTv] - i.e. on for Android TV, off everywhere
+/// else - and can be explicitly overridden by the user as an escape hatch, so
 /// a wrong detection can never strand someone with manga hidden.
 final animeOnlyTvModeProvider = NotifierProvider<AnimeOnlyTvMode, bool>(
   AnimeOnlyTvMode.new,
@@ -45,7 +45,7 @@ class AnimeOnlyTvMode extends Notifier<bool> {
 }
 
 /// Which controls to use for the anime player on TV: `true` = the dedicated
-/// Netflix-style TV player (default), `false` = the original desktop player.
+/// dedicated TV player (default), `false` = the original desktop player.
 /// Only consulted when [isTv]; phones/desktops are unaffected.
 final tvPlayerStyleProvider = NotifierProvider<TvPlayerStyle, bool>(
   TvPlayerStyle.new,

--- a/lib/modules/more/categories/categories_screen.dart
+++ b/lib/modules/more/categories/categories_screen.dart
@@ -1,4 +1,5 @@
 import 'package:mangayomi/utils/platform_utils.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isar_community/isar.dart';
@@ -31,7 +32,12 @@ class _CategoriesScreenState extends ConsumerState<CategoriesScreen>
   @override
   void initState() {
     super.initState();
-    _visibleTabTypes = hiddenItemTypes(ref.read(hideItemsStateProvider));
+    var types = hiddenItemTypes(ref.read(hideItemsStateProvider));
+    // Anime-only layout: only manage anime categories.
+    if (ref.read(animeOnlyTvModeProvider)) {
+      types = types.where((t) => t == ItemType.anime).toList();
+    }
+    _visibleTabTypes = types;
     _tabBarController = TabController(
       length: _visibleTabTypes.length,
       vsync: this,

--- a/lib/modules/more/categories/widgets/custom_textfield.dart
+++ b/lib/modules/more/categories/widgets/custom_textfield.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mangayomi/models/category.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 
 class CustomTextFormField extends StatelessWidget {
@@ -25,7 +26,7 @@ class CustomTextFormField extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = l10nLocalizations(context);
     return TextFormField(
-      autofocus: true,
+      autofocus: !isTv,
       controller: controller,
       keyboardType: TextInputType.text,
       onChanged: (value) {

--- a/lib/modules/more/data_and_storage/data_and_storage.dart
+++ b/lib/modules/more/data_and_storage/data_and_storage.dart
@@ -12,6 +12,8 @@ import 'package:mangayomi/modules/more/data_and_storage/providers/storage_usage.
 import 'package:mangayomi/modules/more/settings/downloads/providers/downloads_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/modules/widgets/tv_escapable_slider.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
 class DataAndStorage extends ConsumerWidget {
@@ -337,22 +339,31 @@ class DataAndStorage extends ConsumerWidget {
                       color: context.secondaryColor,
                     ),
                   ),
-                  Slider(
-                    min: 0,
-                    max: 9,
-                    divisions: 9,
-                    value: compression.toDouble(),
-                    label: compression.toString(),
-                    onChanged: (value) {
-                      ref
-                          .read(backupCompressionLevelProvider.notifier)
-                          .update(value.round());
-                    },
-                    onChangeEnd: (value) {
-                      ref
-                          .read(backupCompressionLevelProvider.notifier)
-                          .set(value.round());
-                    },
+                  TvEscapableSlider(
+                    enabled: isTv,
+                    onDecrease: () => ref
+                        .read(backupCompressionLevelProvider.notifier)
+                        .set((compression - 1).clamp(0, 9)),
+                    onIncrease: () => ref
+                        .read(backupCompressionLevelProvider.notifier)
+                        .set((compression + 1).clamp(0, 9)),
+                    child: Slider(
+                      min: 0,
+                      max: 9,
+                      divisions: 9,
+                      value: compression.toDouble(),
+                      label: compression.toString(),
+                      onChanged: (value) {
+                        ref
+                            .read(backupCompressionLevelProvider.notifier)
+                            .update(value.round());
+                      },
+                      onChangeEnd: (value) {
+                        ref
+                            .read(backupCompressionLevelProvider.notifier)
+                            .set(value.round());
+                      },
+                    ),
                   ),
                 ],
               ),

--- a/lib/modules/more/settings/appearance/appearance_screen.dart
+++ b/lib/modules/more/settings/appearance/appearance_screen.dart
@@ -13,6 +13,8 @@ import 'package:mangayomi/modules/more/settings/appearance/providers/pure_black_
 import 'package:mangayomi/modules/more/settings/appearance/widgets/blend_level_slider.dart';
 import 'package:mangayomi/modules/more/settings/appearance/widgets/dark_mode_button.dart';
 import 'package:mangayomi/modules/more/settings/appearance/widgets/theme_selector.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/utils/language.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
@@ -96,6 +98,18 @@ class AppearanceScreen extends ConsumerWidget {
             SettingsSection(
               title: l10n.appearance,
               children: [
+                if (isTv)
+                  SwitchListTile(
+                    secondary: const Icon(Icons.grid_view_outlined),
+                    title: const Text('TV home (beta)'),
+                    subtitle: const Text(
+                      'Rows-based anime home (Continue · New Episodes · '
+                      'categories) instead of the flat grid',
+                    ),
+                    value: ref.watch(tvHomeStyleProvider),
+                    onChanged: (v) =>
+                        ref.read(tvHomeStyleProvider.notifier).set(v),
+                  ),
                 _buildLanguageTile(context, ref, l10n),
                 _buildFontTile(context, ref, l10n),
                 ListTile(

--- a/lib/modules/more/settings/appearance/custom_navigation_settings.dart
+++ b/lib/modules/more/settings/appearance/custom_navigation_settings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/settings/appearance/appearance_screen.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -27,8 +28,18 @@ class _CustomNavigationSettingsState
         child: ReorderableListView.builder(
           header: Padding(
             padding: const EdgeInsets.symmetric(vertical: 10),
-            child: Stack(
+            child: Column(
               children: [
+                SwitchListTile(
+                  value: ref.watch(animeOnlyTvModeProvider),
+                  title: const Text('Anime-only TV layout'),
+                  subtitle: const Text(
+                    'Hide the manga & novel libraries (on by default on TV)',
+                  ),
+                  onChanged: (value) {
+                    ref.read(animeOnlyTvModeProvider.notifier).set(value);
+                  },
+                ),
                 SwitchListTile(
                   value: mergeLibraryNavMobile,
                   title: Text(context.l10n.merge_library_nav_mobile),

--- a/lib/modules/more/settings/appearance/widgets/blend_level_slider.dart
+++ b/lib/modules/more/settings/appearance/widgets/blend_level_slider.dart
@@ -2,7 +2,9 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/blend_level_state_provider.dart';
+import 'package:mangayomi/modules/widgets/tv_escapable_slider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
 class BlendLevelSlider extends ConsumerWidget {
   const BlendLevelSlider({super.key});
@@ -21,16 +23,25 @@ class BlendLevelSlider extends ConsumerWidget {
             style: const TextStyle(fontWeight: FontWeight.bold),
           ),
         ),
-        Slider(
-          min: 0.0,
-          max: 40.0,
-          divisions: max(39, 1),
-          value: blendLevel,
-          onChanged: (value) =>
-              ref.read(blendLevelStateProvider.notifier).setBlendLevel(value),
-          onChangeEnd: (value) => ref
+        TvEscapableSlider(
+          enabled: isTv,
+          onDecrease: () => ref
               .read(blendLevelStateProvider.notifier)
-              .setBlendLevel(value, end: true),
+              .setBlendLevel((blendLevel - 1).clamp(0.0, 40.0), end: true),
+          onIncrease: () => ref
+              .read(blendLevelStateProvider.notifier)
+              .setBlendLevel((blendLevel + 1).clamp(0.0, 40.0), end: true),
+          child: Slider(
+            min: 0.0,
+            max: 40.0,
+            divisions: max(39, 1),
+            value: blendLevel,
+            onChanged: (value) =>
+                ref.read(blendLevelStateProvider.notifier).setBlendLevel(value),
+            onChangeEnd: (value) => ref
+                .read(blendLevelStateProvider.notifier)
+                .setBlendLevel(value, end: true),
+          ),
         ),
       ],
     );

--- a/lib/modules/more/settings/browse/extension_server/android_proxy_server_dialog.dart
+++ b/lib/modules/more/settings/browse/extension_server/android_proxy_server_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 
@@ -30,7 +31,7 @@ void showAndroidProxyServerDialog(
                   padding: const EdgeInsets.symmetric(vertical: 10),
                   child: TextFormField(
                     controller: serverController,
-                    autofocus: true,
+                    autofocus: !isTv,
                     onChanged: (value) => setState(() {
                       server = value;
                     }),

--- a/lib/modules/more/settings/browse/source_repositories.dart
+++ b/lib/modules/more/settings/browse/source_repositories.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isar_community/isar.dart';
@@ -355,7 +356,12 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
                 title: Text(l10n.add_extensions_repo),
                 content: TextFormField(
                   controller: controller,
-                  autofocus: true,
+                  // On Android TV, don't autofocus: it instantly pops the
+                  // full-screen leanback keyboard over the dialog before the
+                  // user can even see the Cancel/Add buttons. Let them navigate
+                  // to the field and open the keyboard with select instead.
+                  // Phones keep autofocus for the usual ready-to-type flow.
+                  autofocus: !isTv,
                   keyboardType: TextInputType.url,
                   onChanged: (value) => setState(() {}),
                   validator: (value) {

--- a/lib/modules/more/settings/player/player_overview_screen.dart
+++ b/lib/modules/more/settings/player/player_overview_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/widgets/list_tile_widget.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
 class PlayerOverviewScreen extends StatelessWidget {
   const PlayerOverviewScreen({super.key});
@@ -14,6 +17,24 @@ class PlayerOverviewScreen extends StatelessWidget {
       body: SingleChildScrollView(
         child: Column(
           children: [
+            // On TV, choose between the dedicated TV player and the original
+            // desktop player. Not shown on phones/desktops.
+            if (isTv)
+              Consumer(
+                builder: (context, ref, _) {
+                  final useTvPlayer = ref.watch(tvPlayerStyleProvider);
+                  return SwitchListTile(
+                    secondary: const Icon(Icons.smart_display_outlined),
+                    title: const Text('TV player (beta)'),
+                    subtitle: const Text(
+                      'On: dedicated TV player.  Off: original (desktop) player.',
+                    ),
+                    value: useTvPlayer,
+                    onChanged: (v) =>
+                        ref.read(tvPlayerStyleProvider.notifier).set(v),
+                  );
+                },
+              ),
             ListTileWidget(
               title: l10n.internal_player,
               subtitle: l10n.internal_player_info,

--- a/lib/modules/more/settings/settings_screen.dart
+++ b/lib/modules/more/settings/settings_screen.dart
@@ -28,7 +28,7 @@ class SettingsScreen extends StatelessWidget {
               icon: Icons.color_lens_rounded,
               onTap: () => context.push('/appearance'),
             ),
-            // Reader is manga/novel-only — hide it on the anime-only layout.
+            // Reader is manga/novel-only - hide it on the anime-only layout.
             Consumer(
               builder: (context, ref, _) {
                 if (ref.watch(animeOnlyTvModeProvider)) {

--- a/lib/modules/more/settings/settings_screen.dart
+++ b/lib/modules/more/settings/settings_screen.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/more/widgets/list_tile_widget.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 
@@ -26,10 +28,18 @@ class SettingsScreen extends StatelessWidget {
               icon: Icons.color_lens_rounded,
               onTap: () => context.push('/appearance'),
             ),
-            ListTileWidget(
-              title: l10n.reader,
-              icon: Icons.chrome_reader_mode_rounded,
-              onTap: () => context.push('/readerMode'),
+            // Reader is manga/novel-only — hide it on the anime-only layout.
+            Consumer(
+              builder: (context, ref, _) {
+                if (ref.watch(animeOnlyTvModeProvider)) {
+                  return const SizedBox.shrink();
+                }
+                return ListTileWidget(
+                  title: l10n.reader,
+                  icon: Icons.chrome_reader_mode_rounded,
+                  onTap: () => context.push('/readerMode'),
+                );
+              },
             ),
             ListTileWidget(
               title: l10n.player,

--- a/lib/modules/more/settings/sync/sync.dart
+++ b/lib/modules/more/settings/sync/sync.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:isar_community/isar.dart';
 import 'package:mangayomi/eval/model/m_bridge.dart';
@@ -460,7 +461,7 @@ class SyncScreen extends ConsumerWidget {
                     padding: const EdgeInsets.symmetric(vertical: 10),
                     child: TextFormField(
                       controller: serverController,
-                      autofocus: true,
+                      autofocus: !isTv,
                       onChanged: (value) => setState(() {
                         server = value;
                       }),
@@ -488,7 +489,7 @@ class SyncScreen extends ConsumerWidget {
                     padding: const EdgeInsets.symmetric(vertical: 10),
                     child: TextFormField(
                       controller: emailController,
-                      autofocus: true,
+                      autofocus: !isTv,
                       onChanged: (value) => setState(() {
                         email = value;
                       }),

--- a/lib/modules/more/settings/track/track.dart
+++ b/lib/modules/more/settings/track/track.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -237,7 +238,7 @@ Future<void> _showDialogLogin(BuildContext context, WidgetRef ref) async {
                         AutofillHints.email,
                         AutofillHints.username,
                       ],
-                      autofocus: true,
+                      autofocus: !isTv,
                       onChanged: (_) => setState(updateCanLogin),
                       onFieldSubmitted: (_) => passwordFocusNode.requestFocus(),
                       decoration: InputDecoration(

--- a/lib/modules/widgets/base_library_tab_screen.dart
+++ b/lib/modules/widgets/base_library_tab_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/library/widgets/search_text_form_field.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -36,6 +37,14 @@ abstract class BaseLibraryTabScreenState<T extends ConsumerStatefulWidget>
     hideItems = ref.read(hideItemsStateProvider);
 
     visibleTabTypes = hiddenItemTypes(hideItems);
+
+    // Anime-only layout: only the anime tab (hides manga/novel in History,
+    // Updates, and any other screen built on this base).
+    if (ref.read(animeOnlyTvModeProvider)) {
+      visibleTabTypes = visibleTabTypes
+          .where((t) => t == ItemType.anime)
+          .toList();
+    }
 
     tabController = TabController(length: visibleTabTypes.length, vsync: this);
 

--- a/lib/modules/widgets/cover_view_widget.dart
+++ b/lib/modules/widgets/cover_view_widget.dart
@@ -86,14 +86,12 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final showOverlay = widget.isLongPressed != null && widget.isLongPressed!;
     // Comfortable grid renders the label below the card, so it must not also be
     // placed inside the card. Render it once, and only when provided.
     final showBottomText =
         widget.isComfortableGrid && widget.bottomTextWidget != null;
     // Matrix4.scale is deprecated in favour of the explicit per-axis form.
     final pop = _focused ? 1.06 : 1.0;
-
     return Padding(
       padding: const EdgeInsets.all(5),
       child: Column(
@@ -124,48 +122,42 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
                   onLongPress: widget.onLongPress,
                   onSecondaryTap: widget.onSecondaryTap,
                   onFocusChange: _onFocusChange,
-                  child: widget.image == null
-                      ? Container(
-                          color: showOverlay
-                              ? context.primaryColor.withValues(alpha: 0.4)
-                              : Colors.transparent,
-                          child: widget.isComfortableGrid
+                  child: Container(
+                    color: widget.isLongPressed != null && widget.isLongPressed!
+                        ? context.primaryColor.withValues(alpha: 0.4)
+                        : Colors.transparent,
+                    child: widget.image == null
+                        ? widget.isComfortableGrid
+                              // bottomTextWidget is rendered once below the card,
+                              // so it's not duplicated inside here anymore.
                               ? Column(children: widget.children)
-                              : Stack(children: widget.children),
-                        )
-                      : Ink.image(
-                          fit: BoxFit.cover,
-                          image: widget.image!,
-                          child: Stack(
-                            children: [
-                              if (showOverlay)
-                                Positioned.fill(
-                                  child: Container(
-                                    color: context.primaryColor.withValues(
-                                      alpha: 0.4,
+                              : Stack(children: widget.children)
+                        : Ink.image(
+                            fit: BoxFit.cover,
+                            image: widget.image!,
+                            child: Stack(
+                              children: [
+                                ...widget.children,
+                                if (widget.progress > 0)
+                                  Positioned(
+                                    left: 0,
+                                    right: 0,
+                                    bottom: 0,
+                                    child: LinearProgressIndicator(
+                                      value: widget.progress.clamp(0.0, 1.0),
+                                      minHeight: 3,
+                                      backgroundColor: Colors.black.withValues(
+                                        alpha: 0.35,
+                                      ),
+                                      valueColor: AlwaysStoppedAnimation<Color>(
+                                        context.primaryColor,
+                                      ),
                                     ),
                                   ),
-                                ),
-                              ...widget.children,
-                              if (widget.progress > 0)
-                                Positioned(
-                                  left: 0,
-                                  right: 0,
-                                  bottom: 0,
-                                  child: LinearProgressIndicator(
-                                    value: widget.progress.clamp(0.0, 1.0),
-                                    minHeight: 3,
-                                    backgroundColor: Colors.black.withValues(
-                                      alpha: 0.35,
-                                    ),
-                                    valueColor: AlwaysStoppedAnimation<Color>(
-                                      context.primaryColor,
-                                    ),
-                                  ),
-                                ),
-                            ],
+                              ],
+                            ),
                           ),
-                        ),
+                  ),
                 ),
               ),
             ),

--- a/lib/modules/widgets/cover_view_widget.dart
+++ b/lib/modules/widgets/cover_view_widget.dart
@@ -86,12 +86,14 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final showOverlay = widget.isLongPressed != null && widget.isLongPressed!;
     // Comfortable grid renders the label below the card, so it must not also be
     // placed inside the card. Render it once, and only when provided.
     final showBottomText =
         widget.isComfortableGrid && widget.bottomTextWidget != null;
     // Matrix4.scale is deprecated in favour of the explicit per-axis form.
     final pop = _focused ? 1.06 : 1.0;
+
     return Padding(
       padding: const EdgeInsets.all(5),
       child: Column(
@@ -122,42 +124,48 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
                   onLongPress: widget.onLongPress,
                   onSecondaryTap: widget.onSecondaryTap,
                   onFocusChange: _onFocusChange,
-                  child: Container(
-                    color: widget.isLongPressed != null && widget.isLongPressed!
-                        ? context.primaryColor.withValues(alpha: 0.4)
-                        : Colors.transparent,
-                    child: widget.image == null
-                        ? widget.isComfortableGrid
-                              // bottomTextWidget is rendered once below the card,
-                              // so it's not duplicated inside here anymore.
+                  child: widget.image == null
+                      ? Container(
+                          color: showOverlay
+                              ? context.primaryColor.withValues(alpha: 0.4)
+                              : Colors.transparent,
+                          child: widget.isComfortableGrid
                               ? Column(children: widget.children)
-                              : Stack(children: widget.children)
-                        : Ink.image(
-                            fit: BoxFit.cover,
-                            image: widget.image!,
-                            child: Stack(
-                              children: [
-                                ...widget.children,
-                                if (widget.progress > 0)
-                                  Positioned(
-                                    left: 0,
-                                    right: 0,
-                                    bottom: 0,
-                                    child: LinearProgressIndicator(
-                                      value: widget.progress.clamp(0.0, 1.0),
-                                      minHeight: 3,
-                                      backgroundColor: Colors.black.withValues(
-                                        alpha: 0.35,
-                                      ),
-                                      valueColor: AlwaysStoppedAnimation<Color>(
-                                        context.primaryColor,
-                                      ),
+                              : Stack(children: widget.children),
+                        )
+                      : Ink.image(
+                          fit: BoxFit.cover,
+                          image: widget.image!,
+                          child: Stack(
+                            children: [
+                              if (showOverlay)
+                                Positioned.fill(
+                                  child: Container(
+                                    color: context.primaryColor.withValues(
+                                      alpha: 0.4,
                                     ),
                                   ),
-                              ],
-                            ),
+                                ),
+                              ...widget.children,
+                              if (widget.progress > 0)
+                                Positioned(
+                                  left: 0,
+                                  right: 0,
+                                  bottom: 0,
+                                  child: LinearProgressIndicator(
+                                    value: widget.progress.clamp(0.0, 1.0),
+                                    minHeight: 3,
+                                    backgroundColor: Colors.black.withValues(
+                                      alpha: 0.35,
+                                    ),
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                      context.primaryColor,
+                                    ),
+                                  ),
+                                ),
+                            ],
                           ),
-                  ),
+                        ),
                 ),
               ),
             ),

--- a/lib/modules/widgets/cover_view_widget.dart
+++ b/lib/modules/widgets/cover_view_widget.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
-class CoverViewWidget extends StatelessWidget {
+class CoverViewWidget extends StatefulWidget {
   final List<Widget> children;
   final bool? isLongPressed;
   final ImageProvider? image;
@@ -10,6 +11,15 @@ class CoverViewWidget extends StatelessWidget {
   final VoidCallback onTap;
   final VoidCallback? onLongPress;
   final VoidCallback? onSecondaryTap;
+  // On TV, the first cover autofocuses so the grid becomes the content scope's
+  // focus target (otherwise d-pad focus never reaches it).
+  final bool autofocus;
+  // Notifies the parent when this card gains/loses focus — used by the TV home
+  // rows to scroll the focused card into view. Fires on any focus change,
+  // independent of the internal ring (which is gated to d-pad/keyboard input).
+  final ValueChanged<bool>? onFocusChange;
+  // 0..1 watch/read progress; when > 0 draws a thin bar along the cover bottom.
+  final double progress;
   const CoverViewWidget({
     super.key,
     required this.children,
@@ -20,41 +30,137 @@ class CoverViewWidget extends StatelessWidget {
     this.onLongPress,
     this.isLongPressed,
     this.onSecondaryTap,
+    this.autofocus = false,
+    this.onFocusChange,
+    this.progress = 0,
   });
 
   @override
+  State<CoverViewWidget> createState() => _CoverViewWidgetState();
+}
+
+class _CoverViewWidgetState extends State<CoverViewWidget> {
+  // Whether the card should draw a focus ring. Only set when focus arrives via
+  // keyboard / d-pad navigation (FocusHighlightMode.traditional), so touch
+  // input on phones/tablets never shows a ring. Gives d-pad/remote users on
+  // Android TV — and keyboard users anywhere — a clearly visible focus target.
+  bool _focused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Track highlight-mode changes so the ring is dropped immediately if the
+    // user switches to touch input while a card is focused (it must never show
+    // for touch), not only when focus is lost.
+    FocusManager.instance.addHighlightModeListener(_onHighlightModeChanged);
+  }
+
+  @override
+  void dispose() {
+    FocusManager.instance.removeHighlightModeListener(_onHighlightModeChanged);
+    super.dispose();
+  }
+
+  void _onHighlightModeChanged(FocusHighlightMode mode) {
+    // On TV the ring must persist regardless of highlight mode (input is d-pad
+    // only); elsewhere drop it the moment input switches away from keyboard.
+    if (!isTv && mode != FocusHighlightMode.traditional && _focused) {
+      setState(() => _focused = false);
+    }
+  }
+
+  void _onFocusChange(bool hasFocus) {
+    widget.onFocusChange?.call(hasFocus);
+    // On TV always show the ring when focused so something is always visibly
+    // focused; elsewhere only for keyboard/d-pad (traditional) so touch input
+    // never shows it.
+    final show =
+        hasFocus &&
+        (isTv ||
+            FocusManager.instance.highlightMode ==
+                FocusHighlightMode.traditional);
+    if (mounted && show != _focused) {
+      setState(() => _focused = show);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    // Comfortable grid renders the label below the card, so it must not also be
+    // placed inside the card. Render it once, and only when provided.
+    final showBottomText =
+        widget.isComfortableGrid && widget.bottomTextWidget != null;
     return Padding(
       padding: const EdgeInsets.all(5),
       child: Column(
         children: [
           Expanded(
-            child: Material(
-              borderRadius: BorderRadius.circular(5),
-              color: Colors.transparent,
-              clipBehavior: Clip.antiAlias,
-              child: InkWell(
-                onTap: onTap,
-                onLongPress: onLongPress,
-                onSecondaryTap: onSecondaryTap,
-                child: Container(
-                  color: isLongPressed != null && isLongPressed!
-                      ? context.primaryColor.withValues(alpha: 0.4)
-                      : Colors.transparent,
-                  child: image == null
-                      ? isComfortableGrid
-                            ? Column(children: [...children, bottomTextWidget!])
-                            : Stack(children: children)
-                      : Ink.image(
-                          fit: BoxFit.cover,
-                          image: image!,
-                          child: Stack(children: children),
-                        ),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 130),
+              curve: Curves.easeOut,
+              // Focus "pop" — the focused cover lifts slightly, TV-style.
+              transform: Matrix4.identity()..scale(_focused ? 1.06 : 1.0),
+              transformAlignment: Alignment.center,
+              decoration: BoxDecoration(
+                // Outer radius = inner clip radius (5) + border width (3) so the
+                // ring's corners stay concentric with the card and don't clip.
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: _focused ? context.primaryColor : Colors.transparent,
+                  width: 3,
+                ),
+              ),
+              child: Material(
+                borderRadius: BorderRadius.circular(5),
+                color: Colors.transparent,
+                clipBehavior: Clip.antiAlias,
+                child: InkWell(
+                  autofocus: widget.autofocus,
+                  onTap: widget.onTap,
+                  onLongPress: widget.onLongPress,
+                  onSecondaryTap: widget.onSecondaryTap,
+                  onFocusChange: _onFocusChange,
+                  child: Container(
+                    color: widget.isLongPressed != null && widget.isLongPressed!
+                        ? context.primaryColor.withValues(alpha: 0.4)
+                        : Colors.transparent,
+                    child: widget.image == null
+                        ? widget.isComfortableGrid
+                              // bottomTextWidget is rendered once below the card,
+                              // so it's not duplicated inside here anymore.
+                              ? Column(children: widget.children)
+                              : Stack(children: widget.children)
+                        : Ink.image(
+                            fit: BoxFit.cover,
+                            image: widget.image!,
+                            child: Stack(
+                              children: [
+                                ...widget.children,
+                                if (widget.progress > 0)
+                                  Positioned(
+                                    left: 0,
+                                    right: 0,
+                                    bottom: 0,
+                                    child: LinearProgressIndicator(
+                                      value: widget.progress.clamp(0.0, 1.0),
+                                      minHeight: 3,
+                                      backgroundColor: Colors.black.withValues(
+                                        alpha: 0.35,
+                                      ),
+                                      valueColor: AlwaysStoppedAnimation<Color>(
+                                        context.primaryColor,
+                                      ),
+                                    ),
+                                  ),
+                              ],
+                            ),
+                          ),
+                  ),
                 ),
               ),
             ),
           ),
-          if (isComfortableGrid) bottomTextWidget!,
+          if (showBottomText) widget.bottomTextWidget!,
         ],
       ),
     );

--- a/lib/modules/widgets/cover_view_widget.dart
+++ b/lib/modules/widgets/cover_view_widget.dart
@@ -14,7 +14,7 @@ class CoverViewWidget extends StatefulWidget {
   // On TV, the first cover autofocuses so the grid becomes the content scope's
   // focus target (otherwise d-pad focus never reaches it).
   final bool autofocus;
-  // Notifies the parent when this card gains/loses focus — used by the TV home
+  // Notifies the parent when this card gains/loses focus - used by the TV home
   // rows to scroll the focused card into view. Fires on any focus change,
   // independent of the internal ring (which is gated to d-pad/keyboard input).
   final ValueChanged<bool>? onFocusChange;
@@ -43,7 +43,7 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
   // Whether the card should draw a focus ring. Only set when focus arrives via
   // keyboard / d-pad navigation (FocusHighlightMode.traditional), so touch
   // input on phones/tablets never shows a ring. Gives d-pad/remote users on
-  // Android TV — and keyboard users anywhere — a clearly visible focus target.
+  // Android TV - and keyboard users anywhere - a clearly visible focus target.
   bool _focused = false;
 
   @override
@@ -98,7 +98,7 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 130),
               curve: Curves.easeOut,
-              // Focus "pop" — the focused cover lifts slightly, TV-style.
+              // Focus "pop" - the focused cover lifts slightly, TV-style.
               transform: Matrix4.identity()..scale(_focused ? 1.06 : 1.0),
               transformAlignment: Alignment.center,
               decoration: BoxDecoration(

--- a/lib/modules/widgets/cover_view_widget.dart
+++ b/lib/modules/widgets/cover_view_widget.dart
@@ -90,6 +90,8 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
     // placed inside the card. Render it once, and only when provided.
     final showBottomText =
         widget.isComfortableGrid && widget.bottomTextWidget != null;
+    // Matrix4.scale is deprecated in favour of the explicit per-axis form.
+    final pop = _focused ? 1.06 : 1.0;
     return Padding(
       padding: const EdgeInsets.all(5),
       child: Column(
@@ -99,7 +101,7 @@ class _CoverViewWidgetState extends State<CoverViewWidget> {
               duration: const Duration(milliseconds: 130),
               curve: Curves.easeOut,
               // Focus "pop" - the focused cover lifts slightly, TV-style.
-              transform: Matrix4.identity()..scale(_focused ? 1.06 : 1.0),
+              transform: Matrix4.identity()..scaleByDouble(pop, pop, pop, 1),
               transformAlignment: Alignment.center,
               decoration: BoxDecoration(
                 // Outer radius = inner clip radius (5) + border width (3) so the

--- a/lib/modules/widgets/gridview_widget.dart
+++ b/lib/modules/widgets/gridview_widget.dart
@@ -28,7 +28,7 @@ class GridViewWidget extends StatelessWidget {
         gridDelegate: (gridSize == null || gridSize == 0)
             ? SliverGridDelegateWithMaxCrossAxisExtent(
                 childAspectRatio: childAspectRatio!,
-                // Denser default on TV — from across a room 220px covers show
+                // Denser default on TV - from across a room 220px covers show
                 // only ~4 huge tiles; 150 gives more, smaller covers.
                 maxCrossAxisExtent: isTv ? 150 : 220,
               )

--- a/lib/modules/widgets/gridview_widget.dart
+++ b/lib/modules/widgets/gridview_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
 class GridViewWidget extends StatelessWidget {
   final ScrollController? controller;
@@ -27,7 +28,9 @@ class GridViewWidget extends StatelessWidget {
         gridDelegate: (gridSize == null || gridSize == 0)
             ? SliverGridDelegateWithMaxCrossAxisExtent(
                 childAspectRatio: childAspectRatio!,
-                maxCrossAxisExtent: 220,
+                // Denser default on TV — from across a room 220px covers show
+                // only ~4 huge tiles; 150 gives more, smaller covers.
+                maxCrossAxisExtent: isTv ? 150 : 220,
               )
             : SliverGridDelegateWithFixedCrossAxisCount(
                 crossAxisCount: gridSize!,

--- a/lib/modules/widgets/tv_escapable_slider.dart
+++ b/lib/modules/widgets/tv_escapable_slider.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Makes a Material [Slider] usable with a TV remote.
+///
+/// A Material Slider grabs *all four* arrow keys to change its value, so on a
+/// d-pad you can focus it but never move away — it's a trap. This wrapper owns
+/// the focus instead: Left/Right adjust the value (via [onDecrease]/[onIncrease])
+/// and Up/Down/Select fall through so focus can leave. The inner slider is
+/// excluded from focus so it can't swallow the keys. Off-TV ([enabled] false)
+/// it's a transparent pass-through, keeping normal touch/mouse behaviour.
+class TvEscapableSlider extends StatelessWidget {
+  const TvEscapableSlider({
+    super.key,
+    required this.child,
+    required this.onDecrease,
+    required this.onIncrease,
+    required this.enabled,
+  });
+
+  final Widget child;
+  final VoidCallback onDecrease;
+  final VoidCallback onIncrease;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!enabled) return child;
+    return Focus(
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent || event is KeyRepeatEvent) {
+          final k = event.logicalKey;
+          if (k == LogicalKeyboardKey.arrowLeft) {
+            onDecrease();
+            return KeyEventResult.handled;
+          }
+          if (k == LogicalKeyboardKey.arrowRight) {
+            onIncrease();
+            return KeyEventResult.handled;
+          }
+        }
+        // Up / Down / Select fall through so focus can leave the slider.
+        return KeyEventResult.ignored;
+      },
+      child: ExcludeFocus(child: child),
+    );
+  }
+}

--- a/lib/modules/widgets/tv_escapable_slider.dart
+++ b/lib/modules/widgets/tv_escapable_slider.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 /// Makes a Material [Slider] usable with a TV remote.
 ///
 /// A Material Slider grabs *all four* arrow keys to change its value, so on a
-/// d-pad you can focus it but never move away — it's a trap. This wrapper owns
+/// d-pad you can focus it but never move away - it's a trap. This wrapper owns
 /// the focus instead: Left/Right adjust the value (via [onDecrease]/[onIncrease])
 /// and Up/Down/Select fall through so focus can leave. The inner slider is
 /// excluded from focus so it can't swallow the keys. Off-TV ([enabled] false)

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -16,7 +16,7 @@ final bool isApple = Platform.isMacOS || Platform.isIOS;
 ///
 /// Defaults to false and is hydrated once at startup by [initIsTv] (Android
 /// only); it stays false on every other platform. Nothing branches on this
-/// yet — it's the detection foundation for Android TV support (see #729).
+/// yet - it's the detection foundation for Android TV support (see #729).
 bool isTv = false;
 
 /// Asks the native side whether this is a TV / leanback device and caches the

--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -1,4 +1,6 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 /// macOS, Linux or Windows
 final bool isDesktop =
@@ -9,3 +11,26 @@ final bool isMobile = Platform.isAndroid || Platform.isIOS;
 
 /// macOS or iOS
 final bool isApple = Platform.isMacOS || Platform.isIOS;
+
+/// Whether the app is running on an Android TV / leanback device.
+///
+/// Defaults to false and is hydrated once at startup by [initIsTv] (Android
+/// only); it stays false on every other platform. Nothing branches on this
+/// yet — it's the detection foundation for Android TV support (see #729).
+bool isTv = false;
+
+/// Asks the native side whether this is a TV / leanback device and caches the
+/// answer in [isTv]. No-op (and leaves [isTv] false) on non-Android platforms
+/// or if the channel isn't available. Safe to call once the engine is up.
+Future<void> initIsTv() async {
+  if (!Platform.isAndroid) return;
+  try {
+    const channel = MethodChannel('com.kodjodevf.mangayomi.device');
+    isTv = (await channel.invokeMethod<bool>('isTv')) ?? false;
+  } catch (_) {
+    isTv = false;
+  }
+  if (kDebugMode) {
+    debugPrint('[platform] isTv = $isTv');
+  }
+}


### PR DESCRIPTION
Consolidates the Android TV work into a single PR (per the request to combine the separate TV PRs), rebuilt cleanly off `main`.

**Supersedes:** #771, #769, #772, #775, #776, #786, #787, #788, #785, #791.
Also folds in the autoplay toggle (**Closes #739**) and makes it shared across mobile, desktop and TV players with one setting, rather than a separate PR.

Closes #729.

### What it does
- **Form-factor detection** (`isTv`) via a native leanback check, with an explicit user override so a wrong detection is never a trap.
- **Anime-only TV layout**: manga/novel libraries hidden, anime-first, across Library / Browse / History / Updates / Categories.
- **D-pad navigation**: tab-rail focus, a d-pad library grid with a focus ring, escapable settings sliders, and no autofocus on dialog text fields so the on-screen keyboard behaves.
- **Rows-based TV home**: hero plus Continue / New Episodes / Recently Added / category rows (toggleable back to the grid).
- **Dedicated TV player**: always-visible transport, a split settings panel (quality / subtitle / audio, d-pad focusable), and a shared autoplay-next toggle.

Phones and desktop are unaffected; everything is gated on `isTv` or user settings.

The new preferences (the `isTv` override, TV home and player style, genre rows, and autoplay next) are persisted on the Isar `Settings` collection, matching how the app stores its other preferences.

### Screenshots

Dark Mode (Default-TV)
<img width="1436" height="857" alt="Screenshot 2026-07-12 at 10 41 07 PM" src="https://github.com/user-attachments/assets/09cc9d03-678b-4edb-9722-9bf1caeca3a6" />

<img width="1434" height="868" alt="Screenshot 2026-07-12 at 10 41 15 PM" src="https://github.com/user-attachments/assets/5a0b6adb-5fb0-4872-ad92-c54f669a0ff3" />

<img width="1434" height="862" alt="Screenshot 2026-07-12 at 10 41 34 PM" src="https://github.com/user-attachments/assets/0f974db5-0848-4479-b70f-5225d7b5f186" />

<img width="1436" height="866" alt="Screenshot 2026-07-12 at 10 41 44 PM" src="https://github.com/user-attachments/assets/44bf52f4-bc0d-43d1-bc93-fd61fd647de7" />

<img width="1349" height="758" alt="Screenshot 2026-07-09 at 2 13 05 AM" src="https://github.com/user-attachments/assets/16aa97a1-1557-404a-86b0-17264cb73aa7" />

<img width="1433" height="837" alt="Screenshot 2026-07-10 at 11 46 24 PM" src="https://github.com/user-attachments/assets/a35d64a5-a66b-4719-a222-1287666e970f" />

<img width="1431" height="843" alt="Screenshot 2026-07-13 at 2 43 58 PM" src="https://github.com/user-attachments/assets/79a1f6b1-1c6a-49eb-b787-3ab33daf9043" />


Light Mode
<img width="1434" height="866" alt="Screenshot 2026-07-15 at 1 37 28 PM" src="https://github.com/user-attachments/assets/60c4ae3c-2a09-44cc-b20c-257a636eb0d1" />

<img width="1434" height="864" alt="Screenshot 2026-07-15 at 1 36 32 PM" src="https://github.com/user-attachments/assets/4b1d7212-79be-4ffa-910f-cd8f67468f57" />

<img width="1432" height="867" alt="Screenshot 2026-07-15 at 1 40 38 PM" src="https://github.com/user-attachments/assets/cb7c5886-d513-473e-9f56-2b91ea41530a" />


### Testing
Verified on a Fire TV and via a Force-TV desktop build driven with keyboard arrows.


