### PR TITLE
feat(downloads): rearrange the download queue (#514)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,7 +35,6 @@ import 'package:mangayomi/services/http/m_client.dart';
 import 'package:mangayomi/services/isolate_service.dart';
 import 'package:mangayomi/services/m_extension_server.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
-import 'package:mangayomi/services/download_manager/download_queue_order.dart';
 import 'package:mangayomi/src/rust/frb_generated.dart';
 import 'package:mangayomi/utils/discord_rpc.dart';
 import 'package:mangayomi/utils/log/logger.dart';
@@ -178,7 +177,6 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
-  await DownloadQueueOrder.openBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,7 @@ import 'package:mangayomi/services/http/m_client.dart';
 import 'package:mangayomi/services/isolate_service.dart';
 import 'package:mangayomi/services/m_extension_server.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
+import 'package:mangayomi/services/download_manager/download_queue_order.dart';
 import 'package:mangayomi/src/rust/frb_generated.dart';
 import 'package:mangayomi/utils/discord_rpc.dart';
 import 'package:mangayomi/utils/log/logger.dart';
@@ -177,6 +178,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await DownloadQueueOrder.openBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -93,6 +93,9 @@ class Settings {
 
   String? downloadLocation;
 
+  /// User's manual download-queue order (Download ids, highest priority first).
+  List<int>? downloadQueueOrder;
+
   List<FilterScanlator>? filterScanlatorList;
 
   final sources = IsarLinks<Source>();
@@ -448,6 +451,7 @@ class Settings {
     this.personalPageModeList,
     this.backupFrequency,
     this.backupListOptions,
+    this.downloadQueueOrder,
     this.autoBackupLocation,
     this.startDatebackup,
     this.usePageTapZones = true,
@@ -704,6 +708,7 @@ class Settings {
     userAgent = json['userAgent'];
     backupFrequency = json['backupFrequency'];
     backupListOptions = json['backupListOptions']?.cast<int>();
+    downloadQueueOrder = json['downloadQueueOrder']?.cast<int>();
     autoBackupLocation = json['autoBackupLocation'];
     startDatebackup = json['startDatebackup'];
     usePageTapZones = json['usePageTapZones'];
@@ -959,6 +964,7 @@ class Settings {
     'userAgent': userAgent,
     'backupFrequency': backupFrequency,
     'backupListOptions': backupListOptions,
+    'downloadQueueOrder': downloadQueueOrder,
     'autoBackupLocation': autoBackupLocation,
     'startDatebackup': startDatebackup,
     'usePageTapZones': usePageTapZones,

--- a/lib/models/settings.g.dart
+++ b/lib/models/settings.g.dart
@@ -332,682 +332,687 @@ const SettingsSchema = CollectionSchema(
       name: r'downloadOnlyOnWifi',
       type: IsarType.bool,
     ),
-    r'downloadedOnlyMode': PropertySchema(
+    r'downloadQueueOrder': PropertySchema(
       id: 57,
+      name: r'downloadQueueOrder',
+      type: IsarType.longList,
+    ),
+    r'downloadedOnlyMode': PropertySchema(
+      id: 58,
       name: r'downloadedOnlyMode',
       type: IsarType.bool,
     ),
     r'dualPageInvert': PropertySchema(
-      id: 58,
+      id: 59,
       name: r'dualPageInvert',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFit': PropertySchema(
-      id: 59,
+      id: 60,
       name: r'dualPageRotateToFit',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFitInvert': PropertySchema(
-      id: 60,
+      id: 61,
       name: r'dualPageRotateToFitInvert',
       type: IsarType.bool,
     ),
     r'enableAniSkip': PropertySchema(
-      id: 61,
+      id: 62,
       name: r'enableAniSkip',
       type: IsarType.bool,
     ),
     r'enableAudioPitchCorrection': PropertySchema(
-      id: 62,
+      id: 63,
       name: r'enableAudioPitchCorrection',
       type: IsarType.bool,
     ),
     r'enableAutoSkip': PropertySchema(
-      id: 63,
+      id: 64,
       name: r'enableAutoSkip',
       type: IsarType.bool,
     ),
     r'enableCustomColorFilter': PropertySchema(
-      id: 64,
+      id: 65,
       name: r'enableCustomColorFilter',
       type: IsarType.bool,
     ),
     r'enableDiscordRpc': PropertySchema(
-      id: 65,
+      id: 66,
       name: r'enableDiscordRpc',
       type: IsarType.bool,
     ),
     r'enableGpuNext': PropertySchema(
-      id: 66,
+      id: 67,
       name: r'enableGpuNext',
       type: IsarType.bool,
     ),
     r'enableHardwareAcceleration': PropertySchema(
-      id: 67,
+      id: 68,
       name: r'enableHardwareAcceleration',
       type: IsarType.bool,
     ),
     r'enableLogs': PropertySchema(
-      id: 68,
+      id: 69,
       name: r'enableLogs',
       type: IsarType.bool,
     ),
     r'extensionServerPath': PropertySchema(
-      id: 69,
+      id: 70,
       name: r'extensionServerPath',
       type: IsarType.string,
     ),
     r'filterScanlatorList': PropertySchema(
-      id: 70,
+      id: 71,
       name: r'filterScanlatorList',
       type: IsarType.objectList,
 
       target: r'FilterScanlator',
     ),
     r'flashColor': PropertySchema(
-      id: 71,
+      id: 72,
       name: r'flashColor',
       type: IsarType.long,
     ),
     r'flashDuration': PropertySchema(
-      id: 72,
+      id: 73,
       name: r'flashDuration',
       type: IsarType.long,
     ),
     r'flashInterval': PropertySchema(
-      id: 73,
+      id: 74,
       name: r'flashInterval',
       type: IsarType.long,
     ),
     r'flashOnPageChange': PropertySchema(
-      id: 74,
+      id: 75,
       name: r'flashOnPageChange',
       type: IsarType.bool,
     ),
     r'flexColorSchemeBlendLevel': PropertySchema(
-      id: 75,
+      id: 76,
       name: r'flexColorSchemeBlendLevel',
       type: IsarType.double,
     ),
     r'flexSchemeColorIndex': PropertySchema(
-      id: 76,
+      id: 77,
       name: r'flexSchemeColorIndex',
       type: IsarType.long,
     ),
     r'followSystemTheme': PropertySchema(
-      id: 77,
+      id: 78,
       name: r'followSystemTheme',
       type: IsarType.bool,
     ),
     r'forceLandscapePlayer': PropertySchema(
-      id: 78,
+      id: 79,
       name: r'forceLandscapePlayer',
       type: IsarType.bool,
     ),
     r'fullScreenPlayer': PropertySchema(
-      id: 79,
+      id: 80,
       name: r'fullScreenPlayer',
       type: IsarType.bool,
     ),
     r'fullScreenReader': PropertySchema(
-      id: 80,
+      id: 81,
       name: r'fullScreenReader',
       type: IsarType.bool,
     ),
     r'grayscale': PropertySchema(
-      id: 81,
+      id: 82,
       name: r'grayscale',
       type: IsarType.bool,
     ),
     r'hideDiscordRpcInIncognito': PropertySchema(
-      id: 82,
+      id: 83,
       name: r'hideDiscordRpcInIncognito',
       type: IsarType.bool,
     ),
     r'hideItems': PropertySchema(
-      id: 83,
+      id: 84,
       name: r'hideItems',
       type: IsarType.stringList,
     ),
     r'hwdecMode': PropertySchema(
-      id: 84,
+      id: 85,
       name: r'hwdecMode',
       type: IsarType.string,
     ),
     r'incognitoMode': PropertySchema(
-      id: 85,
+      id: 86,
       name: r'incognitoMode',
       type: IsarType.bool,
     ),
     r'invertColors': PropertySchema(
-      id: 86,
+      id: 87,
       name: r'invertColors',
       type: IsarType.bool,
     ),
-    r'jrePath': PropertySchema(id: 87, name: r'jrePath', type: IsarType.string),
+    r'jrePath': PropertySchema(id: 88, name: r'jrePath', type: IsarType.string),
     r'keepScreenOnReader': PropertySchema(
-      id: 88,
+      id: 89,
       name: r'keepScreenOnReader',
       type: IsarType.bool,
     ),
     r'landscapeZoom': PropertySchema(
-      id: 89,
+      id: 90,
       name: r'landscapeZoom',
       type: IsarType.bool,
     ),
     r'lastTrackerLibraryLocation': PropertySchema(
-      id: 90,
+      id: 91,
       name: r'lastTrackerLibraryLocation',
       type: IsarType.string,
     ),
     r'libraryDownloadedChapters': PropertySchema(
-      id: 91,
+      id: 92,
       name: r'libraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'libraryFilterAnimeBookMarkedType': PropertySchema(
-      id: 92,
+      id: 93,
       name: r'libraryFilterAnimeBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeCompletedType': PropertySchema(
-      id: 93,
+      id: 94,
       name: r'libraryFilterAnimeCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeDownloadType': PropertySchema(
-      id: 94,
+      id: 95,
       name: r'libraryFilterAnimeDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeStartedType': PropertySchema(
-      id: 95,
+      id: 96,
       name: r'libraryFilterAnimeStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeTrackingType': PropertySchema(
-      id: 96,
+      id: 97,
       name: r'libraryFilterAnimeTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeUnreadType': PropertySchema(
-      id: 97,
+      id: 98,
       name: r'libraryFilterAnimeUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasBookMarkedType': PropertySchema(
-      id: 98,
+      id: 99,
       name: r'libraryFilterMangasBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasCompletedType': PropertySchema(
-      id: 99,
+      id: 100,
       name: r'libraryFilterMangasCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasDownloadType': PropertySchema(
-      id: 100,
+      id: 101,
       name: r'libraryFilterMangasDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasStartedType': PropertySchema(
-      id: 101,
+      id: 102,
       name: r'libraryFilterMangasStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasTrackingType': PropertySchema(
-      id: 102,
+      id: 103,
       name: r'libraryFilterMangasTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasUnreadType': PropertySchema(
-      id: 103,
+      id: 104,
       name: r'libraryFilterMangasUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelBookMarkedType': PropertySchema(
-      id: 104,
+      id: 105,
       name: r'libraryFilterNovelBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelCompletedType': PropertySchema(
-      id: 105,
+      id: 106,
       name: r'libraryFilterNovelCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelDownloadType': PropertySchema(
-      id: 106,
+      id: 107,
       name: r'libraryFilterNovelDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelStartedType': PropertySchema(
-      id: 107,
+      id: 108,
       name: r'libraryFilterNovelStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelTrackingType': PropertySchema(
-      id: 108,
+      id: 109,
       name: r'libraryFilterNovelTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelUnreadType': PropertySchema(
-      id: 109,
+      id: 110,
       name: r'libraryFilterNovelUnreadType',
       type: IsarType.long,
     ),
     r'libraryLocalSource': PropertySchema(
-      id: 110,
+      id: 111,
       name: r'libraryLocalSource',
       type: IsarType.bool,
     ),
     r'libraryShowCategoryTabs': PropertySchema(
-      id: 111,
+      id: 112,
       name: r'libraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'libraryShowContinueReadingButton': PropertySchema(
-      id: 112,
+      id: 113,
       name: r'libraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'libraryShowLanguage': PropertySchema(
-      id: 113,
+      id: 114,
       name: r'libraryShowLanguage',
       type: IsarType.bool,
     ),
     r'libraryShowNumbersOfItems': PropertySchema(
-      id: 114,
+      id: 115,
       name: r'libraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'localFolders': PropertySchema(
-      id: 115,
+      id: 116,
       name: r'localFolders',
       type: IsarType.stringList,
     ),
     r'locale': PropertySchema(
-      id: 116,
+      id: 117,
       name: r'locale',
       type: IsarType.object,
 
       target: r'L10nLocale',
     ),
     r'mangaExtensionsRepo': PropertySchema(
-      id: 117,
+      id: 118,
       name: r'mangaExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'mangaGridSize': PropertySchema(
-      id: 118,
+      id: 119,
       name: r'mangaGridSize',
       type: IsarType.long,
     ),
     r'mangaHomeDisplayType': PropertySchema(
-      id: 119,
+      id: 120,
       name: r'mangaHomeDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsmangaHomeDisplayTypeEnumValueMap,
     ),
     r'markEpisodeAsSeenType': PropertySchema(
-      id: 120,
+      id: 121,
       name: r'markEpisodeAsSeenType',
       type: IsarType.long,
     ),
     r'mergeLibraryNavMobile': PropertySchema(
-      id: 121,
+      id: 122,
       name: r'mergeLibraryNavMobile',
       type: IsarType.bool,
     ),
     r'navigateToPan': PropertySchema(
-      id: 122,
+      id: 123,
       name: r'navigateToPan',
       type: IsarType.bool,
     ),
     r'navigationOrder': PropertySchema(
-      id: 123,
+      id: 124,
       name: r'navigationOrder',
       type: IsarType.stringList,
     ),
     r'novelDisplayType': PropertySchema(
-      id: 124,
+      id: 125,
       name: r'novelDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsnovelDisplayTypeEnumValueMap,
     ),
     r'novelExtensionsRepo': PropertySchema(
-      id: 125,
+      id: 126,
       name: r'novelExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'novelFontSize': PropertySchema(
-      id: 126,
+      id: 127,
       name: r'novelFontSize',
       type: IsarType.long,
     ),
     r'novelGridSize': PropertySchema(
-      id: 127,
+      id: 128,
       name: r'novelGridSize',
       type: IsarType.long,
     ),
     r'novelLibraryDownloadedChapters': PropertySchema(
-      id: 128,
+      id: 129,
       name: r'novelLibraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'novelLibraryLocalSource': PropertySchema(
-      id: 129,
+      id: 130,
       name: r'novelLibraryLocalSource',
       type: IsarType.bool,
     ),
     r'novelLibraryShowCategoryTabs': PropertySchema(
-      id: 130,
+      id: 131,
       name: r'novelLibraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'novelLibraryShowContinueReadingButton': PropertySchema(
-      id: 131,
+      id: 132,
       name: r'novelLibraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'novelLibraryShowLanguage': PropertySchema(
-      id: 132,
+      id: 133,
       name: r'novelLibraryShowLanguage',
       type: IsarType.bool,
     ),
     r'novelLibraryShowNumbersOfItems': PropertySchema(
-      id: 133,
+      id: 134,
       name: r'novelLibraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'novelReaderLineHeight': PropertySchema(
-      id: 134,
+      id: 135,
       name: r'novelReaderLineHeight',
       type: IsarType.double,
     ),
     r'novelReaderPadding': PropertySchema(
-      id: 135,
+      id: 136,
       name: r'novelReaderPadding',
       type: IsarType.long,
     ),
     r'novelReaderTextColor': PropertySchema(
-      id: 136,
+      id: 137,
       name: r'novelReaderTextColor',
       type: IsarType.string,
     ),
     r'novelReaderTheme': PropertySchema(
-      id: 137,
+      id: 138,
       name: r'novelReaderTheme',
       type: IsarType.string,
     ),
     r'novelRemoveExtraParagraphSpacing': PropertySchema(
-      id: 138,
+      id: 139,
       name: r'novelRemoveExtraParagraphSpacing',
       type: IsarType.bool,
     ),
     r'novelShowScrollPercentage': PropertySchema(
-      id: 139,
+      id: 140,
       name: r'novelShowScrollPercentage',
       type: IsarType.bool,
     ),
     r'novelTapToScroll': PropertySchema(
-      id: 140,
+      id: 141,
       name: r'novelTapToScroll',
       type: IsarType.bool,
     ),
     r'novelTextAlign': PropertySchema(
-      id: 141,
+      id: 142,
       name: r'novelTextAlign',
       type: IsarType.byte,
       enumMap: _SettingsnovelTextAlignEnumValueMap,
     ),
     r'onlyIncludePinnedSources': PropertySchema(
-      id: 142,
+      id: 143,
       name: r'onlyIncludePinnedSources',
       type: IsarType.bool,
     ),
     r'pagePreloadAmount': PropertySchema(
-      id: 143,
+      id: 144,
       name: r'pagePreloadAmount',
       type: IsarType.long,
     ),
     r'personalPageModeList': PropertySchema(
-      id: 144,
+      id: 145,
       name: r'personalPageModeList',
       type: IsarType.objectList,
 
       target: r'PersonalPageMode',
     ),
     r'personalReaderModeList': PropertySchema(
-      id: 145,
+      id: 146,
       name: r'personalReaderModeList',
       type: IsarType.objectList,
 
       target: r'PersonalReaderMode',
     ),
     r'playerSubtitleSettings': PropertySchema(
-      id: 146,
+      id: 147,
       name: r'playerSubtitleSettings',
       type: IsarType.object,
 
       target: r'PlayerSubtitleSettings',
     ),
     r'pureBlackDarkMode': PropertySchema(
-      id: 147,
+      id: 148,
       name: r'pureBlackDarkMode',
       type: IsarType.bool,
     ),
     r'readerBrightness': PropertySchema(
-      id: 148,
+      id: 149,
       name: r'readerBrightness',
       type: IsarType.double,
     ),
     r'readerContrast': PropertySchema(
-      id: 149,
+      id: 150,
       name: r'readerContrast',
       type: IsarType.double,
     ),
     r'readerHideThreshold': PropertySchema(
-      id: 150,
+      id: 151,
       name: r'readerHideThreshold',
       type: IsarType.long,
     ),
     r'readerNavigationLayout': PropertySchema(
-      id: 151,
+      id: 152,
       name: r'readerNavigationLayout',
       type: IsarType.long,
     ),
     r'readerSaturation': PropertySchema(
-      id: 152,
+      id: 153,
       name: r'readerSaturation',
       type: IsarType.double,
     ),
     r'relativeTimesTamps': PropertySchema(
-      id: 153,
+      id: 154,
       name: r'relativeTimesTamps',
       type: IsarType.long,
     ),
     r'rpcShowCoverImage': PropertySchema(
-      id: 154,
+      id: 155,
       name: r'rpcShowCoverImage',
       type: IsarType.bool,
     ),
     r'rpcShowReadingWatchingProgress': PropertySchema(
-      id: 155,
+      id: 156,
       name: r'rpcShowReadingWatchingProgress',
       type: IsarType.bool,
     ),
     r'rpcShowTitle': PropertySchema(
-      id: 156,
+      id: 157,
       name: r'rpcShowTitle',
       type: IsarType.bool,
     ),
     r'saveAsCBZArchive': PropertySchema(
-      id: 157,
+      id: 158,
       name: r'saveAsCBZArchive',
       type: IsarType.bool,
     ),
     r'scaleType': PropertySchema(
-      id: 158,
+      id: 159,
       name: r'scaleType',
       type: IsarType.byte,
       enumMap: _SettingsscaleTypeEnumValueMap,
     ),
     r'showNSFW': PropertySchema(
-      id: 159,
+      id: 160,
       name: r'showNSFW',
       type: IsarType.bool,
     ),
     r'showNavigationOverlayOnStart': PropertySchema(
-      id: 160,
+      id: 161,
       name: r'showNavigationOverlayOnStart',
       type: IsarType.bool,
     ),
     r'showPageGaps': PropertySchema(
-      id: 161,
+      id: 162,
       name: r'showPageGaps',
       type: IsarType.bool,
     ),
     r'showPagesNumber': PropertySchema(
-      id: 162,
+      id: 163,
       name: r'showPagesNumber',
       type: IsarType.bool,
     ),
     r'sortChapterList': PropertySchema(
-      id: 163,
+      id: 164,
       name: r'sortChapterList',
       type: IsarType.objectList,
 
       target: r'SortChapter',
     ),
     r'sortLibraryAnime': PropertySchema(
-      id: 164,
+      id: 165,
       name: r'sortLibraryAnime',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryManga': PropertySchema(
-      id: 165,
+      id: 166,
       name: r'sortLibraryManga',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryNovel': PropertySchema(
-      id: 166,
+      id: 167,
       name: r'sortLibraryNovel',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'splitWidePages': PropertySchema(
-      id: 167,
+      id: 168,
       name: r'splitWidePages',
       type: IsarType.bool,
     ),
     r'startDatebackup': PropertySchema(
-      id: 168,
+      id: 169,
       name: r'startDatebackup',
       type: IsarType.long,
     ),
     r'tappingInversion': PropertySchema(
-      id: 169,
+      id: 170,
       name: r'tappingInversion',
       type: IsarType.long,
     ),
     r'themeIsDark': PropertySchema(
-      id: 170,
+      id: 171,
       name: r'themeIsDark',
       type: IsarType.bool,
     ),
     r'ttsLanguage': PropertySchema(
-      id: 171,
+      id: 172,
       name: r'ttsLanguage',
       type: IsarType.string,
     ),
     r'ttsPitch': PropertySchema(
-      id: 172,
+      id: 173,
       name: r'ttsPitch',
       type: IsarType.double,
     ),
     r'ttsSpeechRate': PropertySchema(
-      id: 173,
+      id: 174,
       name: r'ttsSpeechRate',
       type: IsarType.double,
     ),
     r'ttsVoice': PropertySchema(
-      id: 174,
+      id: 175,
       name: r'ttsVoice',
       type: IsarType.string,
     ),
     r'updateErrorsList': PropertySchema(
-      id: 175,
+      id: 176,
       name: r'updateErrorsList',
       type: IsarType.objectList,
 
       target: r'UpdateError',
     ),
     r'updateProgressAfterReading': PropertySchema(
-      id: 176,
+      id: 177,
       name: r'updateProgressAfterReading',
       type: IsarType.bool,
     ),
     r'updatedAt': PropertySchema(
-      id: 177,
+      id: 178,
       name: r'updatedAt',
       type: IsarType.long,
     ),
     r'useLibass': PropertySchema(
-      id: 178,
+      id: 179,
       name: r'useLibass',
       type: IsarType.bool,
     ),
     r'useMpvConfig': PropertySchema(
-      id: 179,
+      id: 180,
       name: r'useMpvConfig',
       type: IsarType.bool,
     ),
     r'usePageTapZones': PropertySchema(
-      id: 180,
+      id: 181,
       name: r'usePageTapZones',
       type: IsarType.bool,
     ),
     r'useYUV420P': PropertySchema(
-      id: 181,
+      id: 182,
       name: r'useYUV420P',
       type: IsarType.bool,
     ),
     r'userAgent': PropertySchema(
-      id: 182,
+      id: 183,
       name: r'userAgent',
       type: IsarType.string,
     ),
     r'volumeBoostCap': PropertySchema(
-      id: 183,
+      id: 184,
       name: r'volumeBoostCap',
       type: IsarType.long,
     ),
     r'webtoonDisableZoomOut': PropertySchema(
-      id: 184,
+      id: 185,
       name: r'webtoonDisableZoomOut',
       type: IsarType.bool,
     ),
     r'webtoonDoubleTapZoomEnabled': PropertySchema(
-      id: 185,
+      id: 186,
       name: r'webtoonDoubleTapZoomEnabled',
       type: IsarType.bool,
     ),
     r'webtoonSidePadding': PropertySchema(
-      id: 186,
+      id: 187,
       name: r'webtoonSidePadding',
       type: IsarType.long,
     ),
     r'zoomStartPosition': PropertySchema(
-      id: 187,
+      id: 188,
       name: r'zoomStartPosition',
       type: IsarType.long,
     ),
@@ -1276,6 +1281,12 @@ int _settingsEstimateSize(
     final value = object.downloadLocation;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.downloadQueueOrder;
+    if (value != null) {
+      bytesCount += 3 + value.length * 8;
     }
   }
   {
@@ -1660,197 +1671,198 @@ void _settingsSerialize(
   writer.writeLong(offsets[54], object.doubleTapAnimationSpeed);
   writer.writeString(offsets[55], object.downloadLocation);
   writer.writeBool(offsets[56], object.downloadOnlyOnWifi);
-  writer.writeBool(offsets[57], object.downloadedOnlyMode);
-  writer.writeBool(offsets[58], object.dualPageInvert);
-  writer.writeBool(offsets[59], object.dualPageRotateToFit);
-  writer.writeBool(offsets[60], object.dualPageRotateToFitInvert);
-  writer.writeBool(offsets[61], object.enableAniSkip);
-  writer.writeBool(offsets[62], object.enableAudioPitchCorrection);
-  writer.writeBool(offsets[63], object.enableAutoSkip);
-  writer.writeBool(offsets[64], object.enableCustomColorFilter);
-  writer.writeBool(offsets[65], object.enableDiscordRpc);
-  writer.writeBool(offsets[66], object.enableGpuNext);
-  writer.writeBool(offsets[67], object.enableHardwareAcceleration);
-  writer.writeBool(offsets[68], object.enableLogs);
-  writer.writeString(offsets[69], object.extensionServerPath);
+  writer.writeLongList(offsets[57], object.downloadQueueOrder);
+  writer.writeBool(offsets[58], object.downloadedOnlyMode);
+  writer.writeBool(offsets[59], object.dualPageInvert);
+  writer.writeBool(offsets[60], object.dualPageRotateToFit);
+  writer.writeBool(offsets[61], object.dualPageRotateToFitInvert);
+  writer.writeBool(offsets[62], object.enableAniSkip);
+  writer.writeBool(offsets[63], object.enableAudioPitchCorrection);
+  writer.writeBool(offsets[64], object.enableAutoSkip);
+  writer.writeBool(offsets[65], object.enableCustomColorFilter);
+  writer.writeBool(offsets[66], object.enableDiscordRpc);
+  writer.writeBool(offsets[67], object.enableGpuNext);
+  writer.writeBool(offsets[68], object.enableHardwareAcceleration);
+  writer.writeBool(offsets[69], object.enableLogs);
+  writer.writeString(offsets[70], object.extensionServerPath);
   writer.writeObjectList<FilterScanlator>(
-    offsets[70],
+    offsets[71],
     allOffsets,
     FilterScanlatorSchema.serialize,
     object.filterScanlatorList,
   );
-  writer.writeLong(offsets[71], object.flashColor);
-  writer.writeLong(offsets[72], object.flashDuration);
-  writer.writeLong(offsets[73], object.flashInterval);
-  writer.writeBool(offsets[74], object.flashOnPageChange);
-  writer.writeDouble(offsets[75], object.flexColorSchemeBlendLevel);
-  writer.writeLong(offsets[76], object.flexSchemeColorIndex);
-  writer.writeBool(offsets[77], object.followSystemTheme);
-  writer.writeBool(offsets[78], object.forceLandscapePlayer);
-  writer.writeBool(offsets[79], object.fullScreenPlayer);
-  writer.writeBool(offsets[80], object.fullScreenReader);
-  writer.writeBool(offsets[81], object.grayscale);
-  writer.writeBool(offsets[82], object.hideDiscordRpcInIncognito);
-  writer.writeStringList(offsets[83], object.hideItems);
-  writer.writeString(offsets[84], object.hwdecMode);
-  writer.writeBool(offsets[85], object.incognitoMode);
-  writer.writeBool(offsets[86], object.invertColors);
-  writer.writeString(offsets[87], object.jrePath);
-  writer.writeBool(offsets[88], object.keepScreenOnReader);
-  writer.writeBool(offsets[89], object.landscapeZoom);
-  writer.writeString(offsets[90], object.lastTrackerLibraryLocation);
-  writer.writeBool(offsets[91], object.libraryDownloadedChapters);
-  writer.writeLong(offsets[92], object.libraryFilterAnimeBookMarkedType);
-  writer.writeLong(offsets[93], object.libraryFilterAnimeCompletedType);
-  writer.writeLong(offsets[94], object.libraryFilterAnimeDownloadType);
-  writer.writeLong(offsets[95], object.libraryFilterAnimeStartedType);
-  writer.writeLong(offsets[96], object.libraryFilterAnimeTrackingType);
-  writer.writeLong(offsets[97], object.libraryFilterAnimeUnreadType);
-  writer.writeLong(offsets[98], object.libraryFilterMangasBookMarkedType);
-  writer.writeLong(offsets[99], object.libraryFilterMangasCompletedType);
-  writer.writeLong(offsets[100], object.libraryFilterMangasDownloadType);
-  writer.writeLong(offsets[101], object.libraryFilterMangasStartedType);
-  writer.writeLong(offsets[102], object.libraryFilterMangasTrackingType);
-  writer.writeLong(offsets[103], object.libraryFilterMangasUnreadType);
-  writer.writeLong(offsets[104], object.libraryFilterNovelBookMarkedType);
-  writer.writeLong(offsets[105], object.libraryFilterNovelCompletedType);
-  writer.writeLong(offsets[106], object.libraryFilterNovelDownloadType);
-  writer.writeLong(offsets[107], object.libraryFilterNovelStartedType);
-  writer.writeLong(offsets[108], object.libraryFilterNovelTrackingType);
-  writer.writeLong(offsets[109], object.libraryFilterNovelUnreadType);
-  writer.writeBool(offsets[110], object.libraryLocalSource);
-  writer.writeBool(offsets[111], object.libraryShowCategoryTabs);
-  writer.writeBool(offsets[112], object.libraryShowContinueReadingButton);
-  writer.writeBool(offsets[113], object.libraryShowLanguage);
-  writer.writeBool(offsets[114], object.libraryShowNumbersOfItems);
-  writer.writeStringList(offsets[115], object.localFolders);
+  writer.writeLong(offsets[72], object.flashColor);
+  writer.writeLong(offsets[73], object.flashDuration);
+  writer.writeLong(offsets[74], object.flashInterval);
+  writer.writeBool(offsets[75], object.flashOnPageChange);
+  writer.writeDouble(offsets[76], object.flexColorSchemeBlendLevel);
+  writer.writeLong(offsets[77], object.flexSchemeColorIndex);
+  writer.writeBool(offsets[78], object.followSystemTheme);
+  writer.writeBool(offsets[79], object.forceLandscapePlayer);
+  writer.writeBool(offsets[80], object.fullScreenPlayer);
+  writer.writeBool(offsets[81], object.fullScreenReader);
+  writer.writeBool(offsets[82], object.grayscale);
+  writer.writeBool(offsets[83], object.hideDiscordRpcInIncognito);
+  writer.writeStringList(offsets[84], object.hideItems);
+  writer.writeString(offsets[85], object.hwdecMode);
+  writer.writeBool(offsets[86], object.incognitoMode);
+  writer.writeBool(offsets[87], object.invertColors);
+  writer.writeString(offsets[88], object.jrePath);
+  writer.writeBool(offsets[89], object.keepScreenOnReader);
+  writer.writeBool(offsets[90], object.landscapeZoom);
+  writer.writeString(offsets[91], object.lastTrackerLibraryLocation);
+  writer.writeBool(offsets[92], object.libraryDownloadedChapters);
+  writer.writeLong(offsets[93], object.libraryFilterAnimeBookMarkedType);
+  writer.writeLong(offsets[94], object.libraryFilterAnimeCompletedType);
+  writer.writeLong(offsets[95], object.libraryFilterAnimeDownloadType);
+  writer.writeLong(offsets[96], object.libraryFilterAnimeStartedType);
+  writer.writeLong(offsets[97], object.libraryFilterAnimeTrackingType);
+  writer.writeLong(offsets[98], object.libraryFilterAnimeUnreadType);
+  writer.writeLong(offsets[99], object.libraryFilterMangasBookMarkedType);
+  writer.writeLong(offsets[100], object.libraryFilterMangasCompletedType);
+  writer.writeLong(offsets[101], object.libraryFilterMangasDownloadType);
+  writer.writeLong(offsets[102], object.libraryFilterMangasStartedType);
+  writer.writeLong(offsets[103], object.libraryFilterMangasTrackingType);
+  writer.writeLong(offsets[104], object.libraryFilterMangasUnreadType);
+  writer.writeLong(offsets[105], object.libraryFilterNovelBookMarkedType);
+  writer.writeLong(offsets[106], object.libraryFilterNovelCompletedType);
+  writer.writeLong(offsets[107], object.libraryFilterNovelDownloadType);
+  writer.writeLong(offsets[108], object.libraryFilterNovelStartedType);
+  writer.writeLong(offsets[109], object.libraryFilterNovelTrackingType);
+  writer.writeLong(offsets[110], object.libraryFilterNovelUnreadType);
+  writer.writeBool(offsets[111], object.libraryLocalSource);
+  writer.writeBool(offsets[112], object.libraryShowCategoryTabs);
+  writer.writeBool(offsets[113], object.libraryShowContinueReadingButton);
+  writer.writeBool(offsets[114], object.libraryShowLanguage);
+  writer.writeBool(offsets[115], object.libraryShowNumbersOfItems);
+  writer.writeStringList(offsets[116], object.localFolders);
   writer.writeObject<L10nLocale>(
-    offsets[116],
+    offsets[117],
     allOffsets,
     L10nLocaleSchema.serialize,
     object.locale,
   );
   writer.writeObjectList<Repo>(
-    offsets[117],
+    offsets[118],
     allOffsets,
     RepoSchema.serialize,
     object.mangaExtensionsRepo,
   );
-  writer.writeLong(offsets[118], object.mangaGridSize);
-  writer.writeByte(offsets[119], object.mangaHomeDisplayType.index);
-  writer.writeLong(offsets[120], object.markEpisodeAsSeenType);
-  writer.writeBool(offsets[121], object.mergeLibraryNavMobile);
-  writer.writeBool(offsets[122], object.navigateToPan);
-  writer.writeStringList(offsets[123], object.navigationOrder);
-  writer.writeByte(offsets[124], object.novelDisplayType.index);
+  writer.writeLong(offsets[119], object.mangaGridSize);
+  writer.writeByte(offsets[120], object.mangaHomeDisplayType.index);
+  writer.writeLong(offsets[121], object.markEpisodeAsSeenType);
+  writer.writeBool(offsets[122], object.mergeLibraryNavMobile);
+  writer.writeBool(offsets[123], object.navigateToPan);
+  writer.writeStringList(offsets[124], object.navigationOrder);
+  writer.writeByte(offsets[125], object.novelDisplayType.index);
   writer.writeObjectList<Repo>(
-    offsets[125],
+    offsets[126],
     allOffsets,
     RepoSchema.serialize,
     object.novelExtensionsRepo,
   );
-  writer.writeLong(offsets[126], object.novelFontSize);
-  writer.writeLong(offsets[127], object.novelGridSize);
-  writer.writeBool(offsets[128], object.novelLibraryDownloadedChapters);
-  writer.writeBool(offsets[129], object.novelLibraryLocalSource);
-  writer.writeBool(offsets[130], object.novelLibraryShowCategoryTabs);
-  writer.writeBool(offsets[131], object.novelLibraryShowContinueReadingButton);
-  writer.writeBool(offsets[132], object.novelLibraryShowLanguage);
-  writer.writeBool(offsets[133], object.novelLibraryShowNumbersOfItems);
-  writer.writeDouble(offsets[134], object.novelReaderLineHeight);
-  writer.writeLong(offsets[135], object.novelReaderPadding);
-  writer.writeString(offsets[136], object.novelReaderTextColor);
-  writer.writeString(offsets[137], object.novelReaderTheme);
-  writer.writeBool(offsets[138], object.novelRemoveExtraParagraphSpacing);
-  writer.writeBool(offsets[139], object.novelShowScrollPercentage);
-  writer.writeBool(offsets[140], object.novelTapToScroll);
-  writer.writeByte(offsets[141], object.novelTextAlign.index);
-  writer.writeBool(offsets[142], object.onlyIncludePinnedSources);
-  writer.writeLong(offsets[143], object.pagePreloadAmount);
+  writer.writeLong(offsets[127], object.novelFontSize);
+  writer.writeLong(offsets[128], object.novelGridSize);
+  writer.writeBool(offsets[129], object.novelLibraryDownloadedChapters);
+  writer.writeBool(offsets[130], object.novelLibraryLocalSource);
+  writer.writeBool(offsets[131], object.novelLibraryShowCategoryTabs);
+  writer.writeBool(offsets[132], object.novelLibraryShowContinueReadingButton);
+  writer.writeBool(offsets[133], object.novelLibraryShowLanguage);
+  writer.writeBool(offsets[134], object.novelLibraryShowNumbersOfItems);
+  writer.writeDouble(offsets[135], object.novelReaderLineHeight);
+  writer.writeLong(offsets[136], object.novelReaderPadding);
+  writer.writeString(offsets[137], object.novelReaderTextColor);
+  writer.writeString(offsets[138], object.novelReaderTheme);
+  writer.writeBool(offsets[139], object.novelRemoveExtraParagraphSpacing);
+  writer.writeBool(offsets[140], object.novelShowScrollPercentage);
+  writer.writeBool(offsets[141], object.novelTapToScroll);
+  writer.writeByte(offsets[142], object.novelTextAlign.index);
+  writer.writeBool(offsets[143], object.onlyIncludePinnedSources);
+  writer.writeLong(offsets[144], object.pagePreloadAmount);
   writer.writeObjectList<PersonalPageMode>(
-    offsets[144],
+    offsets[145],
     allOffsets,
     PersonalPageModeSchema.serialize,
     object.personalPageModeList,
   );
   writer.writeObjectList<PersonalReaderMode>(
-    offsets[145],
+    offsets[146],
     allOffsets,
     PersonalReaderModeSchema.serialize,
     object.personalReaderModeList,
   );
   writer.writeObject<PlayerSubtitleSettings>(
-    offsets[146],
+    offsets[147],
     allOffsets,
     PlayerSubtitleSettingsSchema.serialize,
     object.playerSubtitleSettings,
   );
-  writer.writeBool(offsets[147], object.pureBlackDarkMode);
-  writer.writeDouble(offsets[148], object.readerBrightness);
-  writer.writeDouble(offsets[149], object.readerContrast);
-  writer.writeLong(offsets[150], object.readerHideThreshold);
-  writer.writeLong(offsets[151], object.readerNavigationLayout);
-  writer.writeDouble(offsets[152], object.readerSaturation);
-  writer.writeLong(offsets[153], object.relativeTimesTamps);
-  writer.writeBool(offsets[154], object.rpcShowCoverImage);
-  writer.writeBool(offsets[155], object.rpcShowReadingWatchingProgress);
-  writer.writeBool(offsets[156], object.rpcShowTitle);
-  writer.writeBool(offsets[157], object.saveAsCBZArchive);
-  writer.writeByte(offsets[158], object.scaleType.index);
-  writer.writeBool(offsets[159], object.showNSFW);
-  writer.writeBool(offsets[160], object.showNavigationOverlayOnStart);
-  writer.writeBool(offsets[161], object.showPageGaps);
-  writer.writeBool(offsets[162], object.showPagesNumber);
+  writer.writeBool(offsets[148], object.pureBlackDarkMode);
+  writer.writeDouble(offsets[149], object.readerBrightness);
+  writer.writeDouble(offsets[150], object.readerContrast);
+  writer.writeLong(offsets[151], object.readerHideThreshold);
+  writer.writeLong(offsets[152], object.readerNavigationLayout);
+  writer.writeDouble(offsets[153], object.readerSaturation);
+  writer.writeLong(offsets[154], object.relativeTimesTamps);
+  writer.writeBool(offsets[155], object.rpcShowCoverImage);
+  writer.writeBool(offsets[156], object.rpcShowReadingWatchingProgress);
+  writer.writeBool(offsets[157], object.rpcShowTitle);
+  writer.writeBool(offsets[158], object.saveAsCBZArchive);
+  writer.writeByte(offsets[159], object.scaleType.index);
+  writer.writeBool(offsets[160], object.showNSFW);
+  writer.writeBool(offsets[161], object.showNavigationOverlayOnStart);
+  writer.writeBool(offsets[162], object.showPageGaps);
+  writer.writeBool(offsets[163], object.showPagesNumber);
   writer.writeObjectList<SortChapter>(
-    offsets[163],
+    offsets[164],
     allOffsets,
     SortChapterSchema.serialize,
     object.sortChapterList,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[164],
+    offsets[165],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryAnime,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[165],
+    offsets[166],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryManga,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[166],
+    offsets[167],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryNovel,
   );
-  writer.writeBool(offsets[167], object.splitWidePages);
-  writer.writeLong(offsets[168], object.startDatebackup);
-  writer.writeLong(offsets[169], object.tappingInversion);
-  writer.writeBool(offsets[170], object.themeIsDark);
-  writer.writeString(offsets[171], object.ttsLanguage);
-  writer.writeDouble(offsets[172], object.ttsPitch);
-  writer.writeDouble(offsets[173], object.ttsSpeechRate);
-  writer.writeString(offsets[174], object.ttsVoice);
+  writer.writeBool(offsets[168], object.splitWidePages);
+  writer.writeLong(offsets[169], object.startDatebackup);
+  writer.writeLong(offsets[170], object.tappingInversion);
+  writer.writeBool(offsets[171], object.themeIsDark);
+  writer.writeString(offsets[172], object.ttsLanguage);
+  writer.writeDouble(offsets[173], object.ttsPitch);
+  writer.writeDouble(offsets[174], object.ttsSpeechRate);
+  writer.writeString(offsets[175], object.ttsVoice);
   writer.writeObjectList<UpdateError>(
-    offsets[175],
+    offsets[176],
     allOffsets,
     UpdateErrorSchema.serialize,
     object.updateErrorsList,
   );
-  writer.writeBool(offsets[176], object.updateProgressAfterReading);
-  writer.writeLong(offsets[177], object.updatedAt);
-  writer.writeBool(offsets[178], object.useLibass);
-  writer.writeBool(offsets[179], object.useMpvConfig);
-  writer.writeBool(offsets[180], object.usePageTapZones);
-  writer.writeBool(offsets[181], object.useYUV420P);
-  writer.writeString(offsets[182], object.userAgent);
-  writer.writeLong(offsets[183], object.volumeBoostCap);
-  writer.writeBool(offsets[184], object.webtoonDisableZoomOut);
-  writer.writeBool(offsets[185], object.webtoonDoubleTapZoomEnabled);
-  writer.writeLong(offsets[186], object.webtoonSidePadding);
-  writer.writeLong(offsets[187], object.zoomStartPosition);
+  writer.writeBool(offsets[177], object.updateProgressAfterReading);
+  writer.writeLong(offsets[178], object.updatedAt);
+  writer.writeBool(offsets[179], object.useLibass);
+  writer.writeBool(offsets[180], object.useMpvConfig);
+  writer.writeBool(offsets[181], object.usePageTapZones);
+  writer.writeBool(offsets[182], object.useYUV420P);
+  writer.writeString(offsets[183], object.userAgent);
+  writer.writeLong(offsets[184], object.volumeBoostCap);
+  writer.writeBool(offsets[185], object.webtoonDisableZoomOut);
+  writer.writeBool(offsets[186], object.webtoonDoubleTapZoomEnabled);
+  writer.writeLong(offsets[187], object.webtoonSidePadding);
+  writer.writeLong(offsets[188], object.zoomStartPosition);
 }
 
 Settings _settingsDeserialize(
@@ -1982,195 +1994,196 @@ Settings _settingsDeserialize(
     doubleTapAnimationSpeed: reader.readLongOrNull(offsets[54]),
     downloadLocation: reader.readStringOrNull(offsets[55]),
     downloadOnlyOnWifi: reader.readBoolOrNull(offsets[56]),
-    downloadedOnlyMode: reader.readBoolOrNull(offsets[57]),
-    dualPageInvert: reader.readBoolOrNull(offsets[58]),
-    dualPageRotateToFit: reader.readBoolOrNull(offsets[59]),
-    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[60]),
-    enableAniSkip: reader.readBoolOrNull(offsets[61]),
-    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[62]),
-    enableAutoSkip: reader.readBoolOrNull(offsets[63]),
-    enableCustomColorFilter: reader.readBoolOrNull(offsets[64]),
-    enableDiscordRpc: reader.readBoolOrNull(offsets[65]),
-    enableGpuNext: reader.readBoolOrNull(offsets[66]),
-    enableHardwareAcceleration: reader.readBoolOrNull(offsets[67]),
-    enableLogs: reader.readBoolOrNull(offsets[68]),
-    extensionServerPath: reader.readStringOrNull(offsets[69]),
-    flashColor: reader.readLongOrNull(offsets[71]),
-    flashDuration: reader.readLongOrNull(offsets[72]),
-    flashInterval: reader.readLongOrNull(offsets[73]),
-    flashOnPageChange: reader.readBoolOrNull(offsets[74]),
-    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[75]),
-    flexSchemeColorIndex: reader.readLongOrNull(offsets[76]),
-    followSystemTheme: reader.readBoolOrNull(offsets[77]),
-    forceLandscapePlayer: reader.readBoolOrNull(offsets[78]),
-    fullScreenPlayer: reader.readBoolOrNull(offsets[79]),
-    fullScreenReader: reader.readBoolOrNull(offsets[80]),
-    grayscale: reader.readBoolOrNull(offsets[81]),
-    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[82]),
-    hideItems: reader.readStringList(offsets[83]),
-    hwdecMode: reader.readStringOrNull(offsets[84]),
+    downloadQueueOrder: reader.readLongList(offsets[57]),
+    downloadedOnlyMode: reader.readBoolOrNull(offsets[58]),
+    dualPageInvert: reader.readBoolOrNull(offsets[59]),
+    dualPageRotateToFit: reader.readBoolOrNull(offsets[60]),
+    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[61]),
+    enableAniSkip: reader.readBoolOrNull(offsets[62]),
+    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[63]),
+    enableAutoSkip: reader.readBoolOrNull(offsets[64]),
+    enableCustomColorFilter: reader.readBoolOrNull(offsets[65]),
+    enableDiscordRpc: reader.readBoolOrNull(offsets[66]),
+    enableGpuNext: reader.readBoolOrNull(offsets[67]),
+    enableHardwareAcceleration: reader.readBoolOrNull(offsets[68]),
+    enableLogs: reader.readBoolOrNull(offsets[69]),
+    extensionServerPath: reader.readStringOrNull(offsets[70]),
+    flashColor: reader.readLongOrNull(offsets[72]),
+    flashDuration: reader.readLongOrNull(offsets[73]),
+    flashInterval: reader.readLongOrNull(offsets[74]),
+    flashOnPageChange: reader.readBoolOrNull(offsets[75]),
+    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[76]),
+    flexSchemeColorIndex: reader.readLongOrNull(offsets[77]),
+    followSystemTheme: reader.readBoolOrNull(offsets[78]),
+    forceLandscapePlayer: reader.readBoolOrNull(offsets[79]),
+    fullScreenPlayer: reader.readBoolOrNull(offsets[80]),
+    fullScreenReader: reader.readBoolOrNull(offsets[81]),
+    grayscale: reader.readBoolOrNull(offsets[82]),
+    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[83]),
+    hideItems: reader.readStringList(offsets[84]),
+    hwdecMode: reader.readStringOrNull(offsets[85]),
     id: id,
-    incognitoMode: reader.readBoolOrNull(offsets[85]),
-    invertColors: reader.readBoolOrNull(offsets[86]),
-    jrePath: reader.readStringOrNull(offsets[87]),
-    keepScreenOnReader: reader.readBoolOrNull(offsets[88]),
-    landscapeZoom: reader.readBoolOrNull(offsets[89]),
-    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[90]),
-    libraryDownloadedChapters: reader.readBoolOrNull(offsets[91]),
-    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[92]),
-    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[93]),
-    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[94]),
-    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[95]),
-    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[96]),
-    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[97]),
-    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[98]),
-    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[99]),
-    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[100]),
-    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[101]),
-    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[102]),
-    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[103]),
-    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[104]),
-    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[105]),
-    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[106]),
-    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[107]),
-    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[108]),
-    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[109]),
-    libraryLocalSource: reader.readBoolOrNull(offsets[110]),
-    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[111]),
-    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[112]),
-    libraryShowLanguage: reader.readBoolOrNull(offsets[113]),
-    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[114]),
-    localFolders: reader.readStringList(offsets[115]),
+    incognitoMode: reader.readBoolOrNull(offsets[86]),
+    invertColors: reader.readBoolOrNull(offsets[87]),
+    jrePath: reader.readStringOrNull(offsets[88]),
+    keepScreenOnReader: reader.readBoolOrNull(offsets[89]),
+    landscapeZoom: reader.readBoolOrNull(offsets[90]),
+    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[91]),
+    libraryDownloadedChapters: reader.readBoolOrNull(offsets[92]),
+    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[93]),
+    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[94]),
+    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[95]),
+    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[96]),
+    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[97]),
+    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[98]),
+    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[99]),
+    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[100]),
+    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[101]),
+    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[102]),
+    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[103]),
+    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[104]),
+    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[105]),
+    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[106]),
+    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[107]),
+    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[108]),
+    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[109]),
+    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[110]),
+    libraryLocalSource: reader.readBoolOrNull(offsets[111]),
+    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[112]),
+    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[113]),
+    libraryShowLanguage: reader.readBoolOrNull(offsets[114]),
+    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[115]),
+    localFolders: reader.readStringList(offsets[116]),
     mangaExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[117],
