### PR TITLE
fix(downloads): bound queue execution and worker resources

### DIFF
--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -1,6 +1,6 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:ui';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/widgets.dart';
 import 'package:isar_community/isar.dart';
@@ -20,20 +20,25 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
+import 'package:mangayomi/services/download_manager/download_queue_runner.dart';
 import 'package:mangayomi/services/get_video_list.dart';
 import 'package:mangayomi/services/get_chapter_pages.dart';
 import 'package:mangayomi/services/http/m_client.dart';
 import 'package:mangayomi/services/download_manager/m3u8/m3u8_downloader.dart';
 import 'package:mangayomi/services/download_manager/m3u8/models/download.dart';
 import 'package:mangayomi/utils/chapter_recognition.dart';
-import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
 import 'package:mangayomi/utils/extensions/string_extensions.dart';
 import 'package:mangayomi/utils/headers.dart';
+import 'package:mangayomi/utils/log/logger.dart';
 import 'package:mangayomi/utils/reg_exp_matcher.dart';
 import 'package:mangayomi/utils/utils.dart';
 import 'package:path/path.dart' as p;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'download_provider.g.dart';
+
+const _maxChapterDownloadConcurrency = 6;
+Future<void>? _activeDownloadQueueRun;
+bool _downloadQueueNeedsDrain = false;
 
 @riverpod
 Future<void> addDownloadToQueue(Ref ref, {required Chapter chapter}) async {
@@ -49,6 +54,20 @@ Future<void> addDownloadToQueue(Ref ref, {required Chapter chapter}) async {
     );
     isar.writeTxnSync(() {
       isar.downloads.putSync(download..chapter.value = chapter);
+    });
+  } else if (download.isDownload != true &&
+      download.isStartDownload != true) {
+    // A failed item can be explicitly requested again. Preserve the linked
+    // chapter and any already downloaded files, but reset queue state.
+    isar.writeTxnSync(() {
+      isar.downloads.putSync(
+        download
+          ..succeeded = 0
+          ..failed = 0
+          ..total = 100
+          ..isDownload = false
+          ..isStartDownload = true,
+      );
     });
   }
 }
@@ -85,7 +104,6 @@ Future<void> downloadChapter(
       chapter,
     );
     List<Track>? subtitles;
-    bool isOk = false;
     final manga = chapter.manga.value!;
     final chapterName = chapter.name!.replaceForbiddenCharacters(' ');
     final itemType = chapter.manga.value!.itemType;
