### PR TITLE
feat(updates): surface library-update failures - persistent screen and dismissible dialog (#623)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/services/http/m_client.dart';
 import 'package:mangayomi/services/isolate_service.dart';
 import 'package:mangayomi/services/m_extension_server.dart';
+import 'package:mangayomi/services/update_errors_provider.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
 import 'package:mangayomi/src/rust/frb_generated.dart';
 import 'package:mangayomi/utils/discord_rpc.dart';
@@ -177,6 +178,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await openUpdateErrorsBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,7 +34,6 @@ import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/services/http/m_client.dart';
 import 'package:mangayomi/services/isolate_service.dart';
 import 'package:mangayomi/services/m_extension_server.dart';
-import 'package:mangayomi/services/update_errors_provider.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
 import 'package:mangayomi/src/rust/frb_generated.dart';
 import 'package:mangayomi/utils/discord_rpc.dart';
@@ -178,7 +177,6 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
-  await openUpdateErrorsBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -67,6 +67,9 @@ class Settings {
 
   List<MCookie>? cookiesList;
 
+  /// The last library update's failures, kept so they can be reviewed later.
+  List<UpdateError>? updateErrorsList;
+
   @enumerated
   late ReaderMode defaultReaderMode;
 
@@ -409,6 +412,7 @@ class Settings {
     this.chapterPageIndexList,
     this.userAgent = defaultUserAgent,
     this.cookiesList,
+    this.updateErrorsList,
     this.defaultReaderMode = ReaderMode.vertical,
     this.personalReaderModeList,
     this.animatePageTransitions = true,
@@ -614,6 +618,11 @@ class Settings {
     if (json['cookiesList'] != null) {
       cookiesList = (json['cookiesList'] as List)
           .map((e) => MCookie.fromJson(e))
+          .toList();
+    }
+    if (json['updateErrorsList'] != null) {
+      updateErrorsList = (json['updateErrorsList'] as List)
+          .map((e) => UpdateError.fromJson(e))
           .toList();
     }
     cropBorders = json['cropBorders'];
@@ -897,6 +906,7 @@ class Settings {
     'checkForAppUpdates': checkForAppUpdates,
     'checkForExtensionUpdates': checkForExtensionUpdates,
     'cookiesList': cookiesList,
+    'updateErrorsList': updateErrorsList,
     'cropBorders': cropBorders,
     'dateFormat': dateFormat,
     'defaultReaderMode': defaultReaderMode.index,
@@ -1103,6 +1113,23 @@ enum ScaleType {
 }
 
 enum BackgroundColor { black, grey, white, automatic }
+
+@embedded
+class UpdateError {
+  int mangaId;
+  String name;
+  String error;
+  UpdateError({this.mangaId = 0, this.name = '', this.error = ''});
+  UpdateError.fromJson(Map<String, dynamic> json)
+    : mangaId = json['mangaId'] ?? 0,
+      name = json['name'] ?? '',
+      error = json['error'] ?? '';
+  Map<String, dynamic> toJson() => {
+    'mangaId': mangaId,
+    'name': name,
+    'error': error,
+  };
+}
 
 @embedded
 class MCookie {

--- a/lib/models/settings.g.dart
+++ b/lib/models/settings.g.dart
@@ -944,63 +944,70 @@ const SettingsSchema = CollectionSchema(
       name: r'ttsVoice',
       type: IsarType.string,
     ),
-    r'updateProgressAfterReading': PropertySchema(
+    r'updateErrorsList': PropertySchema(
       id: 175,
+      name: r'updateErrorsList',
+      type: IsarType.objectList,
+
+      target: r'UpdateError',
+    ),
+    r'updateProgressAfterReading': PropertySchema(
+      id: 176,
       name: r'updateProgressAfterReading',
       type: IsarType.bool,
     ),
     r'updatedAt': PropertySchema(
-      id: 176,
+      id: 177,
       name: r'updatedAt',
       type: IsarType.long,
     ),
     r'useLibass': PropertySchema(
-      id: 177,
+      id: 178,
       name: r'useLibass',
       type: IsarType.bool,
     ),
     r'useMpvConfig': PropertySchema(
-      id: 178,
+      id: 179,
       name: r'useMpvConfig',
       type: IsarType.bool,
     ),
     r'usePageTapZones': PropertySchema(
-      id: 179,
+      id: 180,
       name: r'usePageTapZones',
       type: IsarType.bool,
     ),
     r'useYUV420P': PropertySchema(
-      id: 180,
+      id: 181,
       name: r'useYUV420P',
       type: IsarType.bool,
     ),
     r'userAgent': PropertySchema(
-      id: 181,
+      id: 182,
       name: r'userAgent',
       type: IsarType.string,
     ),
     r'volumeBoostCap': PropertySchema(
-      id: 182,
+      id: 183,
       name: r'volumeBoostCap',
       type: IsarType.long,
     ),
     r'webtoonDisableZoomOut': PropertySchema(
-      id: 183,
+      id: 184,
       name: r'webtoonDisableZoomOut',
       type: IsarType.bool,
     ),
     r'webtoonDoubleTapZoomEnabled': PropertySchema(
-      id: 184,
+      id: 185,
       name: r'webtoonDoubleTapZoomEnabled',
       type: IsarType.bool,
     ),
     r'webtoonSidePadding': PropertySchema(
-      id: 185,
+      id: 186,
       name: r'webtoonSidePadding',
       type: IsarType.long,
     ),
     r'zoomStartPosition': PropertySchema(
-      id: 186,
+      id: 187,
       name: r'zoomStartPosition',
       type: IsarType.long,
     ),
@@ -1029,6 +1036,7 @@ const SettingsSchema = CollectionSchema(
     r'ChapterPageurls': ChapterPageurlsSchema,
     r'ChapterPageIndex': ChapterPageIndexSchema,
     r'MCookie': MCookieSchema,
+    r'UpdateError': UpdateErrorSchema,
     r'PersonalReaderMode': PersonalReaderModeSchema,
     r'FilterScanlator': FilterScanlatorSchema,
     r'L10nLocale': L10nLocaleSchema,
@@ -1509,6 +1517,23 @@ int _settingsEstimateSize(
     }
   }
   {
+    final list = object.updateErrorsList;
+    if (list != null) {
+      bytesCount += 3 + list.length * 3;
+      {
+        final offsets = allOffsets[UpdateError]!;
+        for (var i = 0; i < list.length; i++) {
+          final value = list[i];
+          bytesCount += UpdateErrorSchema.estimateSize(
+            value,
+            offsets,
+            allOffsets,
+          );
+        }
+      }
+    }
+  }
+  {
     final value = object.userAgent;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
@@ -1808,18 +1833,24 @@ void _settingsSerialize(
   writer.writeDouble(offsets[172], object.ttsPitch);
   writer.writeDouble(offsets[173], object.ttsSpeechRate);
   writer.writeString(offsets[174], object.ttsVoice);
-  writer.writeBool(offsets[175], object.updateProgressAfterReading);
-  writer.writeLong(offsets[176], object.updatedAt);
-  writer.writeBool(offsets[177], object.useLibass);
-  writer.writeBool(offsets[178], object.useMpvConfig);
-  writer.writeBool(offsets[179], object.usePageTapZones);
-  writer.writeBool(offsets[180], object.useYUV420P);
-  writer.writeString(offsets[181], object.userAgent);
-  writer.writeLong(offsets[182], object.volumeBoostCap);
-  writer.writeBool(offsets[183], object.webtoonDisableZoomOut);
-  writer.writeBool(offsets[184], object.webtoonDoubleTapZoomEnabled);
-  writer.writeLong(offsets[185], object.webtoonSidePadding);
-  writer.writeLong(offsets[186], object.zoomStartPosition);
+  writer.writeObjectList<UpdateError>(
+    offsets[175],
+    allOffsets,
+    UpdateErrorSchema.serialize,
+    object.updateErrorsList,
+  );
+  writer.writeBool(offsets[176], object.updateProgressAfterReading);
+  writer.writeLong(offsets[177], object.updatedAt);
+  writer.writeBool(offsets[178], object.useLibass);
+  writer.writeBool(offsets[179], object.useMpvConfig);
+  writer.writeBool(offsets[180], object.usePageTapZones);
+  writer.writeBool(offsets[181], object.useYUV420P);
+  writer.writeString(offsets[182], object.userAgent);
+  writer.writeLong(offsets[183], object.volumeBoostCap);
+  writer.writeBool(offsets[184], object.webtoonDisableZoomOut);
+  writer.writeBool(offsets[185], object.webtoonDoubleTapZoomEnabled);
+  writer.writeLong(offsets[186], object.webtoonSidePadding);
+  writer.writeLong(offsets[187], object.zoomStartPosition);
 }
 
 Settings _settingsDeserialize(
@@ -2122,18 +2153,24 @@ Settings _settingsDeserialize(
     ttsPitch: reader.readDoubleOrNull(offsets[172]),
     ttsSpeechRate: reader.readDoubleOrNull(offsets[173]),
     ttsVoice: reader.readStringOrNull(offsets[174]),
-    updateProgressAfterReading: reader.readBoolOrNull(offsets[175]),
-    updatedAt: reader.readLongOrNull(offsets[176]),
-    useLibass: reader.readBoolOrNull(offsets[177]),
-    useMpvConfig: reader.readBoolOrNull(offsets[178]),
-    usePageTapZones: reader.readBoolOrNull(offsets[179]),
-    useYUV420P: reader.readBoolOrNull(offsets[180]),
-    userAgent: reader.readStringOrNull(offsets[181]),
-    volumeBoostCap: reader.readLongOrNull(offsets[182]),
-    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[183]),
-    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[184]),
-    webtoonSidePadding: reader.readLongOrNull(offsets[185]),
-    zoomStartPosition: reader.readLongOrNull(offsets[186]),
+    updateErrorsList: reader.readObjectList<UpdateError>(
+      offsets[175],
+      UpdateErrorSchema.deserialize,
+      allOffsets,
+      UpdateError(),
+    ),
+    updateProgressAfterReading: reader.readBoolOrNull(offsets[176]),
+    updatedAt: reader.readLongOrNull(offsets[177]),
+    useLibass: reader.readBoolOrNull(offsets[178]),
+    useMpvConfig: reader.readBoolOrNull(offsets[179]),
+    usePageTapZones: reader.readBoolOrNull(offsets[180]),
+    useYUV420P: reader.readBoolOrNull(offsets[181]),
+    userAgent: reader.readStringOrNull(offsets[182]),
+    volumeBoostCap: reader.readLongOrNull(offsets[183]),
+    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[184]),
+    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[185]),
+    webtoonSidePadding: reader.readLongOrNull(offsets[186]),
+    zoomStartPosition: reader.readLongOrNull(offsets[187]),
   );
   object.chapterFilterBookmarkedList = reader
       .readObjectList<ChapterFilterBookmarked>(
@@ -2694,11 +2731,17 @@ P _settingsDeserializeProp<P>(
     case 174:
       return (reader.readStringOrNull(offset)) as P;
     case 175:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readObjectList<UpdateError>(
+            offset,
+            UpdateErrorSchema.deserialize,
+            allOffsets,
+            UpdateError(),
+          ))
+          as P;
     case 176:
-      return (reader.readLongOrNull(offset)) as P;
-    case 177:
       return (reader.readBoolOrNull(offset)) as P;
+    case 177:
+      return (reader.readLongOrNull(offset)) as P;
     case 178:
       return (reader.readBoolOrNull(offset)) as P;
     case 179:
@@ -2706,16 +2749,18 @@ P _settingsDeserializeProp<P>(
     case 180:
       return (reader.readBoolOrNull(offset)) as P;
     case 181:
-      return (reader.readStringOrNull(offset)) as P;
-    case 182:
-      return (reader.readLongOrNull(offset)) as P;
-    case 183:
       return (reader.readBoolOrNull(offset)) as P;
+    case 182:
+      return (reader.readStringOrNull(offset)) as P;
+    case 183:
+      return (reader.readLongOrNull(offset)) as P;
     case 184:
       return (reader.readBoolOrNull(offset)) as P;
     case 185:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 186:
+      return (reader.readLongOrNull(offset)) as P;
+    case 187:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -14616,6 +14661,83 @@ extension SettingsQueryFilter
   }
 
   QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  updateErrorsListIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'updateErrorsList'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  updateErrorsListIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'updateErrorsList'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  updateErrorsListLengthEqualTo(int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'updateErrorsList', length, true, length, true);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  updateErrorsListIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'updateErrorsList', 0, true, 0, true);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  updateErrorsListIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'updateErrorsList', 0, false, 999999, true);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  updateErrorsListLengthLessThan(int length, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'updateErrorsList', 0, true, length, include);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  updateErrorsListLengthGreaterThan(int length, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'updateErrorsList',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  updateErrorsListLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'updateErrorsList',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
   updateProgressAfterReadingIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(
@@ -15435,6 +15557,13 @@ extension SettingsQueryObject
   ) {
     return QueryBuilder.apply(this, (query) {
       return query.object(q, r'sortLibraryNovel');
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  updateErrorsListElement(FilterQuery<UpdateError> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.object(q, r'updateErrorsList');
     });
   }
 }
@@ -21983,6 +22112,13 @@ extension SettingsQueryProperty
     });
   }
 
+  QueryBuilder<Settings, List<UpdateError>?, QQueryOperations>
+  updateErrorsListProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'updateErrorsList');
+    });
+  }
+
   QueryBuilder<Settings, bool?, QQueryOperations>
   updateProgressAfterReadingProperty() {
     return QueryBuilder.apply(this, (query) {
@@ -22062,6 +22198,436 @@ extension SettingsQueryProperty
 // **************************************************************************
 // IsarEmbeddedGenerator
 // **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+const UpdateErrorSchema = Schema(
+  name: r'UpdateError',
+  id: -6793279269818166592,
+  properties: {
+    r'error': PropertySchema(id: 0, name: r'error', type: IsarType.string),
+    r'mangaId': PropertySchema(id: 1, name: r'mangaId', type: IsarType.long),
+    r'name': PropertySchema(id: 2, name: r'name', type: IsarType.string),
+  },
+
+  estimateSize: _updateErrorEstimateSize,
+  serialize: _updateErrorSerialize,
+  deserialize: _updateErrorDeserialize,
+  deserializeProp: _updateErrorDeserializeProp,
+);
+
+int _updateErrorEstimateSize(
+  UpdateError object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.error.length * 3;
+  bytesCount += 3 + object.name.length * 3;
+  return bytesCount;
+}
+
+void _updateErrorSerialize(
+  UpdateError object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.error);
+  writer.writeLong(offsets[1], object.mangaId);
+  writer.writeString(offsets[2], object.name);
+}
+
+UpdateError _updateErrorDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = UpdateError(
+    error: reader.readStringOrNull(offsets[0]) ?? '',
+    mangaId: reader.readLongOrNull(offsets[1]) ?? 0,
+    name: reader.readStringOrNull(offsets[2]) ?? '',
+  );
+  return object;
+}
+
+P _updateErrorDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readStringOrNull(offset) ?? '') as P;
+    case 1:
+      return (reader.readLongOrNull(offset) ?? 0) as P;
+    case 2:
+      return (reader.readStringOrNull(offset) ?? '') as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+extension UpdateErrorQueryFilter
+    on QueryBuilder<UpdateError, UpdateError, QFilterCondition> {
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> errorEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'error',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition>
+  errorGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'error',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> errorLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'error',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> errorBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'error',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> errorStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'error',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> errorEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'error',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> errorContains(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'error',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> errorMatches(
+    String pattern, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'error',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> errorIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'error', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition>
+  errorIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'error', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> mangaIdEqualTo(
+    int value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'mangaId', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition>
+  mangaIdGreaterThan(int value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'mangaId',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> mangaIdLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'mangaId',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> mangaIdBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'mangaId',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> nameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> nameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> nameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> nameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'name',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> nameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> nameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> nameContains(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> nameMatches(
+    String pattern, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'name',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition> nameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'name', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<UpdateError, UpdateError, QAfterFilterCondition>
+  nameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'name', value: ''),
+      );
+    });
+  }
+}
+
+extension UpdateErrorQueryObject
+    on QueryBuilder<UpdateError, UpdateError, QFilterCondition> {}
 
 // coverage:ignore-file
 // ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types

--- a/lib/modules/updates/update_errors_screen.dart
+++ b/lib/modules/updates/update_errors_screen.dart
@@ -1,0 +1,96 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/modules/manga/detail/widgets/migrate_screen.dart';
+import 'package:mangayomi/services/update_errors_provider.dart';
+
+/// Persistent list of the last library update's failures. Each entry can be
+/// dismissed or migrated away, so recurring source failures don't have to be
+/// caught in the transient post-update dialog.
+class UpdateErrorsScreen extends ConsumerWidget {
+  const UpdateErrorsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final errors = ref.watch(updateErrorsProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Update errors'),
+        actions: [
+          if (errors.isNotEmpty)
+            IconButton(
+              tooltip: 'Clear all',
+              icon: const Icon(Icons.clear_all),
+              onPressed: () => ref.read(updateErrorsProvider.notifier).clear(),
+            ),
+        ],
+      ),
+      body: errors.isEmpty
+          ? const Center(child: Text('No update errors'))
+          : ListView.builder(
+              itemCount: errors.length,
+              itemBuilder: (context, index) {
+                final err = errors[index];
+                final manga = isar.mangas.getSync(err.mangaId);
+                return ListTile(
+                  leading: _cover(manga),
+                  title: Text(
+                    err.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Text(
+                    err.error,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (manga != null)
+                        IconButton(
+                          tooltip: 'Migrate',
+                          icon: const Icon(Icons.swap_horiz),
+                          onPressed: () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => MigrationScreen(manga: manga),
+                            ),
+                          ),
+                        ),
+                      IconButton(
+                        tooltip: 'Dismiss',
+                        icon: const Icon(Icons.close),
+                        onPressed: () => ref
+                            .read(updateErrorsProvider.notifier)
+                            .remove(err.mangaId),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+    );
+  }
+
+  Widget _cover(Manga? manga) {
+    final cover = manga?.customCoverImage;
+    return SizedBox(
+      width: 40,
+      height: 56,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(4),
+        child: cover != null && cover.isNotEmpty
+            ? Image.memory(Uint8List.fromList(cover), fit: BoxFit.cover)
+            : const ColoredBox(
+                color: Colors.black12,
+                child: Icon(Icons.broken_image_outlined, size: 20),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/modules/updates/update_errors_screen.dart
+++ b/lib/modules/updates/update_errors_screen.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:isar_community/isar.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/migrate_screen.dart';

--- a/lib/modules/updates/updates_screen.dart
+++ b/lib/modules/updates/updates_screen.dart
@@ -10,6 +10,8 @@ import 'package:mangayomi/models/chapter.dart';
 import 'package:mangayomi/models/update.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/updates/widgets/update_chapter_list_tile_widget.dart';
+import 'package:mangayomi/modules/updates/update_errors_screen.dart';
+import 'package:mangayomi/services/update_errors_provider.dart';
 import 'package:mangayomi/modules/history/providers/isar_providers.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/library_updater.dart';
@@ -60,6 +62,19 @@ class _UpdatesScreenState extends BaseLibraryTabScreenState<UpdatesScreen> {
     final l10n = l10nLocalizations(context)!;
 
     return [
+      if (ref.watch(updateErrorsProvider).isNotEmpty)
+        IconButton(
+          splashRadius: 20,
+          tooltip: 'Update errors',
+          icon: Icon(
+            Icons.error_outline,
+            color: Theme.of(context).colorScheme.error,
+          ),
+          onPressed: () => Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const UpdateErrorsScreen()),
+          ),
+        ),
       IconButton(
         splashRadius: 20,
         icon: Icon(Icons.refresh_outlined, color: Theme.of(context).hintColor),

--- a/lib/services/library_updater.dart
+++ b/lib/services/library_updater.dart
@@ -71,17 +71,40 @@ Future<void> updateLibrary({
   BotToast.cleanAll();
   // Persist this run's failures (empty list clears any previous ones) so they
   // can be reviewed and migrated away later from the Updates tab's error
-  // screen, instead of only in this transient toast.
+  // screen, in addition to the dialog below.
   ref.read(updateErrorsProvider.notifier).set(failures);
   if (context.mounted && failures.isNotEmpty) {
-    final failedListText = failures.map((m) => "• ${m.name}").join('\n');
     final plural = failed == 1 ? itemtype : "${itemtype}s";
-    botToast(
-      "Failed to update $failed $plural:\n$failedListText",
-      fontSize: 13,
-      second: 10,
-      alignY: !context.isTablet ? 0.85 : 1,
-      themeDark: isDark,
+    // Show the failures in a dismissible dialog rather than a transient toast,
+    // so the list can be reviewed at the user's pace and isn't missed when many
+    // entries fail. See #623.
+    await showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text("Failed to update $failed $plural"),
+        content: SizedBox(
+          width: context.width(0.8),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: context.height(0.5)),
+            // ListView.builder so rows are built lazily - a large library with
+            // many failed updates won't build one widget per entry up front.
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: failures.length,
+              itemBuilder: (context, index) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2),
+                child: Text("• ${failures[index].name}"),
+              ),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(context.l10n.ok),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/services/library_updater.dart
+++ b/lib/services/library_updater.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/log/logger.dart';
 import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/services/update_errors_provider.dart';
 
 Future<void> updateLibrary({
   required WidgetRef ref,
@@ -30,7 +31,7 @@ Future<void> updateLibrary({
     themeDark: isDark,
   );
   int failed = 0;
-  List<String> failedMangas = [];
+  List<UpdateError> failures = [];
   for (var i = 0; i < mangaList.length; i++) {
     final manga = mangaList[i];
     try {
@@ -45,7 +46,13 @@ Future<void> updateLibrary({
       AppLogger.log("Failed to update $itemtype:", logLevel: LogLevel.error);
       AppLogger.log(e.toString(), logLevel: LogLevel.error);
       failed++;
-      failedMangas.add(manga.name ?? "Unknown $itemtype");
+      failures.add(
+        UpdateError(
+          mangaId: manga.id!,
+          name: manga.name ?? "Unknown $itemtype",
+          error: e.toString(),
+        ),
+      );
     }
     if (context.mounted) {
       botToast(
@@ -62,8 +69,12 @@ Future<void> updateLibrary({
   }
   await Future.delayed(const Duration(seconds: 1));
   BotToast.cleanAll();
-  if (context.mounted && failedMangas.isNotEmpty) {
-    final failedListText = failedMangas.map((m) => "• $m").join('\n');
+  // Persist this run's failures (empty list clears any previous ones) so they
+  // can be reviewed and migrated away later from the Updates tab's error
+  // screen, instead of only in this transient toast.
+  ref.read(updateErrorsProvider.notifier).set(failures);
+  if (context.mounted && failures.isNotEmpty) {
+    final failedListText = failures.map((m) => "• ${m.name}").join('\n');
     final plural = failed == 1 ? itemtype : "${itemtype}s";
     botToast(
       "Failed to update $failed $plural:\n$failedListText",

--- a/lib/services/update_errors_provider.dart
+++ b/lib/services/update_errors_provider.dart
@@ -1,46 +1,14 @@
-import 'dart:convert';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hive/hive.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/settings.dart';
 
-/// A single failed library-update entry, persisted so the user can review it
-/// (and migrate the entry away) after the update run has finished.
-class UpdateError {
-  final int mangaId;
-  final String name;
-  final String error;
+// UpdateError is an @embedded model on the Settings collection; re-export it so
+// existing call sites can keep importing it from this provider.
+export 'package:mangayomi/models/settings.dart' show UpdateError;
 
-  const UpdateError({
-    required this.mangaId,
-    required this.name,
-    required this.error,
-  });
-
-  Map<String, dynamic> toJson() => {
-    'mangaId': mangaId,
-    'name': name,
-    'error': error,
-  };
-
-  factory UpdateError.fromJson(Map<dynamic, dynamic> json) => UpdateError(
-    mangaId: json['mangaId'] as int,
-    name: (json['name'] ?? '') as String,
-    error: (json['error'] ?? '') as String,
-  );
-}
-
-const _boxName = 'update_errors';
-const _key = 'errors';
-
-/// Opens the backing box. Called once at startup (see main.dart).
-Future<void> openUpdateErrorsBox() async {
-  if (!Hive.isBoxOpen(_boxName)) {
-    await Hive.openBox(_boxName);
-  }
-}
-
-/// The last library update's failures, persisted across restarts so they can be
-/// reviewed on the [UpdateErrorsScreen] rather than only in a transient dialog.
+/// The last library update's failures, persisted on the Settings collection so
+/// they can be reviewed on the [UpdateErrorsScreen] rather than only in a
+/// transient dialog.
 final updateErrorsProvider =
     NotifierProvider<UpdateErrorsNotifier, List<UpdateError>>(
       UpdateErrorsNotifier.new,
@@ -48,21 +16,8 @@ final updateErrorsProvider =
 
 class UpdateErrorsNotifier extends Notifier<List<UpdateError>> {
   @override
-  List<UpdateError> build() => _read();
-
-  List<UpdateError> _read() {
-    if (Hive.isBoxOpen(_boxName)) {
-      final raw = Hive.box(_boxName).get(_key);
-      if (raw is String && raw.isNotEmpty) {
-        try {
-          return (jsonDecode(raw) as List)
-              .map((e) => UpdateError.fromJson(e as Map))
-              .toList();
-        } catch (_) {}
-      }
-    }
-    return [];
-  }
+  List<UpdateError> build() =>
+      isar.settings.getSync(227)?.updateErrorsList ?? const [];
 
   /// Replaces the stored failures with the latest update run's results.
   void set(List<UpdateError> errors) {
@@ -82,10 +37,11 @@ class UpdateErrorsNotifier extends Notifier<List<UpdateError>> {
   }
 
   void _persist() {
-    if (Hive.isBoxOpen(_boxName)) {
-      Hive.box(
-        _boxName,
-      ).put(_key, jsonEncode(state.map((e) => e.toJson()).toList()));
-    }
+    isar.writeTxnSync(() {
+      final settings = isar.settings.getSync(227);
+      if (settings != null) {
+        isar.settings.putSync(settings..updateErrorsList = [...state]);
+      }
+    });
   }
 }

--- a/lib/services/update_errors_provider.dart
+++ b/lib/services/update_errors_provider.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+/// A single failed library-update entry, persisted so the user can review it
+/// (and migrate the entry away) after the update run has finished.
+class UpdateError {
+  final int mangaId;
+  final String name;
+  final String error;
+
+  const UpdateError({
+    required this.mangaId,
+    required this.name,
+    required this.error,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'mangaId': mangaId,
+    'name': name,
+    'error': error,
+  };
+
+  factory UpdateError.fromJson(Map<dynamic, dynamic> json) => UpdateError(
+    mangaId: json['mangaId'] as int,
+    name: (json['name'] ?? '') as String,
+    error: (json['error'] ?? '') as String,
+  );
+}
+
+const _boxName = 'update_errors';
+const _key = 'errors';
+
+/// Opens the backing box. Called once at startup (see main.dart).
+Future<void> openUpdateErrorsBox() async {
+  if (!Hive.isBoxOpen(_boxName)) {
+    await Hive.openBox(_boxName);
+  }
+}
+
+/// The last library update's failures, persisted across restarts so they can be
+/// reviewed on the [UpdateErrorsScreen] rather than only in a transient dialog.
+final updateErrorsProvider =
+    NotifierProvider<UpdateErrorsNotifier, List<UpdateError>>(
+      UpdateErrorsNotifier.new,
+    );
+
+class UpdateErrorsNotifier extends Notifier<List<UpdateError>> {
+  @override
+  List<UpdateError> build() => _read();
+
+  List<UpdateError> _read() {
+    if (Hive.isBoxOpen(_boxName)) {
+      final raw = Hive.box(_boxName).get(_key);
+      if (raw is String && raw.isNotEmpty) {
+        try {
+          return (jsonDecode(raw) as List)
+              .map((e) => UpdateError.fromJson(e as Map))
+              .toList();
+        } catch (_) {}
+      }
+    }
+    return [];
+  }
+
+  /// Replaces the stored failures with the latest update run's results.
+  void set(List<UpdateError> errors) {
+    state = errors;
+    _persist();
+  }
+
+  /// Drops a single entry (e.g. after the user migrated or handled it).
+  void remove(int mangaId) {
+    state = state.where((e) => e.mangaId != mangaId).toList();
+    _persist();
+  }
+
+  void clear() {
+    state = [];
+    _persist();
+  }
+
+  void _persist() {
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(
+        _boxName,
+      ).put(_key, jsonEncode(state.map((e) => e.toJson()).toList()));
+    }
+  }
+}


### PR DESCRIPTION
Combines the two library-update-failure surfacing PRs into one, since they cover the same feature from two angles and both touched `library_updater.dart`.

- **Persistent update-errors screen:** record each run's failures to a provider and show them on a dedicated screen reachable from the Updates tab, where each entry can be dismissed or migrated away.
- **Dismissible dialog (#623):** at the end of a run, also surface the same failures in a dismissible dialog (lazy `ListView` so a large failure list stays cheap), so they aren't missed in a transient toast. Closes #623.

The failures are persisted on the Isar `Settings` collection (`UpdateError` `@embedded`), matching how the app stores its other preferences, so they survive a restart.

Both read the one `failures` list, so the dialog and the screen stay in sync. Replaces #779 and #767 (closed in favour of this).