+      offsets[118],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    mangaGridSize: reader.readLongOrNull(offsets[118]),
+    mangaGridSize: reader.readLongOrNull(offsets[119]),
     mangaHomeDisplayType:
         _SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[119],
+          offsets[120],
         )] ??
         DisplayType.comfortableGrid,
-    markEpisodeAsSeenType: reader.readLongOrNull(offsets[120]),
-    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[121]),
-    navigateToPan: reader.readBoolOrNull(offsets[122]),
-    navigationOrder: reader.readStringList(offsets[123]),
+    markEpisodeAsSeenType: reader.readLongOrNull(offsets[121]),
+    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[122]),
+    navigateToPan: reader.readBoolOrNull(offsets[123]),
+    navigationOrder: reader.readStringList(offsets[124]),
     novelDisplayType:
         _SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[124],
+          offsets[125],
         )] ??
         DisplayType.comfortableGrid,
     novelExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[125],
+      offsets[126],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    novelFontSize: reader.readLongOrNull(offsets[126]),
-    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[128]),
-    novelLibraryLocalSource: reader.readBoolOrNull(offsets[129]),
-    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[130]),
-    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[131]),
-    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[132]),
-    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[133]),
-    novelReaderLineHeight: reader.readDoubleOrNull(offsets[134]),
-    novelReaderPadding: reader.readLongOrNull(offsets[135]),
-    novelReaderTextColor: reader.readStringOrNull(offsets[136]),
-    novelReaderTheme: reader.readStringOrNull(offsets[137]),
-    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[138]),
-    novelShowScrollPercentage: reader.readBoolOrNull(offsets[139]),
-    novelTapToScroll: reader.readBoolOrNull(offsets[140]),
+    novelFontSize: reader.readLongOrNull(offsets[127]),
+    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[129]),
+    novelLibraryLocalSource: reader.readBoolOrNull(offsets[130]),
+    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[131]),
+    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[132]),
+    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[133]),
+    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[134]),
+    novelReaderLineHeight: reader.readDoubleOrNull(offsets[135]),
+    novelReaderPadding: reader.readLongOrNull(offsets[136]),
+    novelReaderTextColor: reader.readStringOrNull(offsets[137]),
+    novelReaderTheme: reader.readStringOrNull(offsets[138]),
+    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[139]),
+    novelShowScrollPercentage: reader.readBoolOrNull(offsets[140]),
+    novelTapToScroll: reader.readBoolOrNull(offsets[141]),
     novelTextAlign:
         _SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