@@ -207,48 +225,61 @@ Future<void> downloadChapter(
     }
 
     if (itemType == ItemType.manga) {
-      ref.read(getChapterPagesProvider(chapter: chapter).future).then((value) {
-        if (value.pageUrls.isNotEmpty) {
-          pageUrls = value.pageUrls;
-          isOk = true;
-        }
-      });
+      final chapterPages = await ref
+          .read(getChapterPagesProvider(chapter: chapter).future)
+          .timeout(
+            const Duration(seconds: 60),
+            onTimeout: () => throw TimeoutException(
+              'Timed out while loading pages for chapter ${chapter.id}',
+            ),
+          );
+      if (chapterPages.pageUrls.isEmpty) {
+        throw StateError('No pages returned for chapter ${chapter.id}');
+      }
+      pageUrls = chapterPages.pageUrls;
     } else if (itemType == ItemType.anime) {
-      ref.read(getVideoListProvider(episode: chapter).future).then((
-        value,
-      ) async {
-        final m3u8Urls = value.$1
-            .where(
-              (element) =>
-                  element.originalUrl.endsWith(".m3u8") ||
-                  element.originalUrl.endsWith(".m3u"),
-            )
-            .toList();
-        final nonM3u8Urls = value.$1
-            .where((element) => element.originalUrl.isMediaVideo())
-            .toList();
-        nonM3U8File = nonM3u8Urls.isNotEmpty;
-        hasM3U8File = nonM3U8File ? false : m3u8Urls.isNotEmpty;
-        final videosUrls = nonM3U8File ? nonM3u8Urls : m3u8Urls;
-        if (videosUrls.isNotEmpty) {
-          subtitles = videosUrls.first.subtitles;
-          if (hasM3U8File) {
-            m3u8Downloader = M3u8Downloader(
-              m3u8Url: videosUrls.first.url,
-              downloadDir: chapterDirectory.path,
-              headers: videosUrls.first.headers ?? {},
-              subtitles: subtitles,
-              fileName: p.join(mangaMainDirectory!.path, "$chapterName.mp4"),
-              chapter: chapter,
-            );
-          } else {
-            pageUrls = [PageUrl(videosUrls.first.url)];
-          }
-          videoHeader.addAll(videosUrls.first.headers ?? {});
-          isOk = true;
-        }
-      });
-    } else if (itemType == ItemType.novel && chapter.url != null) {
+      final videoList = await ref
+          .read(getVideoListProvider(episode: chapter).future)
+          .timeout(
+            const Duration(seconds: 60),
+            onTimeout: () => throw TimeoutException(
+              'Timed out while loading video for chapter ${chapter.id}',
+            ),
+          );
+      final m3u8Urls = videoList.$1
+          .where(
+            (element) =>
+                element.originalUrl.endsWith(".m3u8") ||
+                element.originalUrl.endsWith(".m3u"),
+          )
+          .toList();
+      final nonM3u8Urls = videoList.$1
+          .where((element) => element.originalUrl.isMediaVideo())
+          .toList();
+      nonM3U8File = nonM3u8Urls.isNotEmpty;
+      hasM3U8File = nonM3U8File ? false : m3u8Urls.isNotEmpty;
+      final videosUrls = nonM3U8File ? nonM3u8Urls : m3u8Urls;
+      if (videosUrls.isEmpty) {
+        throw StateError('No video returned for chapter ${chapter.id}');
+      }
+      subtitles = videosUrls.first.subtitles;
+      if (hasM3U8File) {
+        m3u8Downloader = M3u8Downloader(
+          m3u8Url: videosUrls.first.url,
+          downloadDir: chapterDirectory.path,
+          headers: videosUrls.first.headers ?? {},
+          subtitles: subtitles,
+          fileName: p.join(mangaMainDirectory!.path, "$chapterName.mp4"),
+          chapter: chapter,
+        );
+      } else {
+        pageUrls = [PageUrl(videosUrls.first.url)];
+      }
+      videoHeader.addAll(videosUrls.first.headers ?? {});
+    } else if (itemType == ItemType.novel) {
+      if (chapter.url == null) {
+        throw StateError('No URL available for novel chapter ${chapter.id}');
+      }
       final manga = chapter.manga.value!;
       final source = getSource(manga.lang!, manga.source!, manga.sourceId)!;
       final chapterUrl = "${source.baseUrl}${chapter.url!.getUrlWithoutDomain}";
@@ -265,16 +296,9 @@ Future<void> downloadChapter(
       } else {
         novelPage = PageUrl(chapterUrl);
       }
-      isOk = true;
+    } else {
+      throw UnsupportedError('Unsupported download item type: $itemType');
     }
-
-    await Future.doWhile(() async {
-      await Future.delayed(const Duration(seconds: 1));
-      if (isOk == true) {
-        return false;
-      }
-      return true;
-    });
 
     if (pageUrls.isNotEmpty) {
       bool cbzFileExist =
@@ -398,52 +422,100 @@ Future<void> downloadChapter(
     if (callback != null) {
       callback();
     }
-    keepAlive.close();
-  } catch (_) {
+  } catch (error, stackTrace) {
+    final message =
+        'Download failed for chapter ${chapter.id} (${chapter.name}): '
+        '$error\n$stackTrace';
+    AppLogger.log(message, logLevel: LogLevel.error);
+    debugPrint(message);
+    rethrow;
+  } finally {
     keepAlive.close();
   }
 }
 
 @riverpod
 Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
