### PR TITLE
fix: missing-source robustness - null source/lang crash (#708) and orphaned sources on repo delete

### DIFF
--- a/lib/modules/library/widgets/library_app_bar.dart
+++ b/lib/modules/library/widgets/library_app_bar.dart
@@ -204,9 +204,9 @@ class LibraryAppBar extends ConsumerWidget implements PreferredSizeWidget {
                       ? randomManga.id
                       : null,
                   context: context,
-                  lang: randomManga.lang!,
+                  lang: randomManga.lang ?? '',
                   mangaM: randomManga,
-                  source: randomManga.source!,
+                  source: randomManga.source ?? '',
                   sourceId: randomManga.sourceId,
                 );
               });

--- a/lib/modules/library/widgets/library_entry_utils.dart
+++ b/lib/modules/library/widgets/library_entry_utils.dart
@@ -20,17 +20,25 @@ ImageProvider resolveCoverImage(Manga entry, WidgetRef ref) {
   if (entry.customCoverImage != null) {
     return MemoryImage(entry.customCoverImage as Uint8List);
   }
+  // An orphaned/corrupted entry can have a null source or lang (e.g. its
+  // source was uninstalled, or a legacy record). Skip source headers in that
+  // case instead of force-unwrapping — otherwise the whole tile throws while
+  // building and the entry becomes an un-removable "gray square". See #708.
+  final canUseSourceHeaders =
+      !(entry.isLocalArchive ?? false) &&
+      entry.source != null &&
+      entry.lang != null;
   return coverProvider(
     toImgUrl(entry.customCoverFromTracker ?? entry.imageUrl ?? ''),
-    headers: (entry.isLocalArchive ?? false)
-        ? null
-        : ref.watch(
+    headers: canUseSourceHeaders
+        ? ref.watch(
             headersProvider(
               source: entry.source!,
               lang: entry.lang!,
               sourceId: entry.sourceId,
             ),
-          ),
+          )
+        : null,
   );
 }
 
@@ -65,9 +73,9 @@ Future<void> onTapEntry({
     ref: ref,
     archiveId: isLocalArchive ? entry.id : null,
     context: context,
-    lang: entry.lang!,
+    lang: entry.lang ?? '',
     mangaM: entry,
-    source: entry.source!,
+    source: entry.source ?? '',
     sourceId: entry.sourceId,
   );
 

--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -122,7 +122,7 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                       ),
 
                       // ── Top-right: Language ──
-                      if (widget.language && entry.lang!.isNotEmpty)
+                      if (widget.language && (entry.lang?.isNotEmpty ?? false))
                         Positioned(
                           top: 0,
                           right: 0,

--- a/lib/modules/library/widgets/library_listview_widget.dart
+++ b/lib/modules/library/widgets/library_listview_widget.dart
@@ -130,7 +130,8 @@ class LibraryListViewWidget extends StatelessWidget {
                                         ),
                                       ),
                                     ),
-                                    if (language && entry.lang!.isNotEmpty)
+                                    if (language &&
+                                        (entry.lang?.isNotEmpty ?? false))
                                       EntryBadgeChip(
                                         label: entry.lang!.toUpperCase(),
                                       ),

--- a/lib/modules/more/settings/browse/source_repositories.dart
+++ b/lib/modules/more/settings/browse/source_repositories.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:isar_community/isar.dart';
 import 'package:mangayomi/eval/model/m_bridge.dart';
+import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
 import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -265,6 +268,26 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
     );
   }
 
+  /// #774: when a repo is removed, drop its *not-installed* sources so they
+  /// don't linger as placeholders with a dead install button. Installed
+  /// sources (non-empty [Source.sourceCode]) are kept so users don't lose them.
+  void _removeOrphanSources(Repo removedRepo) {
+    final repoUrl = removedRepo.jsonUrl;
+    if (repoUrl == null) return;
+    final orphanIds = isar.sources
+        .filter()
+        .itemTypeEqualTo(widget.itemType)
+        .findAllSync()
+        .where(
+          (s) => s.repo?.jsonUrl == repoUrl && (s.sourceCode?.isEmpty ?? true),
+        )
+        .map((s) => s.id!)
+        .toList();
+    if (orphanIds.isNotEmpty) {
+      isar.writeTxnSync(() => isar.sources.deleteAllSync(orphanIds));
+    }
+  }
+
   void _showRemoveRepoDialog(BuildContext context, int index) {
     showDialog(
       context: context,
@@ -288,10 +311,11 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
                     const SizedBox(width: 15),
                     TextButton(
                       onPressed: () {
+                        final removedRepo = _entries[index];
                         final mangaRepos = ref
                             .read(extensionsRepoStateProvider(widget.itemType))
                             .toList();
-                        mangaRepos.removeWhere((url) => url == _entries[index]);
+                        mangaRepos.removeWhere((url) => url == removedRepo);
                         ref
                             .read(
                               extensionsRepoStateProvider(
@@ -299,6 +323,7 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
                               ).notifier,
                             )
                             .set(mangaRepos);
+                        _removeOrphanSources(removedRepo);
                         ref.watch(extensionsRepoStateProvider(widget.itemType));
                         if (context.mounted) {
                           Navigator.pop(context);


### PR DESCRIPTION
Combines two missing-source robustness fixes into one PR, to reduce PR count.

- **Null source/lang (#708):** don't crash on library entries whose source or language is null (the "gray squares"); render them safely instead. Closes #708.
- **Orphaned sources on repo delete:** when a source repo is removed, also remove the sources that came from it, so they don't linger as dead entries.

Replaces #778 and #761 (closed in favour of this).