-          offsets[141],
+          offsets[142],
         )] ??
         NovelTextAlign.left,
-    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[142]),
-    pagePreloadAmount: reader.readLongOrNull(offsets[143]),
+    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[143]),
+    pagePreloadAmount: reader.readLongOrNull(offsets[144]),
     personalPageModeList: reader.readObjectList<PersonalPageMode>(
-      offsets[144],
+      offsets[145],
       PersonalPageModeSchema.deserialize,
       allOffsets,
       PersonalPageMode(),
     ),
     personalReaderModeList: reader.readObjectList<PersonalReaderMode>(
-      offsets[145],
+      offsets[146],
       PersonalReaderModeSchema.deserialize,
       allOffsets,
       PersonalReaderMode(),
     ),
     playerSubtitleSettings: reader.readObjectOrNull<PlayerSubtitleSettings>(
-      offsets[146],
+      offsets[147],
       PlayerSubtitleSettingsSchema.deserialize,
       allOffsets,
     ),
-    pureBlackDarkMode: reader.readBoolOrNull(offsets[147]),
-    readerBrightness: reader.readDoubleOrNull(offsets[148]),
-    readerContrast: reader.readDoubleOrNull(offsets[149]),
-    readerHideThreshold: reader.readLongOrNull(offsets[150]),
-    readerNavigationLayout: reader.readLongOrNull(offsets[151]),
-    readerSaturation: reader.readDoubleOrNull(offsets[152]),
-    relativeTimesTamps: reader.readLongOrNull(offsets[153]),
-    rpcShowCoverImage: reader.readBoolOrNull(offsets[154]),
-    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[155]),
-    rpcShowTitle: reader.readBoolOrNull(offsets[156]),
-    saveAsCBZArchive: reader.readBoolOrNull(offsets[157]),
+    pureBlackDarkMode: reader.readBoolOrNull(offsets[148]),
+    readerBrightness: reader.readDoubleOrNull(offsets[149]),
+    readerContrast: reader.readDoubleOrNull(offsets[150]),
+    readerHideThreshold: reader.readLongOrNull(offsets[151]),
+    readerNavigationLayout: reader.readLongOrNull(offsets[152]),
+    readerSaturation: reader.readDoubleOrNull(offsets[153]),
+    relativeTimesTamps: reader.readLongOrNull(offsets[154]),
+    rpcShowCoverImage: reader.readBoolOrNull(offsets[155]),
+    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[156]),
+    rpcShowTitle: reader.readBoolOrNull(offsets[157]),
+    saveAsCBZArchive: reader.readBoolOrNull(offsets[158]),
     scaleType:
