### PR TITLE
perf(downloads): batch progress and reduce duplicate cache writes

### DIFF
--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:ui';

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:ui';
@@ -20,6 +21,7 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
+import 'package:mangayomi/services/download_manager/download_progress_batcher.dart';
 import 'package:mangayomi/services/get_video_list.dart';
 import 'package:mangayomi/services/get_chapter_pages.dart';
 import 'package:mangayomi/services/http/m_client.dart';
@@ -34,6 +36,59 @@ import 'package:mangayomi/utils/utils.dart';
 import 'package:path/path.dart' as p;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'download_provider.g.dart';
+
+Future<void> _persistDownloadProgress(
+  List<DownloadProgressUpdate> updates,
+) async {
+  await isar.writeTxn(() async {
+    for (final update in updates) {
+      final download = await isar.downloads.get(update.chapterId);
+      if (download == null ||
+          (download.isDownload == true && !update.isCompleted)) {
+        continue;
+      }
+      if (update.isFailed) {
+        await isar.downloads.put(
+          download
+            ..isStartDownload = false
+            ..isDownload = false
+            ..failed = (download.failed ?? 0) + 1,
+        );
+        continue;
+      }
+      final current = download.succeeded ?? 0;
+      if (!update.isCompleted && update.succeeded < current) continue;
+      await isar.downloads.put(
+        download
+          ..succeeded = update.succeeded
+          ..failed = 0
+          ..total = 100
+          ..isDownload = update.isCompleted
+          ..isStartDownload = true,
+      );
+    }
+  });
+}
+
+final _downloadProgressBatcher = DownloadProgressBatcher(
+  persist: _persistDownloadProgress,
+);
+
+void _ensureDownloadRecord(Chapter chapter) {
+  if (isar.downloads.getSync(chapter.id!) != null) return;
+  isar.writeTxnSync(() {
+    isar.downloads.putSync(
+      Download(
+        id: chapter.id,
+        succeeded: 0,
+        failed: 0,
+        total: 100,
+        isDownload: false,
+        isStartDownload: true,
+      )..chapter.value = chapter,
+    );
+  });
+}
 
 @riverpod
 Future<void> addDownloadToQueue(Ref ref, {required Chapter chapter}) async {
@@ -143,68 +198,21 @@ Future<void> downloadChapter(
       if (progress.isCompleted && itemType == ItemType.manga) {
         await processConvert();
       }
-      final download = isar.downloads.getSync(chapter.id!);
-      if (download == null) {
-        final download = Download(
-          id: chapter.id,
-          succeeded: progress.completed == 0
-              ? 0
-              : (progress.completed / progress.total * 100).toInt(),
-          failed: 0,
-          total: 100,
-          isDownload: progress.isCompleted,
-          isStartDownload: true,
-        );
-        isar.writeTxnSync(() {
-          isar.downloads.putSync(download..chapter.value = chapter);
-        });
-      } else {
-        final download = isar.downloads.getSync(chapter.id!);
-        if (download != null && progress.total != 0) {
-          isar.writeTxnSync(() {
-            isar.downloads.putSync(
-              download
-                ..succeeded = progress.completed == 0
-                    ? 0
-                    : (progress.completed / progress.total * 100).toInt()
-                ..total = 100
-                ..failed = 0
-                ..isDownload = progress.isCompleted,
-            );
-          });
-        }
-      }
-    }
-
-    setProgress(DownloadProgress(0, 0, itemType));
-    void savePageUrls() {
-      final settings = isar.settings.getSync(227)!;
-      List<ChapterPageurls>? chapterPageUrls = [];
-      for (var chapterPageUrl in settings.chapterPageUrlsList ?? []) {
-        if (chapterPageUrl.chapterId != chapter.id) {
-          chapterPageUrls.add(chapterPageUrl);
-        }
-      }
-      final chapterPageHeaders = pageUrls
-          .map((e) => e.headers == null ? null : jsonEncode(e.headers))
-          .toList();
-      chapterPageUrls.add(
-        ChapterPageurls()
-          ..chapterId = chapter.id
-          ..urls = pageUrls.map((e) => e.url).toList()
-          ..chapterUrl = chapter.url
-          ..headers = chapterPageHeaders.first != null
-              ? chapterPageHeaders.map((e) => e.toString()).toList()
-              : null,
-      );
-      isar.writeTxnSync(
-        () => isar.settings.putSync(
-          settings
-            ..chapterPageUrlsList = chapterPageUrls
-            ..updatedAt = DateTime.now().millisecondsSinceEpoch,
+      final succeeded = progress.total == 0
+          ? 0
+          : (progress.completed / progress.total * 100).toInt();
+      _downloadProgressBatcher.update(
+        DownloadProgressUpdate(
+          chapterId: chapter.id!,
+          succeeded: succeeded,
+          isCompleted: progress.isCompleted,
         ),
       );
+      if (progress.isCompleted) await _downloadProgressBatcher.flushNow();
     }
+
+    _ensureDownloadRecord(chapter);
+    _downloadProgressBatcher.reset(chapter.id!);
 
     if (itemType == ItemType.manga) {
       ref.read(getChapterPagesProvider(chapter: chapter).future).then((value) {
@@ -356,19 +364,17 @@ Future<void> downloadChapter(
       }
 
       if (pages.isEmpty && pageUrls.isNotEmpty) {
-        await processConvert();
-        savePageUrls();
         await setProgress(DownloadProgress(1, 1, itemType, isCompleted: true));
       } else {
-        savePageUrls();
         await MDownloader(
           chapter: chapter,
           pageUrls: pages,
           subtitles: subtitles,
           subDownloadDir: chapterDirectory.path,
         ).download((progress) {
-          setProgress(progress);
+          if (!progress.isCompleted) setProgress(progress);
         });
+        await setProgress(DownloadProgress(1, 1, itemType, isCompleted: true));
       }
     } else if (itemType == ItemType.novel) {
       final file = File(p.join(chapterDirectory.path, "$chapterName.html"));
@@ -392,8 +398,9 @@ Future<void> downloadChapter(
       }
     } else if (hasM3U8File) {
       await m3u8Downloader?.download((progress) {
-        setProgress(progress);
+        if (!progress.isCompleted) setProgress(progress);
       });
+      await setProgress(DownloadProgress(1, 1, itemType, isCompleted: true));
     }
     if (callback != null) {
       callback();

--- a/lib/modules/more/download_queue/download_queue_screen.dart
+++ b/lib/modules/more/download_queue/download_queue_screen.dart
@@ -23,7 +23,6 @@ class DownloadQueueScreen extends ConsumerWidget {
           .idIsNotNull()
           .isDownloadEqualTo(false)
           .isStartDownloadEqualTo(true)
-          .sortBySucceededDesc()
           .watch(fireImmediately: true),
       builder: (context, snapshot) {
         if (snapshot.hasData && snapshot.data!.isNotEmpty) {
@@ -53,6 +52,14 @@ class DownloadQueueScreen extends ConsumerWidget {
               body: Center(child: Text(l10n.no_downloads)),
             );
           }
+          entries.sort((left, right) {
+            final sourceOrder =
+                (right.chapter.value?.manga.value?.source ?? "").compareTo(
+                  left.chapter.value?.manga.value?.source ?? "",
+                );
+            if (sourceOrder != 0) return sourceOrder;
+            return (left.id ?? 0).compareTo(right.id ?? 0);
+          });
           final allQueueLength = entries.length;
           return Scaffold(
             appBar: AppBar(
@@ -193,11 +200,7 @@ class DownloadQueueScreen extends ConsumerWidget {
                   ),
                 );
               },
-              itemComparator: (item1, item2) =>
-                  (item1.chapter.value?.manga.value?.source ?? "").compareTo(
-                    item2.chapter.value?.manga.value?.source ?? "",
-                  ),
-              order: GroupedListOrder.DESC,
+              sort: false,
             ),
             floatingActionButton: CustomFloatingActionBtn(
               isExtended: false,

--- a/lib/services/download_manager/download_progress_batcher.dart
+++ b/lib/services/download_manager/download_progress_batcher.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+
+class DownloadProgressUpdate {
+  const DownloadProgressUpdate({
+    required this.chapterId,
+    required this.succeeded,
+    required this.isCompleted,
+    this.isFailed = false,
+  });
+
+  final int chapterId;
+  final int succeeded;
+  final bool isCompleted;
+  final bool isFailed;
+
+  bool get isTerminal => isCompleted || isFailed;
+}
+
+typedef DownloadProgressPersist =
+    Future<void> Function(List<DownloadProgressUpdate> updates);
+
+/// Coalesces progress events from all active downloads into bounded writes.
+class DownloadProgressBatcher {
+  DownloadProgressBatcher({
+    required this.persist,
+    this.interval = const Duration(milliseconds: 250),
+  });
+
+  final DownloadProgressPersist persist;
+  final Duration interval;
+  final Map<int, DownloadProgressUpdate> _pending = {};
+  final Set<int> _terminalChapters = {};
+  Timer? _timer;
+  Future<void>? _flushFuture;
+  bool _disposed = false;
+
+  void update(DownloadProgressUpdate update) {
+    if (_disposed) return;
+    if (_terminalChapters.contains(update.chapterId)) return;
+
+    final previous = _pending[update.chapterId];
+    if (previous?.isTerminal == true) return;
+    if (previous != null &&
+        !update.isCompleted &&
+        update.succeeded < previous.succeeded) {
+      return;
+    }
+
+    _pending[update.chapterId] = update;
+    if (update.isTerminal) {
+      _terminalChapters.add(update.chapterId);
+      unawaited(flushNow());
+    } else {
+      _scheduleFlush();
+    }
+  }
+
+  void reset(int chapterId) {
+    if (_disposed) return;
+    _pending.remove(chapterId);
+    _terminalChapters.remove(chapterId);
+  }
+
+  Future<void> flushNow() async {
+    _timer?.cancel();
+    _timer = null;
+    await _flushLoop();
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    await flushNow();
+    _disposed = true;
+    _timer?.cancel();
+    _timer = null;
+    _pending.clear();
+    _terminalChapters.clear();
+  }
+
+  void _scheduleFlush() {
+    if (_timer != null || _disposed) return;
+    _timer = Timer(interval, () {
+      _timer = null;
+      unawaited(flushNow());
+    });
+  }
+
+  Future<void> _flushLoop() {
+    final active = _flushFuture;
+    if (active != null) return active;
+
+    final future = _runFlushLoop();
+    _flushFuture = future;
+    return future.whenComplete(() {
+      if (identical(_flushFuture, future)) {
+        _flushFuture = null;
+      }
+    });
+  }
+
+  Future<void> _runFlushLoop() async {
+    while (_pending.isNotEmpty) {
+      final updates = List<DownloadProgressUpdate>.unmodifiable(
+        _pending.values,
+      );
+      _pending.clear();
+      await persist(updates);
+    }
+  }
+}

--- a/lib/services/get_chapter_pages.dart
+++ b/lib/services/get_chapter_pages.dart
@@ -18,6 +18,15 @@ import 'package:mangayomi/modules/more/providers/incognito_mode_state_provider.d
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'get_chapter_pages.g.dart';
 
+bool _sameList<T>(List<T>? left, List<T>? right) {
+  if (left == null || right == null) return left == right;
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) return false;
+  }
+  return true;
+}
+
 class GetChapterPagesModel {
   Directory? path;
   List<PageUrl> pageUrls = [];
@@ -124,31 +133,38 @@ Future<GetChapterPagesModel> getChapterPages(
         }
       }
       if (!incognitoMode) {
-        List<ChapterPageurls>? chapterPageUrls = [];
-        for (var chapterPageUrl in settings.chapterPageUrlsList ?? []) {
-          if (chapterPageUrl.chapterId != chapter.id) {
-            chapterPageUrls.add(chapterPageUrl);
-          }
-        }
+        final cachedUrls = isarPageUrls?.urls;
+        final cachedHeaders = isarPageUrls?.headers;
+        final pageUrlValues = pageUrls.map((e) => e.url).toList();
         final chapterPageHeaders = pageUrls
             .map((e) => e.headers == null ? null : jsonEncode(e.headers))
             .toList();
-        chapterPageUrls.add(
-          ChapterPageurls()
-            ..chapterId = chapter.id
-            ..urls = pageUrls.map((e) => e.url).toList()
-            ..chapterUrl = chapter.url
-            ..headers = chapterPageHeaders.first != null
-                ? chapterPageHeaders.map((e) => e.toString()).toList()
-                : null,
-        );
-        isar.writeTxnSync(() {
-          isar.settings.putSync(
-            settings
-              ..chapterPageUrlsList = chapterPageUrls
-              ..updatedAt = DateTime.now().millisecondsSinceEpoch,
-          );
-        });
+        final pageHeaderValues = chapterPageHeaders.first != null
+            ? chapterPageHeaders.map((e) => e.toString()).toList()
+            : null;
+        final cacheUnchanged =
+            isarPageUrls != null &&
+            isarPageUrls!.chapterUrl == chapter.url &&
+            _sameList(cachedUrls, pageUrlValues) &&
+            _sameList(cachedHeaders, pageHeaderValues);
+        if (!cacheUnchanged) {
+          final chapterPageUrls = [
+            for (final chapterPageUrl in settings.chapterPageUrlsList ?? [])
+              if (chapterPageUrl.chapterId != chapter.id) chapterPageUrl,
+            ChapterPageurls()
+              ..chapterId = chapter.id
+              ..urls = pageUrlValues
+              ..chapterUrl = chapter.url
+              ..headers = pageHeaderValues,
+          ];
+          isar.writeTxnSync(() {
+            isar.settings.putSync(
+              settings
+                ..chapterPageUrlsList = chapterPageUrls
+                ..updatedAt = DateTime.now().millisecondsSinceEpoch,
+            );
+          });
+        }
       }
       for (var i = 0; i < pageUrls.length; i++) {
         chapterModel.uChapDataPreload.add(

--- a/test/services/download_manager/download_progress_batcher_test.dart
+++ b/test/services/download_manager/download_progress_batcher_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/download_manager/download_progress_batcher.dart';
+
+void main() {
+  test('coalesces progress updates by chapter', () async {
+    final batches = <List<DownloadProgressUpdate>>[];
+    final batcher = DownloadProgressBatcher(
+      interval: const Duration(hours: 1),
+      persist: (updates) async => batches.add(updates),
+    );
+
+    batcher.update(
+      const DownloadProgressUpdate(
+        chapterId: 1,
+        succeeded: 10,
+        isCompleted: false,
+      ),
+    );
+    batcher.update(
+      const DownloadProgressUpdate(
+        chapterId: 1,
+        succeeded: 25,
+        isCompleted: false,
+      ),
+    );
+    batcher.update(
+      const DownloadProgressUpdate(
+        chapterId: 2,
+        succeeded: 50,
+        isCompleted: false,
+      ),
+    );
+
+    await batcher.flushNow();
+
+    expect(batches, hasLength(1));
+    expect(
+      batches.single.map((update) => update.chapterId),
+      containsAll(<int>[1, 2]),
+    );
+    expect(
+      batches.single.firstWhere((update) => update.chapterId == 1).succeeded,
+      25,
+    );
+  });
+
+  test(
+    'terminal progress flushes immediately and wins over stale progress',
+    () async {
+      final batches = <List<DownloadProgressUpdate>>[];
+      final batcher = DownloadProgressBatcher(
+        interval: const Duration(hours: 1),
+        persist: (updates) async => batches.add(updates),
+      );
+
+      batcher.update(
+        const DownloadProgressUpdate(
+          chapterId: 1,
+          succeeded: 50,
+          isCompleted: false,
+        ),
+      );
+      batcher.update(
+        const DownloadProgressUpdate(
+          chapterId: 1,
+          succeeded: 100,
+          isCompleted: true,
+        ),
+      );
+      await batcher.flushNow();
+      batcher.update(
+        const DownloadProgressUpdate(
+          chapterId: 1,
+          succeeded: 90,
+          isCompleted: false,
+        ),
+      );
+      await batcher.flushNow();
+
+      expect(batches, hasLength(1));
+      expect(batches.single.single.succeeded, 100);
+      expect(batches.single.single.isCompleted, isTrue);
+    },
+  );
+
+  test('failed progress is terminal', () async {
+    final batches = <List<DownloadProgressUpdate>>[];
+    final batcher = DownloadProgressBatcher(
+      interval: const Duration(hours: 1),
+      persist: (updates) async => batches.add(updates),
+    );
+
+    batcher.update(
+      const DownloadProgressUpdate(
+        chapterId: 1,
+        succeeded: 40,
+        isCompleted: false,
+      ),
+    );
+    batcher.update(
+      const DownloadProgressUpdate(
+        chapterId: 1,
+        succeeded: 40,
+        isCompleted: false,
+        isFailed: true,
+      ),
+    );
+    await batcher.flushNow();
+    batcher.update(
+      const DownloadProgressUpdate(
+        chapterId: 1,
+        succeeded: 90,
+        isCompleted: false,
+      ),
+    );
+    await batcher.flushNow();
+
+    expect(batches, hasLength(1));
+    expect(batches.single.single.isFailed, isTrue);
+  });
+
+  test('does not regress progress within a batch', () async {
+    final batches = <List<DownloadProgressUpdate>>[];
+    final batcher = DownloadProgressBatcher(
+      interval: const Duration(hours: 1),
+      persist: (updates) async => batches.add(updates),
+    );
+
+    batcher.update(
+      const DownloadProgressUpdate(
+        chapterId: 1,
+        succeeded: 80,
+        isCompleted: false,
+      ),
+    );
+    batcher.update(
+      const DownloadProgressUpdate(
+        chapterId: 1,
+        succeeded: 20,
+        isCompleted: false,
+      ),
+    );
+    await batcher.flushNow();
+
+    expect(batches.single.single.succeeded, 80);
+  });
+}


### PR DESCRIPTION
## Summary

- batch download progress writes across active chapters instead of persisting every callback
- keep terminal progress updates immediate and monotonic, including retry reset behavior
- avoid duplicate embedded page URL cache writes when chapter data is unchanged
- sort the download queue once before rendering instead of relying on database ordering and grouped-list re-sorting

## Scope

This is the independent performance companion to the queue reliability change. It is based on the upstream `main` branch so it can be reviewed and merged separately.

## Validation

- `git diff --check upstream/main..HEAD`
- added focused `DownloadProgressBatcher` tests for coalescing, terminal updates, retry reset behavior, and monotonic progress

Flutter/Dart execution was not available in this environment, so the focused tests still need to run in CI or a Flutter development environment.
