### PR TITLE
fix(browse): respect Show NSFW in the migration destination picker and the source filter (#806)

### DIFF
--- a/lib/modules/browse/sources/sources_filter_screen.dart
+++ b/lib/modules/browse/sources/sources_filter_screen.dart
@@ -5,6 +5,7 @@ import 'package:isar_community/isar.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/source.dart';
+import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/language.dart';
@@ -16,6 +17,7 @@ class SourcesFilterScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = l10nLocalizations(context)!;
+    final showNSFW = ref.watch(showNSFWStateProvider);
     return Scaffold(
       appBar: AppBar(title: Text(l10n.sources)),
       body: Padding(
@@ -31,7 +33,9 @@ class SourcesFilterScreen extends ConsumerWidget {
               .watch(fireImmediately: true),
           builder: (context, snapshot) {
             if (snapshot.hasData && snapshot.data!.isNotEmpty) {
-              final entries = snapshot.data!;
+              final entries = snapshot.data!
+                  .where((e) => showNSFW || !(e.isNsfw ?? false))
+                  .toList();
               return CustomScrollView(
                 slivers: [
                   CustomSliverGroupedListView<Source, String>(

--- a/lib/modules/mass_migration/mass_migration_destination_screen.dart
+++ b/lib/modules/mass_migration/mass_migration_destination_screen.dart
@@ -1,22 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/modules/mass_migration/mass_migration_runner_screen.dart';
 import 'package:mangayomi/modules/mass_migration/models/mass_migration_models.dart';
 import 'package:mangayomi/modules/mass_migration/widgets/mass_migration_widgets.dart';
+import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/utils/language.dart';
 
-class MassMigrationDestinationScreen extends StatelessWidget {
+class MassMigrationDestinationScreen extends ConsumerWidget {
   const MassMigrationDestinationScreen({required this.sourceGroup, super.key});
 
   final MassMigrationSourceGroup sourceGroup;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final sources = buildMassMigrationDestinationSources(
       sourceGroup: sourceGroup,
+      showNSFW: ref.watch(showNSFWStateProvider),
     );
 
     return Scaffold(

--- a/lib/modules/mass_migration/models/mass_migration_models.dart
+++ b/lib/modules/mass_migration/models/mass_migration_models.dart
@@ -150,6 +150,7 @@ List<MassMigrationSourceGroup> buildMassMigrationSourceGroups({
 
 List<Source> buildMassMigrationDestinationSources({
   required MassMigrationSourceGroup sourceGroup,
+  required bool showNSFW,
 }) {
   final sources = isar.sources
       .filter()
@@ -159,6 +160,7 @@ List<Source> buildMassMigrationDestinationSources({
       .where(
         (source) =>
             source.sourceCode != null &&
+            (showNSFW || !(source.isNsfw ?? false)) &&
             !(source.name == sourceGroup.sourceName &&
                 source.lang == sourceGroup.lang),
       )


### PR DESCRIPTION
Turning off **Settings > Browse > Show NSFW** hides NSFW sources in Browse, but two other source lists still showed them.

- **Mass migration destination picker:** `buildMassMigrationDestinationSources` never filtered on `isNsfw`, so NSFW sources were still offered as migration destinations.
- **Source filter** (Browse > Sources, top right): the screen streamed `isar.sources` filtered by `isActive` and language only, so NSFW sources were still listed as checkboxes.

Both now use the same guard Browse already applies in `sources_screen.dart`, `extension_screen.dart` and `global_search_screen.dart`:

```dart
showNSFW || !(source.isNsfw ?? false)
```

### Notes

`buildMassMigrationDestinationSources` stays a pure function and takes `showNSFW` as a parameter; `MassMigrationDestinationScreen` supplies it from `showNSFWStateProvider` (so it becomes a `ConsumerWidget`), which also makes the list react to the setting being changed rather than only on a rebuild.

In the source filter the guard is applied to the `entries` list the whole screen derives from, so the per-language switch cannot toggle a hidden NSFW source either.

Library and History entries are deliberately left alone: a single source can carry both SFW and NSFW titles, so filtering those by the source-level flag would hide legitimate entries while still missing NSFW titles from unflagged sources. That needs finer, per-item filtering and is a separate discussion.

Closes #806