-        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[158])] ??
+        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[159])] ??
         ScaleType.fitScreen,
-    showNSFW: reader.readBoolOrNull(offsets[159]),
-    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[160]),
-    showPageGaps: reader.readBoolOrNull(offsets[161]),
-    showPagesNumber: reader.readBoolOrNull(offsets[162]),
+    showNSFW: reader.readBoolOrNull(offsets[160]),
+    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[161]),
+    showPageGaps: reader.readBoolOrNull(offsets[162]),
+    showPagesNumber: reader.readBoolOrNull(offsets[163]),
     sortChapterList: reader.readObjectList<SortChapter>(
-      offsets[163],
+      offsets[164],
       SortChapterSchema.deserialize,
       allOffsets,
       SortChapter(),
     ),
     sortLibraryAnime: reader.readObjectOrNull<SortLibraryManga>(
-      offsets[164],
-      SortLibraryMangaSchema.deserialize,
-      allOffsets,
-    ),
-    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
       offsets[165],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
       offsets[166],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    splitWidePages: reader.readBoolOrNull(offsets[167]),
-    startDatebackup: reader.readLongOrNull(offsets[168]),
-    tappingInversion: reader.readLongOrNull(offsets[169]),
-    themeIsDark: reader.readBoolOrNull(offsets[170]),
-    ttsLanguage: reader.readStringOrNull(offsets[171]),
-    ttsPitch: reader.readDoubleOrNull(offsets[172]),
-    ttsSpeechRate: reader.readDoubleOrNull(offsets[173]),
-    ttsVoice: reader.readStringOrNull(offsets[174]),
+    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+      offsets[167],
+      SortLibraryMangaSchema.deserialize,
+      allOffsets,
+    ),
+    splitWidePages: reader.readBoolOrNull(offsets[168]),
+    startDatebackup: reader.readLongOrNull(offsets[169]),
+    tappingInversion: reader.readLongOrNull(offsets[170]),
+    themeIsDark: reader.readBoolOrNull(offsets[171]),
+    ttsLanguage: reader.readStringOrNull(offsets[172]),
+    ttsPitch: reader.readDoubleOrNull(offsets[173]),
+    ttsSpeechRate: reader.readDoubleOrNull(offsets[174]),
+    ttsVoice: reader.readStringOrNull(offsets[175]),
     updateErrorsList: reader.readObjectList<UpdateError>(
-      offsets[175],
+      offsets[176],
       UpdateErrorSchema.deserialize,
       allOffsets,
       UpdateError(),
     ),