+  final activeRun = _activeDownloadQueueRun;
+  if (activeRun != null) {
+    _downloadQueueNeedsDrain = true;
+    return activeRun;
+  }
+
+  final run = _drainDownloadQueue(ref, useWifi: useWifi);
+  _activeDownloadQueueRun = run;
+
+  try {
+    await run;
+  } finally {
+    if (identical(_activeDownloadQueueRun, run)) {
+      _activeDownloadQueueRun = null;
+    }
+  }
+}
+
+Future<void> _drainDownloadQueue(Ref ref, {bool? useWifi}) async {
   final keepAlive = ref.keepAlive();
   try {
-    final ongoingDownloads = await isar.downloads
-        .filter()
-        .idIsNotNull()
-        .isDownloadEqualTo(false)
-        .isStartDownloadEqualTo(true)
-        .findAll();
-    final maxConcurrentDownloads = ref.read(concurrentDownloadsStateProvider);
-    int index = 0;
-    int downloaded = 0;
-    int current = 0;
-    await Future.doWhile(() async {
-      await Future.delayed(const Duration(seconds: 1));
-      if (ongoingDownloads.length == downloaded) {
-        return false;
+    final attemptedIds = <int>{};
+    while (true) {
+      _downloadQueueNeedsDrain = false;
+      final ongoingDownloads = await isar.downloads
+          .filter()
+          .idIsNotNull()
+          .isDownloadEqualTo(false)
+          .isStartDownloadEqualTo(true)
+          .findAll();
+      final pendingDownloads = ongoingDownloads
+          .where((download) => !attemptedIds.contains(download.id))
+          .toList(growable: false);
+
+      if (pendingDownloads.isEmpty) {
+        if (_downloadQueueNeedsDrain) continue;
+        break;
       }
-      if (current < maxConcurrentDownloads) {
-        current++;
-        final downloadItem = ongoingDownloads[index++];
-        final chapter = downloadItem.chapter.value!;
-        chapter.cancelDownloads(downloadItem.id);
-        await Future.delayed(const Duration(milliseconds: 500));
-        ref.read(
-          downloadChapterProvider(
-            chapter: chapter,
-            useWifi: useWifi,
-            callback: () {
-              downloaded++;
-              current--;
-            },
-          ),
+
+      final configuredConcurrency = ref.read(concurrentDownloadsStateProvider);
+      final concurrency = configuredConcurrency < 1
+          ? 1
+          : configuredConcurrency > _maxChapterDownloadConcurrency
+          ? _maxChapterDownloadConcurrency
+          : configuredConcurrency;
+      final runner = DownloadQueueRunner<void>(concurrency: concurrency);
+      final run = await runner.run(
+        pendingDownloads.map((downloadItem) {
+          final downloadId = downloadItem.id!;
+          attemptedIds.add(downloadId);
+          return () async {
+            final chapter = downloadItem.chapter.value;
+            if (chapter == null) {
+              throw StateError('Download $downloadId has no linked chapter');
+            }
+            await ref.read(
+              downloadChapterProvider(chapter: chapter, useWifi: useWifi).future,
+            );
+          };
+        }),
+      );
+
+      for (final outcome in run.failures) {
+        final downloadItem = pendingDownloads[outcome.index];
+        isar.writeTxnSync(() {
+          final download = isar.downloads.getSync(downloadItem.id!);
+          if (download == null || download.isDownload == true) return;
+          isar.downloads.putSync(
+            download
+              ..isStartDownload = false
+              ..failed = (download.failed ?? 0) + 1,
+          );
+        });
+        AppLogger.log(
+          'Download queue item ${downloadItem.id} failed: ${outcome.error}',
+          logLevel: LogLevel.error,
         );
       }
-      return true;
-    });
-    keepAlive.close();
-  } catch (_) {
+    }
+  } finally {
     keepAlive.close();
   }
 }

--- a/lib/services/download_manager/download_isolate_pool.dart
+++ b/lib/services/download_manager/download_isolate_pool.dart
@@ -4,18 +4,17 @@ import 'dart:async';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart';
+import 'package:http/io_client.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/page.dart';
-import 'package:mangayomi/services/http/m_client.dart';
-import 'package:mangayomi/services/http/rhttp/src/model/settings.dart';
 import 'package:mangayomi/services/download_manager/m3u8/models/download.dart';
 import 'package:mangayomi/services/download_manager/m3u8/models/ts_info.dart';
-import 'package:mangayomi/src/rust/frb_generated.dart';
 import 'package:mangayomi/utils/extensions/string_extensions.dart';
 import 'package:path/path.dart' as path;
 import 'package:encrypt/encrypt.dart' as encrypt;
 
 final downloadTaskCancellation = <String, bool>{};
+const _downloadRequestTimeout = Duration(seconds: 60);
 
 /// Shared Isolate pool to optimize performance
 /// Instead of creating a new Isolate for each download,
@@ -372,15 +371,10 @@ class _WorkerTask {
 
 /// Isolate worker entry point
 void _workerEntryPoint(_WorkerInit init) async {
-  // Initialize dependencies in the Isolate
-  await RustLib.init();
-
-  final httpClient = MClient.httpClient(
-    settings: const ClientSettings(
-      throwOnStatusCode: false,
-      tlsSettings: TlsSettings(verifyCertificates: false),
-    ),
-  );
+  // Keep one Dart HTTP client per persistent worker. The previous path
+  // initialized a separate Rust/rhttp runtime in every worker, which made
+  // large queues allocate unnecessary native resources.
+  final httpClient = _createWorkerHttpClient();
 
   // Create the receive port for this worker
   final receivePort = ReceivePort();
@@ -414,6 +408,13 @@ void _workerEntryPoint(_WorkerInit init) async {
       }
     }
   }
+}
+
+Client _createWorkerHttpClient() {
+  final dartHttpClient = HttpClient()
+    ..badCertificateCallback =
+        (X509Certificate certificate, String host, int port) => true;
+  return IOClient(dartHttpClient);
 }
 
 /// Process a file download
@@ -481,7 +482,9 @@ Future<void> _downloadFile(
   try {
     if (itemType != ItemType.anime) {
       final response = await _withRetry(
-        () => client.get(Uri.parse(pageUrl.url), headers: pageUrl.headers),
+        () => client
+            .get(Uri.parse(pageUrl.url), headers: pageUrl.headers)
+            .timeout(_downloadRequestTimeout),
         3,
       );
       if (response.statusCode != 200) {
@@ -497,7 +500,9 @@ Future<void> _downloadFile(
       await _withRetry(() async {
         var request = Request('GET', Uri.parse(pageUrl.url));
         request.headers.addAll(pageUrl.headers ?? {});
-        StreamedResponse response = await client.send(request);
+        StreamedResponse response = await client
+            .send(request)
+            .timeout(_downloadRequestTimeout);
         // Accept any 2xx — including 206 Partial Content, which the server
         // returns when the source extension sends `Range: bytes=0-` on the
         // streaming request (e.g. AnimeGG). Rejecting 206 here caused 3
@@ -514,7 +519,9 @@ Future<void> _downloadFile(
         final file = File(pageUrl.fileName!);
         final sink = file.openWrite();
         try {
-          await for (var value in response.stream) {
+          await for (var value in response.stream.timeout(
+            _downloadRequestTimeout,
+          )) {
             sink.add(value);
             received += value.length;
             try {
@@ -609,7 +616,10 @@ Future<void> _downloadSegment(
     if (params.headers != null) {
       request.headers.addAll(params.headers!);
     }
-    StreamedResponse response = await _withRetry(() => client.send(request), 3);
+    StreamedResponse response = await _withRetry(
+      () => client.send(request).timeout(_downloadRequestTimeout),
+      3,
+    );
 
     // Accept any 2xx (including 206 Partial Content) — see comment in
     // _downloadFile.
@@ -621,7 +631,9 @@ Future<void> _downloadSegment(
 
     final sink = file.openWrite();
     try {
-      await for (var chunk in response.stream) {
+      await for (var chunk in response.stream.timeout(
+        _downloadRequestTimeout,
+      )) {
         sink.add(chunk);
       }
     } finally {

--- a/lib/services/download_manager/download_queue_runner.dart
+++ b/lib/services/download_manager/download_queue_runner.dart
@@ -1,0 +1,121 @@
+/// A single download job executed by [DownloadQueueRunner].
+typedef DownloadQueueJob<T> = Future<T> Function();
+
+enum DownloadQueueOutcomeType { success, failure }
+
+class DownloadQueueOutcome<T> {
+  const DownloadQueueOutcome._({
+    required this.index,
+    required this.type,
+    this.value,
+    this.error,
+    this.stackTrace,
+  });
+
+  const DownloadQueueOutcome.success({required int index, required T value})
+    : this._(
+        index: index,
+        type: DownloadQueueOutcomeType.success,
+        value: value,
+      );
+
+  const DownloadQueueOutcome.failure({
+    required int index,
+    required Object error,
+    required StackTrace stackTrace,
+  }) : this._(
+         index: index,
+         type: DownloadQueueOutcomeType.failure,
+         error: error,
+         stackTrace: stackTrace,
+       );
+
+  final int index;
+  final DownloadQueueOutcomeType type;
+  final T? value;
+  final Object? error;
+  final StackTrace? stackTrace;
+
+  bool get isSuccess => type == DownloadQueueOutcomeType.success;
+  bool get isFailure => type == DownloadQueueOutcomeType.failure;
+}
+
+class DownloadQueueRun<T> {
+  const DownloadQueueRun(this.outcomes);
+
+  final List<DownloadQueueOutcome<T>> outcomes;
+
+  Iterable<DownloadQueueOutcome<T>> get successes =>
+      outcomes.where((outcome) => outcome.isSuccess);
+
+  Iterable<DownloadQueueOutcome<T>> get failures =>
+      outcomes.where((outcome) => outcome.isFailure);
+
+  bool get isSuccessful => failures.isEmpty;
+}
+
+/// Runs each job once with a bounded number of workers.
+///
+/// A failed job is recorded as an outcome so it cannot stop later jobs. Retry
+/// and cancellation remain the responsibility of the caller.
+class DownloadQueueRunner<T> {
+  DownloadQueueRunner({required this.concurrency}) {
+    if (concurrency <= 0) {
+      throw ArgumentError.value(
+        concurrency,
+        'concurrency',
+        'must be greater than zero',
+      );
+    }
+  }
+
+  final int concurrency;
+
+  Future<DownloadQueueRun<T>> run(Iterable<DownloadQueueJob<T>> jobs) async {
+    final jobList = jobs.toList(growable: false);
+    if (jobList.isEmpty) {
+      return DownloadQueueRun(<DownloadQueueOutcome<T>>[]);
+    }
+
+    final outcomes = List<DownloadQueueOutcome<T>?>.filled(
+      jobList.length,
+      null,
+    );
+    var nextJobIndex = 0;
+
+    Future<void> runWorker() async {
+      while (true) {
+        final jobIndex = nextJobIndex++;
+        if (jobIndex >= jobList.length) return;
+        try {
+          outcomes[jobIndex] = DownloadQueueOutcome.success(
+            index: jobIndex,
+            value: await jobList[jobIndex](),
+          );
+        } catch (error, stackTrace) {
+          outcomes[jobIndex] = DownloadQueueOutcome.failure(
+            index: jobIndex,
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
+      }
+    }
+
+    final workerCount = concurrency < jobList.length
+        ? concurrency
+        : jobList.length;
+    await Future.wait(
+      List<Future<void>>.generate(workerCount, (_) => runWorker()),
+    );
+
+    return DownloadQueueRun(
+      List<DownloadQueueOutcome<T>>.unmodifiable(
+        List<DownloadQueueOutcome<T>>.generate(
+          outcomes.length,
+          (index) => outcomes[index]!,
+        ),
+      ),
+    );
+  }
+}

--- a/test/services/download_manager/download_queue_runner_test.dart
+++ b/test/services/download_manager/download_queue_runner_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/download_manager/download_queue_runner.dart';
+
+void main() {
+  test('returns successful outcomes in original job order', () async {
+    final runner = DownloadQueueRunner<int>(concurrency: 2);
+
+    final run = await runner.run(<DownloadQueueJob<int>>[
+      () async => 1,
+      () async => 2,
+      () async => 3,
+    ]);
+
+    expect(run.isSuccessful, isTrue);
+    expect(run.outcomes.map((outcome) => outcome.index), <int>[0, 1, 2]);
+    expect(run.successes.map((outcome) => outcome.value), <int?>[1, 2, 3]);
+  });
+
+  test('records a failure and continues with later jobs', () async {
+    final runner = DownloadQueueRunner<int>(concurrency: 1);
+    final executed = <int>[];
+
+    final run = await runner.run(<DownloadQueueJob<int>>[
+      () async {
+        executed.add(1);
+        return 1;
+      },
+      () async {
+        executed.add(2);
+        throw StateError('expected failure');
+      },
+      () async {
+        executed.add(3);
+        return 3;
+      },
+    ]);
+
+    expect(executed, <int>[1, 2, 3]);
+    expect(run.outcomes[1].error, isA<StateError>());
+    expect(run.successes.length, 2);
+    expect(run.failures.length, 1);
+  });
+
+  test('never runs more jobs than the configured concurrency', () async {
+    const concurrency = 2;
+    final runner = DownloadQueueRunner<int>(concurrency: concurrency);
+    var activeJobs = 0;
+    var maximumActiveJobs = 0;
+
+    Future<int> job(int value) async {
+      activeJobs++;
+      maximumActiveJobs = maximumActiveJobs > activeJobs
+          ? maximumActiveJobs
+          : activeJobs;
+      try {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        return value;
+      } finally {
+        activeJobs--;
+      }
+    }
+
+    final run = await runner.run(
+      List<DownloadQueueJob<int>>.generate(7, (index) => () => job(index)),
+    );
+
+    expect(maximumActiveJobs, concurrency);
+    expect(run.outcomes.length, 7);
+  });
+
+  test('rejects a non-positive concurrency', () {
+    expect(
+      () => DownloadQueueRunner<Object>(concurrency: 0),
+      throwsArgumentError,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- remove per-worker Rust/rhttp runtime initialization from the shared download pool
- add finite request and stream timeouts for image, direct video, and M3U8 segment downloads
- replace polling-based chapter preparation with awaited, bounded provider calls
- run chapter downloads through a bounded queue and isolate individual failures
- drain items added while a queue run is active and allow explicit retry of failed records
- add queue runner tests for ordering, failure isolation, and concurrency limits

## Why

Large download queues could keep waiting indefinitely when page/video preparation did not resolve, and one failed chapter could prevent later work from progressing. Each worker also initialized a native HTTP runtime, creating unnecessary process-wide resource pressure.

## Scope

This PR is limited to shared download reliability. Progress persistence batching, queue-screen rebuild reduction, and page URL cache write reduction are planned for a follow-up performance PR.

## Validation

- git diff --check passed
- queue runner tests were added
- local Flutter analyze/test could not be run because the Flutter SDK is not available on the current shell PATH
- GitHub Actions should provide the Flutter compile and test validation

No NTK source or reader changes are included.