-    updateProgressAfterReading: reader.readBoolOrNull(offsets[176]),
-    updatedAt: reader.readLongOrNull(offsets[177]),
-    useLibass: reader.readBoolOrNull(offsets[178]),
-    useMpvConfig: reader.readBoolOrNull(offsets[179]),
-    usePageTapZones: reader.readBoolOrNull(offsets[180]),
-    useYUV420P: reader.readBoolOrNull(offsets[181]),
-    userAgent: reader.readStringOrNull(offsets[182]),
-    volumeBoostCap: reader.readLongOrNull(offsets[183]),
-    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[184]),
-    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[185]),
-    webtoonSidePadding: reader.readLongOrNull(offsets[186]),
-    zoomStartPosition: reader.readLongOrNull(offsets[187]),
+    updateProgressAfterReading: reader.readBoolOrNull(offsets[177]),
+    updatedAt: reader.readLongOrNull(offsets[178]),
+    useLibass: reader.readBoolOrNull(offsets[179]),
+    useMpvConfig: reader.readBoolOrNull(offsets[180]),
+    usePageTapZones: reader.readBoolOrNull(offsets[181]),
+    useYUV420P: reader.readBoolOrNull(offsets[182]),
+    userAgent: reader.readStringOrNull(offsets[183]),
+    volumeBoostCap: reader.readLongOrNull(offsets[184]),
+    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[185]),
+    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[186]),
+    webtoonSidePadding: reader.readLongOrNull(offsets[187]),
+    zoomStartPosition: reader.readLongOrNull(offsets[188]),
   );
   object.chapterFilterBookmarkedList = reader
       .readObjectList<ChapterFilterBookmarked>(
@@ -2191,17 +2204,17 @@ Settings _settingsDeserialize(
     allOffsets,
   );
   object.filterScanlatorList = reader.readObjectList<FilterScanlator>(
-    offsets[70],
+    offsets[71],
     FilterScanlatorSchema.deserialize,
     allOffsets,
     FilterScanlator(),
   );
   object.locale = reader.readObjectOrNull<L10nLocale>(
-    offsets[116],
+    offsets[117],
     L10nLocaleSchema.deserialize,
     allOffsets,
   );
-  object.novelGridSize = reader.readLongOrNull(offsets[127]);
+  object.novelGridSize = reader.readLongOrNull(offsets[128]);
   return object;
 }
 
@@ -2420,7 +2433,7 @@ P _settingsDeserializeProp<P>(
     case 56:
       return (reader.readBoolOrNull(offset)) as P;
     case 57:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongList(offset)) as P;
     case 58:
       return (reader.readBoolOrNull(offset)) as P;
     case 59:
@@ -2444,8 +2457,10 @@ P _settingsDeserializeProp<P>(
     case 68:
       return (reader.readBoolOrNull(offset)) as P;
     case 69:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 70:
+      return (reader.readStringOrNull(offset)) as P;
+    case 71:
       return (reader.readObjectList<FilterScanlator>(
             offset,
             FilterScanlatorSchema.deserialize,
@@ -2453,20 +2468,18 @@ P _settingsDeserializeProp<P>(
             FilterScanlator(),
           ))
           as P;
-    case 71:
-      return (reader.readLongOrNull(offset)) as P;
     case 72:
       return (reader.readLongOrNull(offset)) as P;
     case 73:
       return (reader.readLongOrNull(offset)) as P;
     case 74:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 75:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 76:
       return (reader.readLongOrNull(offset)) as P;
-    case 77:
+    case 75:
       return (reader.readBoolOrNull(offset)) as P;
+    case 76:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 77:
+      return (reader.readLongOrNull(offset)) as P;
     case 78:
       return (reader.readBoolOrNull(offset)) as P;
     case 79:
@@ -2478,25 +2491,25 @@ P _settingsDeserializeProp<P>(
     case 82:
       return (reader.readBoolOrNull(offset)) as P;
     case 83:
-      return (reader.readStringList(offset)) as P;
-    case 84:
-      return (reader.readStringOrNull(offset)) as P;
-    case 85:
       return (reader.readBoolOrNull(offset)) as P;
+    case 84:
+      return (reader.readStringList(offset)) as P;
+    case 85:
+      return (reader.readStringOrNull(offset)) as P;
     case 86:
       return (reader.readBoolOrNull(offset)) as P;
     case 87:
-      return (reader.readStringOrNull(offset)) as P;
-    case 88:
       return (reader.readBoolOrNull(offset)) as P;
+    case 88:
+      return (reader.readStringOrNull(offset)) as P;
     case 89:
       return (reader.readBoolOrNull(offset)) as P;
     case 90:
-      return (reader.readStringOrNull(offset)) as P;
-    case 91:
       return (reader.readBoolOrNull(offset)) as P;
+    case 91:
+      return (reader.readStringOrNull(offset)) as P;
     case 92:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 93:
       return (reader.readLongOrNull(offset)) as P;
     case 94:
@@ -2532,7 +2545,7 @@ P _settingsDeserializeProp<P>(
     case 109:
       return (reader.readLongOrNull(offset)) as P;
     case 110:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 111:
       return (reader.readBoolOrNull(offset)) as P;
     case 112:
@@ -2542,15 +2555,17 @@ P _settingsDeserializeProp<P>(
     case 114:
       return (reader.readBoolOrNull(offset)) as P;
     case 115:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 116:
+      return (reader.readStringList(offset)) as P;
+    case 117:
       return (reader.readObjectOrNull<L10nLocale>(
             offset,
             L10nLocaleSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 117:
+    case 118:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2558,29 +2573,29 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 118:
-      return (reader.readLongOrNull(offset)) as P;
     case 119:
+      return (reader.readLongOrNull(offset)) as P;
+    case 120:
       return (_SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 120:
-      return (reader.readLongOrNull(offset)) as P;
     case 121:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 122:
       return (reader.readBoolOrNull(offset)) as P;
     case 123:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 124:
+      return (reader.readStringList(offset)) as P;
+    case 125:
       return (_SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 125:
+    case 126:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2588,12 +2603,10 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 126:
-      return (reader.readLongOrNull(offset)) as P;
     case 127:
       return (reader.readLongOrNull(offset)) as P;
     case 128:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 129:
       return (reader.readBoolOrNull(offset)) as P;
     case 130:
@@ -2605,30 +2618,32 @@ P _settingsDeserializeProp<P>(
     case 133:
       return (reader.readBoolOrNull(offset)) as P;
     case 134:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 135:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 136:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 137:
       return (reader.readStringOrNull(offset)) as P;
     case 138:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 139:
       return (reader.readBoolOrNull(offset)) as P;
     case 140:
       return (reader.readBoolOrNull(offset)) as P;
     case 141:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 142:
       return (_SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               NovelTextAlign.left)
           as P;
-    case 142:
-      return (reader.readBoolOrNull(offset)) as P;
     case 143:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 144:
+      return (reader.readLongOrNull(offset)) as P;
+    case 145:
       return (reader.readObjectList<PersonalPageMode>(
             offset,
             PersonalPageModeSchema.deserialize,
@@ -2636,7 +2651,7 @@ P _settingsDeserializeProp<P>(
             PersonalPageMode(),
           ))
           as P;
-    case 145:
+    case 146:
       return (reader.readObjectList<PersonalReaderMode>(
             offset,
             PersonalReaderModeSchema.deserialize,
@@ -2644,29 +2659,27 @@ P _settingsDeserializeProp<P>(
             PersonalReaderMode(),
           ))
           as P;
-    case 146:
+    case 147:
       return (reader.readObjectOrNull<PlayerSubtitleSettings>(
             offset,
             PlayerSubtitleSettingsSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 147:
-      return (reader.readBoolOrNull(offset)) as P;
     case 148:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 149:
       return (reader.readDoubleOrNull(offset)) as P;
     case 150:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 151:
       return (reader.readLongOrNull(offset)) as P;
     case 152:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 153:
       return (reader.readLongOrNull(offset)) as P;
+    case 153:
+      return (reader.readDoubleOrNull(offset)) as P;
     case 154:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 155:
       return (reader.readBoolOrNull(offset)) as P;
     case 156:
@@ -2674,11 +2687,11 @@ P _settingsDeserializeProp<P>(
     case 157:
       return (reader.readBoolOrNull(offset)) as P;
     case 158:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 159:
       return (_SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offset)] ??
               ScaleType.fitScreen)
           as P;
-    case 159:
-      return (reader.readBoolOrNull(offset)) as P;
     case 160:
       return (reader.readBoolOrNull(offset)) as P;
     case 161:
@@ -2686,18 +2699,13 @@ P _settingsDeserializeProp<P>(
     case 162:
       return (reader.readBoolOrNull(offset)) as P;
     case 163:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 164:
       return (reader.readObjectList<SortChapter>(
             offset,
             SortChapterSchema.deserialize,
             allOffsets,
             SortChapter(),
-          ))
-          as P;
-    case 164:
-      return (reader.readObjectOrNull<SortLibraryManga>(
-            offset,
-            SortLibraryMangaSchema.deserialize,
-            allOffsets,
           ))
           as P;
     case 165:
@@ -2715,22 +2723,29 @@ P _settingsDeserializeProp<P>(
           ))
           as P;
     case 167:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readObjectOrNull<SortLibraryManga>(
+            offset,
+            SortLibraryMangaSchema.deserialize,
+            allOffsets,
+          ))
+          as P;
     case 168:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 169:
       return (reader.readLongOrNull(offset)) as P;
     case 170:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 171:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 172:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 173:
       return (reader.readDoubleOrNull(offset)) as P;
     case 174:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 175:
+      return (reader.readStringOrNull(offset)) as P;
+    case 176:
       return (reader.readObjectList<UpdateError>(
             offset,
             UpdateErrorSchema.deserialize,
@@ -2738,12 +2753,10 @@ P _settingsDeserializeProp<P>(
             UpdateError(),
           ))
           as P;
-    case 176:
-      return (reader.readBoolOrNull(offset)) as P;
     case 177:
-      return (reader.readLongOrNull(offset)) as P;
-    case 178:
       return (reader.readBoolOrNull(offset)) as P;
+    case 178:
+      return (reader.readLongOrNull(offset)) as P;
     case 179:
       return (reader.readBoolOrNull(offset)) as P;
     case 180:
@@ -2751,16 +2764,18 @@ P _settingsDeserializeProp<P>(
     case 181:
       return (reader.readBoolOrNull(offset)) as P;
     case 182:
-      return (reader.readStringOrNull(offset)) as P;
-    case 183:
-      return (reader.readLongOrNull(offset)) as P;
-    case 184:
       return (reader.readBoolOrNull(offset)) as P;
+    case 183:
+      return (reader.readStringOrNull(offset)) as P;
+    case 184:
+      return (reader.readLongOrNull(offset)) as P;
     case 185:
       return (reader.readBoolOrNull(offset)) as P;
     case 186:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 187:
+      return (reader.readLongOrNull(offset)) as P;
+    case 188:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -7045,6 +7060,144 @@ extension SettingsQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(
         FilterCondition.equalTo(property: r'downloadOnlyOnWifi', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'downloadQueueOrder'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'downloadQueueOrder'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderElementEqualTo(int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'downloadQueueOrder', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderElementGreaterThan(int value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'downloadQueueOrder',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderElementLessThan(int value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'downloadQueueOrder',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderElementBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'downloadQueueOrder',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderLengthEqualTo(int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'downloadQueueOrder',
+        length,
+        true,
+        length,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'downloadQueueOrder', 0, true, 0, true);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'downloadQueueOrder', 0, false, 999999, true);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderLengthLessThan(int length, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'downloadQueueOrder', 0, true, length, include);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderLengthGreaterThan(int length, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'downloadQueueOrder',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'downloadQueueOrder',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
       );
     });
   }
@@ -20158,6 +20311,12 @@ extension SettingsQueryWhereDistinct
     });
   }
 
+  QueryBuilder<Settings, Settings, QDistinct> distinctByDownloadQueueOrder() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'downloadQueueOrder');
+    });
+  }
+
   QueryBuilder<Settings, Settings, QDistinct> distinctByDownloadedOnlyMode() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'downloadedOnlyMode');
@@ -21336,6 +21495,13 @@ extension SettingsQueryProperty
   QueryBuilder<Settings, bool?, QQueryOperations> downloadOnlyOnWifiProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'downloadOnlyOnWifi');
+    });
+  }
+
+  QueryBuilder<Settings, List<int>?, QQueryOperations>
+  downloadQueueOrderProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'downloadQueueOrder');
     });
   }
 

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -20,6 +20,7 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
+import 'package:mangayomi/services/download_manager/download_queue_order.dart';
 import 'package:mangayomi/services/get_video_list.dart';
 import 'package:mangayomi/services/get_chapter_pages.dart';
 import 'package:mangayomi/services/http/m_client.dart';
@@ -408,24 +409,33 @@ Future<void> downloadChapter(
 Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
   final keepAlive = ref.keepAlive();
   try {
-    final ongoingDownloads = await isar.downloads
-        .filter()
-        .idIsNotNull()
-        .isDownloadEqualTo(false)
-        .isStartDownloadEqualTo(true)
-        .findAll();
     final maxConcurrentDownloads = ref.read(concurrentDownloadsStateProvider);
-    int index = 0;
-    int downloaded = 0;
-    int current = 0;
+    // Ids already handed to a downloader in this run, so re-reading the queue
+    // each tick never starts the same chapter twice.
+    final started = <int>{};
+    int inFlight = 0;
     await Future.doWhile(() async {
       await Future.delayed(const Duration(seconds: 1));
-      if (ongoingDownloads.length == downloaded) {
+      // Re-read and re-sort the pending queue every tick so manual reordering
+      // takes effect on what's left live, and chapters queued mid-run are
+      // picked up (see #514). Falls back to insertion order when nothing has
+      // been reordered.
+      final pending =
+          DownloadQueueOrder.sorted(
+            await isar.downloads
+                .filter()
+                .idIsNotNull()
+                .isDownloadEqualTo(false)
+                .isStartDownloadEqualTo(true)
+                .findAll(),
+          ).where((d) => !started.contains(d.id)).toList();
+      if (pending.isEmpty && inFlight == 0) {
         return false;
       }
-      if (current < maxConcurrentDownloads) {
-        current++;
-        final downloadItem = ongoingDownloads[index++];
+      if (inFlight < maxConcurrentDownloads && pending.isNotEmpty) {
+        inFlight++;
+        final downloadItem = pending.first;
+        started.add(downloadItem.id!);
         final chapter = downloadItem.chapter.value!;
         chapter.cancelDownloads(downloadItem.id);
         await Future.delayed(const Duration(milliseconds: 500));
@@ -434,8 +444,7 @@ Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
             chapter: chapter,
             useWifi: useWifi,
             callback: () {
-              downloaded++;
-              current--;
+              inFlight--;
             },
           ),
         );

--- a/lib/modules/manga/download/providers/download_provider.g.dart
+++ b/lib/modules/manga/download/providers/download_provider.g.dart
@@ -215,7 +215,7 @@ final class ProcessDownloadsProvider
   }
 }
 
-String _$processDownloadsHash() => r'36903a1ca0140ef7d55aa68ee34d8c74573e8e71';
+String _$processDownloadsHash() => r'332b733f11a05a6c2445db6b6c4c0d1c820d4f51';
 
 final class ProcessDownloadsFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<void>, bool?> {

--- a/lib/modules/more/download_queue/download_queue_screen.dart
+++ b/lib/modules/more/download_queue/download_queue_screen.dart
@@ -1,235 +1,221 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:grouped_list/grouped_list.dart';
 import 'package:isar_community/isar.dart';
+import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/chapter.dart';
 import 'package:mangayomi/models/download.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/custom_floating_action_btn.dart';
 import 'package:mangayomi/modules/manga/download/providers/download_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/services/download_manager/download_queue_order.dart';
 import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
 import 'package:mangayomi/utils/global_style.dart';
 
-class DownloadQueueScreen extends ConsumerWidget {
+class DownloadQueueScreen extends ConsumerStatefulWidget {
   const DownloadQueueScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = l10nLocalizations(context);
+  ConsumerState<DownloadQueueScreen> createState() =>
+      _DownloadQueueScreenState();
+}
+
+class _DownloadQueueScreenState extends ConsumerState<DownloadQueueScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final l10n = l10nLocalizations(context)!;
     return StreamBuilder(
+      // No explicit sort: the natural (insertion) id order is the stable base
+      // the manual queue order is applied on top of, so rows don't reshuffle as
+      // download progress ticks.
       stream: isar.downloads
           .filter()
           .idIsNotNull()
           .isDownloadEqualTo(false)
           .isStartDownloadEqualTo(true)
-          .sortBySucceededDesc()
           .watch(fireImmediately: true),
       builder: (context, snapshot) {
-        if (snapshot.hasData && snapshot.data!.isNotEmpty) {
-          // Filter out orphaned downloads (chapter or manga deleted)
-          final allEntries = snapshot.data!;
-          final orphanIds = <int>[];
-          final entries = <Download>[];
-          for (final d in allEntries) {
-            if (d.chapter.value == null ||
-                d.chapter.value?.manga.value == null) {
-              if (d.id != null) orphanIds.add(d.id!);
-            } else {
-              entries.add(d);
-            }
-          }
-          // Auto-clean orphaned download records
-          if (orphanIds.isNotEmpty) {
-            isar.writeTxnSync(() {
-              for (final id in orphanIds) {
-                isar.downloads.deleteSync(id);
-              }
-            });
-          }
-          if (entries.isEmpty) {
-            return Scaffold(
-              appBar: AppBar(title: Text(l10n!.download_queue)),
-              body: Center(child: Text(l10n.no_downloads)),
-            );
-          }
-          final allQueueLength = entries.length;
+        if (!snapshot.hasData || snapshot.data!.isEmpty) {
           return Scaffold(
-            appBar: AppBar(
-              title: Row(
-                children: [
-                  Text(l10n!.download_queue),
-                  const SizedBox(width: 10),
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 3),
-                    child: Badge(
-                      backgroundColor: Theme.of(context).focusColor,
-                      label: Text(
-                        allQueueLength.toString(),
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: Theme.of(context).textTheme.bodySmall!.color,
-                        ),
+            appBar: AppBar(title: Text(l10n.download_queue)),
+            body: Center(child: Text(l10n.no_downloads)),
+          );
+        }
+        // Filter out orphaned downloads (chapter or manga deleted) and auto-
+        // clean their records.
+        final orphanIds = <int>[];
+        final valid = <Download>[];
+        for (final d in snapshot.data!) {
+          if (d.chapter.value == null ||
+              d.chapter.value?.manga.value == null) {
+            if (d.id != null) orphanIds.add(d.id!);
+          } else {
+            valid.add(d);
+          }
+        }
+        if (orphanIds.isNotEmpty) {
+          isar.writeTxnSync(() {
+            for (final id in orphanIds) {
+              isar.downloads.deleteSync(id);
+            }
+          });
+        }
+        if (valid.isEmpty) {
+          return Scaffold(
+            appBar: AppBar(title: Text(l10n.download_queue)),
+            body: Center(child: Text(l10n.no_downloads)),
+          );
+        }
+        final entries = DownloadQueueOrder.sorted(valid);
+        return Scaffold(
+          appBar: AppBar(
+            title: Row(
+              children: [
+                Text(l10n.download_queue),
+                const SizedBox(width: 10),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 3),
+                  child: Badge(
+                    backgroundColor: Theme.of(context).focusColor,
+                    label: Text(
+                      entries.length.toString(),
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Theme.of(context).textTheme.bodySmall!.color,
                       ),
                     ),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
-            body: GroupedListView<Download, String>(
-              elements: entries,
-              groupBy: (element) =>
-                  element.chapter.value?.manga.value?.source ?? "",
-              groupSeparatorBuilder: (String groupByValue) {
-                final sourceQueueLength = entries
-                    .where(
-                      (element) =>
-                          (element.chapter.value?.manga.value?.source ?? "") ==
-                          groupByValue,
-                    )
-                    .toList()
-                    .length;
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 6, left: 12),
-                  child: Text('$groupByValue ($sourceQueueLength)'),
-                );
-              },
-              itemBuilder: (context, Download element) {
-                return SizedBox(
-                  height: 60,
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      const Padding(
-                        padding: EdgeInsets.all(8.0),
-                        child: Icon(Icons.drag_handle),
-                      ),
-                      Flexible(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Text(
-                                  element.chapter.value?.manga.value?.name ??
-                                      "",
-                                  style: const TextStyle(fontSize: 16),
-                                ),
-                                Text(
-                                  "${element.succeeded}/${element.total}",
-                                  style: const TextStyle(fontSize: 10),
-                                ),
-                              ],
-                            ),
-                            Text(
-                              element.chapter.value?.name ?? "",
-                              style: const TextStyle(fontSize: 13),
-                            ),
-                            const SizedBox(height: 8),
-                            TweenAnimationBuilder<double>(
-                              duration: const Duration(milliseconds: 250),
-                              curve: Curves.easeInOut,
-                              tween: Tween<double>(
-                                begin: 0,
-                                end: element.succeeded! / element.total!,
-                              ),
-                              builder: (context, value, _) =>
-                                  LinearProgressIndicator(value: value),
-                            ),
-                          ],
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: PopupMenuButton(
-                          popUpAnimationStyle: popupAnimationStyle,
-                          child: const Icon(Icons.more_vert),
-                          onSelected: (value) async {
-                            if (value.toString() == 'Cancel') {
-                              if (element.chapter.value != null) {
-                                element.chapter.value!.cancelDownloads(
-                                  element.id!,
-                                );
-                              } else {
-                                // Orphaned download — just delete the record
-                                isar.writeTxnSync(() {
-                                  isar.downloads.deleteSync(element.id!);
-                                });
-                              }
-                            } else if (value.toString() == 'CancelAll') {
-                              final a = entries
-                                  .where(
-                                    (e) =>
-                                        '${e.chapter.value?.manga.value?.name}' ==
-                                            '${element.chapter.value?.manga.value?.name}' &&
-                                        '${e.chapter.value?.manga.value?.source}' ==
-                                            '${element.chapter.value?.manga.value?.source}',
-                                  )
-                                  .map((e) => (e.id, e.chapter.value?.id))
-                                  .toList();
-                              for (var ids in a) {
-                                final (downloadId, chapterId) = ids;
-                                final chapter = isar.chapters.getSync(
-                                  chapterId!,
-                                );
-                                chapter?.cancelDownloads(downloadId!);
-                              }
-                            }
-                          },
-                          itemBuilder: (context) => [
-                            PopupMenuItem(
-                              value: 'Cancel',
-                              child: Text(l10n.cancel),
-                            ),
-                            PopupMenuItem(
-                              value: 'CancelAll',
-                              child: Text(l10n.cancel_all_for_this_series),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              },
-              itemComparator: (item1, item2) =>
-                  (item1.chapter.value?.manga.value?.source ?? "").compareTo(
-                    item2.chapter.value?.manga.value?.source ?? "",
-                  ),
-              order: GroupedListOrder.DESC,
-            ),
-            floatingActionButton: CustomFloatingActionBtn(
-              isExtended: false,
-              label: l10n.download_queue,
-              onPressed: () {
-                ref.read(processDownloadsProvider());
-              },
-            ),
-          );
-        }
-        return Scaffold(
-          appBar: AppBar(title: Text(l10n!.download_queue)),
-          body: Center(child: Text(l10n.no_downloads)),
+          ),
+          body: ReorderableListView.builder(
+            buildDefaultDragHandles: false,
+            itemCount: entries.length,
+            onReorder: (oldIndex, newIndex) {
+              if (newIndex > oldIndex) newIndex -= 1;
+              final ids = entries.map((e) => e.id!).toList();
+              final moved = ids.removeAt(oldIndex);
+              ids.insert(newIndex, moved);
+              DownloadQueueOrder.setOrder(ids);
+              setState(() {});
+            },
+            itemBuilder: (context, index) {
+              final element = entries[index];
+              return _buildRow(context, l10n, entries, element, index);
+            },
+          ),
+          floatingActionButton: CustomFloatingActionBtn(
+            isExtended: false,
+            label: l10n.download_queue,
+            onPressed: () {
+              ref.read(processDownloadsProvider());
+            },
+          ),
         );
       },
     );
   }
 
-  Size measureText(String text, TextStyle style) {
-    final TextPainter textPainter = TextPainter(
-      text: TextSpan(text: text, style: style),
-      textDirection: TextDirection.ltr,
-    )..layout();
-    return textPainter.size;
-  }
-
-  double calculateDynamicButtonWidth(
-    String text,
-    TextStyle textStyle,
-    double padding,
+  Widget _buildRow(
+    BuildContext context,
+    AppLocalizations l10n,
+    List<Download> entries,
+    Download element,
+    int index,
   ) {
-    final textSize = measureText(text, textStyle);
-    return textSize.width + padding;
+    return SizedBox(
+      key: ValueKey(element.id),
+      height: 60,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          ReorderableDragStartListener(
+            index: index,
+            child: const Padding(
+              padding: EdgeInsets.all(8.0),
+              child: Icon(Icons.drag_handle),
+            ),
+          ),
+          Flexible(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      element.chapter.value?.manga.value?.name ?? "",
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                    Text(
+                      "${element.succeeded}/${element.total}",
+                      style: const TextStyle(fontSize: 10),
+                    ),
+                  ],
+                ),
+                Text(
+                  element.chapter.value?.name ?? "",
+                  style: const TextStyle(fontSize: 13),
+                ),
+                const SizedBox(height: 8),
+                TweenAnimationBuilder<double>(
+                  duration: const Duration(milliseconds: 250),
+                  curve: Curves.easeInOut,
+                  tween: Tween<double>(
+                    begin: 0,
+                    end: element.succeeded! / element.total!,
+                  ),
+                  builder: (context, value, _) =>
+                      LinearProgressIndicator(value: value),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: PopupMenuButton(
+              popUpAnimationStyle: popupAnimationStyle,
+              child: const Icon(Icons.more_vert),
+              onSelected: (value) async {
+                if (value.toString() == 'Cancel') {
+                  if (element.chapter.value != null) {
+                    element.chapter.value!.cancelDownloads(element.id!);
+                  } else {
+                    // Orphaned download: just delete the record.
+                    isar.writeTxnSync(() {
+                      isar.downloads.deleteSync(element.id!);
+                    });
+                  }
+                } else if (value.toString() == 'CancelAll') {
+                  final a = entries
+                      .where(
+                        (e) =>
+                            '${e.chapter.value?.manga.value?.name}' ==
+                                '${element.chapter.value?.manga.value?.name}' &&
+                            '${e.chapter.value?.manga.value?.source}' ==
+                                '${element.chapter.value?.manga.value?.source}',
+                      )
+                      .map((e) => (e.id, e.chapter.value?.id))
+                      .toList();
+                  for (var ids in a) {
+                    final (downloadId, chapterId) = ids;
+                    final chapter = isar.chapters.getSync(chapterId!);
+                    chapter?.cancelDownloads(downloadId!);
+                  }
+                }
+              },
+              itemBuilder: (context) => [
+                PopupMenuItem(value: 'Cancel', child: Text(l10n.cancel)),
+                PopupMenuItem(
+                  value: 'CancelAll',
+                  child: Text(l10n.cancel_all_for_this_series),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/modules/more/download_queue/download_queue_screen.dart
+++ b/lib/modules/more/download_queue/download_queue_screen.dart
@@ -92,8 +92,10 @@ class _DownloadQueueScreenState extends ConsumerState<DownloadQueueScreen> {
           body: ReorderableListView.builder(
             buildDefaultDragHandles: false,
             itemCount: entries.length,
-            onReorder: (oldIndex, newIndex) {
-              if (newIndex > oldIndex) newIndex -= 1;
+            // onReorderItem already accounts for the item being lifted out at
+            // oldIndex, so newIndex arrives adjusted and must not be shifted
+            // again here.
+            onReorderItem: (oldIndex, newIndex) {
               final ids = entries.map((e) => e.id!).toList();
               final moved = ids.removeAt(oldIndex);
               ids.insert(newIndex, moved);

--- a/lib/services/download_manager/download_queue_order.dart
+++ b/lib/services/download_manager/download_queue_order.dart
@@ -1,46 +1,31 @@
-import 'package:hive/hive.dart';
+import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/download.dart';
+import 'package:mangayomi/models/settings.dart';
 
-/// Persists the user's manual ordering of the download queue as a list of
-/// Download ids (which equal their chapter ids), highest priority first.
+/// The user's manual ordering of the download queue as a list of Download ids
+/// (which equal their chapter ids), highest priority first.
 ///
-/// Kept in Hive rather than as an Isar field so the queue can be reordered
-/// without a schema change. Ids missing from the saved order are treated as
-/// lowest priority (kept in their incoming id order, after the known ones).
-/// The box is opened once at startup (see [openBox]); when it isn't open the
-/// order is empty and the queue falls back to its natural (insertion) order.
+/// Stored on the Settings collection (`downloadQueueOrder`), alongside the rest
+/// of the app's preferences. Ids missing from the saved order are treated as
+/// lowest priority (kept in their incoming id order, after the known ones), so
+/// newly queued downloads slot in at the end until the user moves them.
 class DownloadQueueOrder {
-  static const _boxName = 'download_queue_prefs';
-  static const _orderKey = 'queue_order';
-
-  /// Opens the backing box. Called once during app startup.
-  static Future<void> openBox() async {
-    // Best-effort: an optional ordering store must never block startup.
-    try {
-      if (!Hive.isBoxOpen(_boxName)) {
-        await Hive.openBox(_boxName);
-      }
-    } catch (_) {}
-  }
-
   /// The saved priority order (Download ids), or an empty list if none.
-  static List<int> get order {
-    if (!Hive.isBoxOpen(_boxName)) return const [];
-    final raw = Hive.box(_boxName).get(_orderKey);
-    if (raw is List) return raw.whereType<int>().toList();
-    return const [];
-  }
+  static List<int> get order =>
+      isar.settings.getSync(227)?.downloadQueueOrder ?? const [];
 
-  /// Persists [ids] as the new priority order (best-effort if the box is open).
+  /// Persists [ids] as the new priority order.
   static void setOrder(List<int> ids) {
-    if (Hive.isBoxOpen(_boxName)) {
-      Hive.box(_boxName).put(_orderKey, ids);
-    }
+    isar.writeTxnSync(() {
+      final settings = isar.settings.getSync(227);
+      if (settings != null) {
+        isar.settings.putSync(settings..downloadQueueOrder = ids);
+      }
+    });
   }
 
   /// Returns [items] arranged by the saved manual order. Items whose id isn't
-  /// in the saved order come last, keeping their incoming id order, so newly
-  /// queued downloads slot in at the end until the user moves them.
+  /// in the saved order come last, keeping their incoming id order.
   static List<Download> sorted(List<Download> items) {
     final ord = order;
     if (ord.isEmpty) return items;

--- a/lib/services/download_manager/download_queue_order.dart
+++ b/lib/services/download_manager/download_queue_order.dart
@@ -1,0 +1,59 @@
+import 'package:hive/hive.dart';
+import 'package:mangayomi/models/download.dart';
+
+/// Persists the user's manual ordering of the download queue as a list of
+/// Download ids (which equal their chapter ids), highest priority first.
+///
+/// Kept in Hive rather than as an Isar field so the queue can be reordered
+/// without a schema change. Ids missing from the saved order are treated as
+/// lowest priority (kept in their incoming id order, after the known ones).
+/// The box is opened once at startup (see [openBox]); when it isn't open the
+/// order is empty and the queue falls back to its natural (insertion) order.
+class DownloadQueueOrder {
+  static const _boxName = 'download_queue_prefs';
+  static const _orderKey = 'queue_order';
+
+  /// Opens the backing box. Called once during app startup.
+  static Future<void> openBox() async {
+    // Best-effort: an optional ordering store must never block startup.
+    try {
+      if (!Hive.isBoxOpen(_boxName)) {
+        await Hive.openBox(_boxName);
+      }
+    } catch (_) {}
+  }
+
+  /// The saved priority order (Download ids), or an empty list if none.
+  static List<int> get order {
+    if (!Hive.isBoxOpen(_boxName)) return const [];
+    final raw = Hive.box(_boxName).get(_orderKey);
+    if (raw is List) return raw.whereType<int>().toList();
+    return const [];
+  }
+
+  /// Persists [ids] as the new priority order (best-effort if the box is open).
+  static void setOrder(List<int> ids) {
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_orderKey, ids);
+    }
+  }
+
+  /// Returns [items] arranged by the saved manual order. Items whose id isn't
+  /// in the saved order come last, keeping their incoming id order, so newly
+  /// queued downloads slot in at the end until the user moves them.
+  static List<Download> sorted(List<Download> items) {
+    final ord = order;
+    if (ord.isEmpty) return items;
+    final rank = <int, int>{};
+    for (var i = 0; i < ord.length; i++) {
+      rank[ord[i]] = i;
+    }
+    final result = [...items];
+    result.sort((a, b) {
+      final ra = rank[a.id] ?? (ord.length + (a.id ?? 0));
+      final rb = rank[b.id] ?? (ord.length + (b.id ?? 0));
+      return ra.compareTo(rb);
+    });
+    return result;
+  }
+}


### PR DESCRIPTION
Closes #514.

Adds the ability to rearrange the download queue so you can prioritise a particular series (or source), as requested.

### What changed
- The download queue screen is now a **flat, drag-to-reorder list** (a drag handle on each row), replacing the source-grouped list. That matches the Mihon example in the issue, and `grouped_list` can't reorder, so a flat `ReorderableListView` is the natural fit. The manga name still shows per row.
- The manual order is **persisted on the Settings collection** (`downloadQueueOrder`), matching how the app stores its other preferences.
- `processDownloads` now **re-reads and re-sorts the pending queue each tick**, so reordering takes effect live on what's still queued (the provider is cached, so a single run drains the queue), and chapters queued mid-run are picked up. The chapter that's already downloading finishes; reordering decides what comes next.

### Notes
- Backward compatible: with nothing reordered, the queue keeps its natural insertion order.
- No new strings (reordering is a drag gesture), so no l10n changes.

### Testing
`flutter analyze` is clean. I don't have an Android build environment here, so a quick on-device check of the drag gesture and that downloads then follow the new order would be good before merge.



https://github.com/user-attachments/assets/e29900a4-1495-4658-a810-d99b18a3ee03
