### PR TITLE
feat: custom network endpoints (DoH + proxy) and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+# Build/compile checks for pull requests and main. The release workflow only
+# runs on version tags, so without this nothing verifies that a PR (or main)
+# actually compiles until a release is cut. This catches that earlier.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # Generated files (frb_generated.dart, *.g.dart, l10n) are committed, so
+      # analyze runs without the Rust/codegen toolchain. Fail only on errors
+      # (e.g. undefined symbols / type errors), not pre-existing infos/warnings.
+      - name: Analyze
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+  build-android:
+    name: Build (Android debug)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Java toolchain
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.18.1"
+
+      - name: Setup ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+
+      - name: Install flutter_rust_bridge_codegen
+        run: cargo install 'flutter_rust_bridge_codegen'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # Debug build: needs no signing secrets, so it also runs on fork PRs,
+      # while still compiling the full Dart + Kotlin + Rust bridge.
+      - name: Build debug APK
+        run: flutter build apk --debug

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,6 +10,11 @@
 analyzer:
   errors:
     unintended_html_in_doc_comment: ignore
+  exclude:
+    # Vendored flutter_rust_bridge build tool — a separate package with its own
+    # dependencies that aren't resolved in the app's analysis context, so it
+    # reports false errors. It's build-time only, not app code.
+    - rust_builder/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'package:mangayomi/modules/more/settings/appearance/providers/theme_mode_
 import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/services/http/m_client.dart';
 import 'package:mangayomi/services/http/doh/doh_custom_store.dart';
+import 'package:mangayomi/services/http/cf_proxy_store.dart';
 import 'package:mangayomi/services/isolate_service.dart';
 import 'package:mangayomi/services/m_extension_server.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
@@ -179,6 +180,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
   await DohCustomStore.openBox();
+  await CfProxyStore.openBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/theme_mode_state_provider.dart';
 import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/services/http/m_client.dart';
+import 'package:mangayomi/services/http/doh/doh_custom_store.dart';
 import 'package:mangayomi/services/isolate_service.dart';
 import 'package:mangayomi/services/m_extension_server.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
@@ -177,6 +178,7 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
+  await DohCustomStore.openBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,8 +32,6 @@ import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/theme_mode_state_provider.dart';
 import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/services/http/m_client.dart';
-import 'package:mangayomi/services/http/doh/doh_custom_store.dart';
-import 'package:mangayomi/services/http/cf_proxy_store.dart';
 import 'package:mangayomi/services/isolate_service.dart';
 import 'package:mangayomi/services/m_extension_server.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
@@ -179,8 +177,6 @@ Future<void> _postLaunchInit(StorageProvider storage) async {
   final hivePath = isApple ? "databases" : p.join("Mangayomi", "databases");
   await Hive.initFlutter(Platform.isAndroid ? "" : hivePath);
   Hive.registerAdapter(TrackSearchAdapter());
-  await DohCustomStore.openBox();
-  await CfProxyStore.openBox();
   if (isDesktop && !kDebugMode) {
     discordRpc = DiscordRPC(applicationId: "1395040506677039157");
     await discordRpc?.initialize();

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -184,6 +184,10 @@ class Settings {
 
   int? doHProviderId;
 
+  String? customDohUrl;
+
+  String? cfProxyUrl;
+
   String? btServerAddress;
 
   int? btServerPort;
@@ -465,6 +469,8 @@ class Settings {
     this.customDns = "",
     this.doHEnabled = false,
     this.doHProviderId = 0,
+    this.customDohUrl = "",
+    this.cfProxyUrl = "",
     this.btServerAddress = "127.0.0.1",
     this.btServerPort,
     this.fullScreenReader = true,
@@ -722,6 +728,8 @@ class Settings {
     customDns = json['customDns'];
     doHEnabled = json['doHEnabled'];
     doHProviderId = json['doHProviderId'];
+    customDohUrl = json['customDohUrl'];
+    cfProxyUrl = json['cfProxyUrl'];
     btServerAddress = json['btServerAddress'];
     btServerPort = json['btServerPort'];
     customColorFilter = json['customColorFilter'] != null
@@ -975,6 +983,8 @@ class Settings {
     'customDns': customDns,
     'doHEnabled': doHEnabled,
     'doHProviderId': doHProviderId,
+    'customDohUrl': customDohUrl,
+    'cfProxyUrl': cfProxyUrl,
     'btServerAddress': btServerAddress,
     'btServerPort': btServerPort,
     'fullScreenReader': fullScreenReader,

--- a/lib/models/settings.g.dart
+++ b/lib/models/settings.g.dart
@@ -166,848 +166,858 @@ const SettingsSchema = CollectionSchema(
       name: r'btServerPort',
       type: IsarType.long,
     ),
-    r'chapterFilterBookmarkedList': PropertySchema(
+    r'cfProxyUrl': PropertySchema(
       id: 28,
+      name: r'cfProxyUrl',
+      type: IsarType.string,
+    ),
+    r'chapterFilterBookmarkedList': PropertySchema(
+      id: 29,
       name: r'chapterFilterBookmarkedList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterBookmarked',
     ),
     r'chapterFilterDownloadedList': PropertySchema(
-      id: 29,
+      id: 30,
       name: r'chapterFilterDownloadedList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterDownloaded',
     ),
     r'chapterFilterUnreadList': PropertySchema(
-      id: 30,
+      id: 31,
       name: r'chapterFilterUnreadList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterUnread',
     ),
     r'chapterPageIndexList': PropertySchema(
-      id: 31,
+      id: 32,
       name: r'chapterPageIndexList',
       type: IsarType.objectList,
 
       target: r'ChapterPageIndex',
     ),
     r'chapterPageUrlsList': PropertySchema(
-      id: 32,
+      id: 33,
       name: r'chapterPageUrlsList',
       type: IsarType.objectList,
 
       target: r'ChapterPageurls',
     ),
     r'checkForAppUpdates': PropertySchema(
-      id: 33,
+      id: 34,
       name: r'checkForAppUpdates',
       type: IsarType.bool,
     ),
     r'checkForExtensionUpdates': PropertySchema(
-      id: 34,
+      id: 35,
       name: r'checkForExtensionUpdates',
       type: IsarType.bool,
     ),
     r'clearChapterCacheOnAppLaunch': PropertySchema(
-      id: 35,
+      id: 36,
       name: r'clearChapterCacheOnAppLaunch',
       type: IsarType.bool,
     ),
     r'colorFilterBlendMode': PropertySchema(
-      id: 36,
+      id: 37,
       name: r'colorFilterBlendMode',
       type: IsarType.byte,
       enumMap: _SettingscolorFilterBlendModeEnumValueMap,
     ),
     r'concurrentDownloads': PropertySchema(
-      id: 37,
+      id: 38,
       name: r'concurrentDownloads',
       type: IsarType.long,
     ),
     r'cookiesList': PropertySchema(
-      id: 38,
+      id: 39,
       name: r'cookiesList',
       type: IsarType.objectList,
 
       target: r'MCookie',
     ),
     r'cropBorders': PropertySchema(
-      id: 39,
+      id: 40,
       name: r'cropBorders',
       type: IsarType.bool,
     ),
     r'customColorFilter': PropertySchema(
-      id: 40,
+      id: 41,
       name: r'customColorFilter',
       type: IsarType.object,
 
       target: r'CustomColorFilter',
     ),
     r'customDns': PropertySchema(
-      id: 41,
+      id: 42,
       name: r'customDns',
       type: IsarType.string,
     ),
+    r'customDohUrl': PropertySchema(
+      id: 43,
+      name: r'customDohUrl',
+      type: IsarType.string,
+    ),
     r'dateFormat': PropertySchema(
-      id: 42,
+      id: 44,
       name: r'dateFormat',
       type: IsarType.string,
     ),
     r'debandingType': PropertySchema(
-      id: 43,
+      id: 45,
       name: r'debandingType',
       type: IsarType.byte,
       enumMap: _SettingsdebandingTypeEnumValueMap,
     ),
     r'defaultDoubleTapToSkipLength': PropertySchema(
-      id: 44,
+      id: 46,
       name: r'defaultDoubleTapToSkipLength',
       type: IsarType.long,
     ),
     r'defaultPlayBackSpeed': PropertySchema(
-      id: 45,
+      id: 47,
       name: r'defaultPlayBackSpeed',
       type: IsarType.double,
     ),
     r'defaultReaderMode': PropertySchema(
-      id: 46,
+      id: 48,
       name: r'defaultReaderMode',
       type: IsarType.byte,
       enumMap: _SettingsdefaultReaderModeEnumValueMap,
     ),
     r'defaultSkipIntroLength': PropertySchema(
-      id: 47,
+      id: 49,
       name: r'defaultSkipIntroLength',
       type: IsarType.long,
     ),
     r'defaultSubtitleLang': PropertySchema(
-      id: 48,
+      id: 50,
       name: r'defaultSubtitleLang',
       type: IsarType.object,
 
       target: r'L10nLocale',
     ),
     r'deleteDownloadAfterReading': PropertySchema(
-      id: 49,
+      id: 51,
       name: r'deleteDownloadAfterReading',
       type: IsarType.bool,
     ),
     r'disableSectionType': PropertySchema(
-      id: 50,
+      id: 52,
       name: r'disableSectionType',
       type: IsarType.byte,
       enumMap: _SettingsdisableSectionTypeEnumValueMap,
     ),
     r'displayType': PropertySchema(
-      id: 51,
+      id: 53,
       name: r'displayType',
       type: IsarType.byte,
       enumMap: _SettingsdisplayTypeEnumValueMap,
     ),
     r'doHEnabled': PropertySchema(
-      id: 52,
+      id: 54,
       name: r'doHEnabled',
       type: IsarType.bool,
     ),
     r'doHProviderId': PropertySchema(
-      id: 53,
+      id: 55,
       name: r'doHProviderId',
       type: IsarType.long,
     ),
     r'doubleTapAnimationSpeed': PropertySchema(
-      id: 54,
+      id: 56,
       name: r'doubleTapAnimationSpeed',
       type: IsarType.long,
     ),
     r'downloadLocation': PropertySchema(
-      id: 55,
+      id: 57,
       name: r'downloadLocation',
       type: IsarType.string,
     ),
     r'downloadOnlyOnWifi': PropertySchema(
-      id: 56,
+      id: 58,
       name: r'downloadOnlyOnWifi',
       type: IsarType.bool,
     ),
     r'downloadedOnlyMode': PropertySchema(
-      id: 57,
+      id: 59,
       name: r'downloadedOnlyMode',
       type: IsarType.bool,
     ),
     r'dualPageInvert': PropertySchema(
-      id: 58,
+      id: 60,
       name: r'dualPageInvert',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFit': PropertySchema(
-      id: 59,
+      id: 61,
       name: r'dualPageRotateToFit',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFitInvert': PropertySchema(
-      id: 60,
+      id: 62,
       name: r'dualPageRotateToFitInvert',
       type: IsarType.bool,
     ),
     r'enableAniSkip': PropertySchema(
-      id: 61,
+      id: 63,
       name: r'enableAniSkip',
       type: IsarType.bool,
     ),
     r'enableAudioPitchCorrection': PropertySchema(
-      id: 62,
+      id: 64,
       name: r'enableAudioPitchCorrection',
       type: IsarType.bool,
     ),
     r'enableAutoSkip': PropertySchema(
-      id: 63,
+      id: 65,
       name: r'enableAutoSkip',
       type: IsarType.bool,
     ),
     r'enableCustomColorFilter': PropertySchema(
-      id: 64,
+      id: 66,
       name: r'enableCustomColorFilter',
       type: IsarType.bool,
     ),
     r'enableDiscordRpc': PropertySchema(
-      id: 65,
+      id: 67,
       name: r'enableDiscordRpc',
       type: IsarType.bool,
     ),
     r'enableGpuNext': PropertySchema(
-      id: 66,
+      id: 68,
       name: r'enableGpuNext',
       type: IsarType.bool,
     ),
     r'enableHardwareAcceleration': PropertySchema(
-      id: 67,
+      id: 69,
       name: r'enableHardwareAcceleration',
       type: IsarType.bool,
     ),
     r'enableLogs': PropertySchema(
-      id: 68,
+      id: 70,
       name: r'enableLogs',
       type: IsarType.bool,
     ),
     r'extensionServerPath': PropertySchema(
-      id: 69,
+      id: 71,
       name: r'extensionServerPath',
       type: IsarType.string,
     ),
     r'filterScanlatorList': PropertySchema(
-      id: 70,
+      id: 72,
       name: r'filterScanlatorList',
       type: IsarType.objectList,
 
       target: r'FilterScanlator',
     ),
     r'flashColor': PropertySchema(
-      id: 71,
+      id: 73,
       name: r'flashColor',
       type: IsarType.long,
     ),
     r'flashDuration': PropertySchema(
-      id: 72,
+      id: 74,
       name: r'flashDuration',
       type: IsarType.long,
     ),
     r'flashInterval': PropertySchema(
-      id: 73,
+      id: 75,
       name: r'flashInterval',
       type: IsarType.long,
     ),
     r'flashOnPageChange': PropertySchema(
-      id: 74,
+      id: 76,
       name: r'flashOnPageChange',
       type: IsarType.bool,
     ),
     r'flexColorSchemeBlendLevel': PropertySchema(
-      id: 75,
+      id: 77,
       name: r'flexColorSchemeBlendLevel',
       type: IsarType.double,
     ),
     r'flexSchemeColorIndex': PropertySchema(
-      id: 76,
+      id: 78,
       name: r'flexSchemeColorIndex',
       type: IsarType.long,
     ),
     r'followSystemTheme': PropertySchema(
-      id: 77,
+      id: 79,
       name: r'followSystemTheme',
       type: IsarType.bool,
     ),
     r'forceLandscapePlayer': PropertySchema(
-      id: 78,
+      id: 80,
       name: r'forceLandscapePlayer',
       type: IsarType.bool,
     ),
     r'fullScreenPlayer': PropertySchema(
-      id: 79,
+      id: 81,
       name: r'fullScreenPlayer',
       type: IsarType.bool,
     ),
     r'fullScreenReader': PropertySchema(
-      id: 80,
+      id: 82,
       name: r'fullScreenReader',
       type: IsarType.bool,
     ),
     r'grayscale': PropertySchema(
-      id: 81,
+      id: 83,
       name: r'grayscale',
       type: IsarType.bool,
     ),
     r'hideDiscordRpcInIncognito': PropertySchema(
-      id: 82,
+      id: 84,
       name: r'hideDiscordRpcInIncognito',
       type: IsarType.bool,
     ),
     r'hideItems': PropertySchema(
-      id: 83,
+      id: 85,
       name: r'hideItems',
       type: IsarType.stringList,
     ),
     r'hwdecMode': PropertySchema(
-      id: 84,
+      id: 86,
       name: r'hwdecMode',
       type: IsarType.string,
     ),
     r'incognitoMode': PropertySchema(
-      id: 85,
+      id: 87,
       name: r'incognitoMode',
       type: IsarType.bool,
     ),
     r'invertColors': PropertySchema(
-      id: 86,
+      id: 88,
       name: r'invertColors',
       type: IsarType.bool,
     ),
-    r'jrePath': PropertySchema(id: 87, name: r'jrePath', type: IsarType.string),
+    r'jrePath': PropertySchema(id: 89, name: r'jrePath', type: IsarType.string),
     r'keepScreenOnReader': PropertySchema(
-      id: 88,
+      id: 90,
       name: r'keepScreenOnReader',
       type: IsarType.bool,
     ),
     r'landscapeZoom': PropertySchema(
-      id: 89,
+      id: 91,
       name: r'landscapeZoom',
       type: IsarType.bool,
     ),
     r'lastTrackerLibraryLocation': PropertySchema(
-      id: 90,
+      id: 92,
       name: r'lastTrackerLibraryLocation',
       type: IsarType.string,
     ),
     r'libraryDownloadedChapters': PropertySchema(
-      id: 91,
+      id: 93,
       name: r'libraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'libraryFilterAnimeBookMarkedType': PropertySchema(
-      id: 92,
+      id: 94,
       name: r'libraryFilterAnimeBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeCompletedType': PropertySchema(
-      id: 93,
+      id: 95,
       name: r'libraryFilterAnimeCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeDownloadType': PropertySchema(
-      id: 94,
+      id: 96,
       name: r'libraryFilterAnimeDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeStartedType': PropertySchema(
-      id: 95,
+      id: 97,
       name: r'libraryFilterAnimeStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeTrackingType': PropertySchema(
-      id: 96,
+      id: 98,
       name: r'libraryFilterAnimeTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeUnreadType': PropertySchema(
-      id: 97,
+      id: 99,
       name: r'libraryFilterAnimeUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasBookMarkedType': PropertySchema(
-      id: 98,
+      id: 100,
       name: r'libraryFilterMangasBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasCompletedType': PropertySchema(
-      id: 99,
+      id: 101,
       name: r'libraryFilterMangasCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasDownloadType': PropertySchema(
-      id: 100,
+      id: 102,
       name: r'libraryFilterMangasDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasStartedType': PropertySchema(
-      id: 101,
+      id: 103,
       name: r'libraryFilterMangasStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasTrackingType': PropertySchema(
-      id: 102,
+      id: 104,
       name: r'libraryFilterMangasTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasUnreadType': PropertySchema(
-      id: 103,
+      id: 105,
       name: r'libraryFilterMangasUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelBookMarkedType': PropertySchema(
-      id: 104,
+      id: 106,
       name: r'libraryFilterNovelBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelCompletedType': PropertySchema(
-      id: 105,
+      id: 107,
       name: r'libraryFilterNovelCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelDownloadType': PropertySchema(
-      id: 106,
+      id: 108,
       name: r'libraryFilterNovelDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelStartedType': PropertySchema(
-      id: 107,
+      id: 109,
       name: r'libraryFilterNovelStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelTrackingType': PropertySchema(
-      id: 108,
+      id: 110,
       name: r'libraryFilterNovelTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelUnreadType': PropertySchema(
-      id: 109,
+      id: 111,
       name: r'libraryFilterNovelUnreadType',
       type: IsarType.long,
     ),
     r'libraryLocalSource': PropertySchema(
-      id: 110,
+      id: 112,
       name: r'libraryLocalSource',
       type: IsarType.bool,
     ),
     r'libraryShowCategoryTabs': PropertySchema(
-      id: 111,
+      id: 113,
       name: r'libraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'libraryShowContinueReadingButton': PropertySchema(
-      id: 112,
+      id: 114,
       name: r'libraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'libraryShowLanguage': PropertySchema(
-      id: 113,
+      id: 115,
       name: r'libraryShowLanguage',
       type: IsarType.bool,
     ),
     r'libraryShowNumbersOfItems': PropertySchema(
-      id: 114,
+      id: 116,
       name: r'libraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'localFolders': PropertySchema(
-      id: 115,
+      id: 117,
       name: r'localFolders',
       type: IsarType.stringList,
     ),
     r'locale': PropertySchema(
-      id: 116,
+      id: 118,
       name: r'locale',
       type: IsarType.object,
 
       target: r'L10nLocale',
     ),
     r'mangaExtensionsRepo': PropertySchema(
-      id: 117,
+      id: 119,
       name: r'mangaExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'mangaGridSize': PropertySchema(
-      id: 118,
+      id: 120,
       name: r'mangaGridSize',
       type: IsarType.long,
     ),
     r'mangaHomeDisplayType': PropertySchema(
-      id: 119,
+      id: 121,
       name: r'mangaHomeDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsmangaHomeDisplayTypeEnumValueMap,
     ),
     r'markEpisodeAsSeenType': PropertySchema(
-      id: 120,
+      id: 122,
       name: r'markEpisodeAsSeenType',
       type: IsarType.long,
     ),
     r'mergeLibraryNavMobile': PropertySchema(
-      id: 121,
+      id: 123,
       name: r'mergeLibraryNavMobile',
       type: IsarType.bool,
     ),
     r'navigateToPan': PropertySchema(
-      id: 122,
+      id: 124,
       name: r'navigateToPan',
       type: IsarType.bool,
     ),
     r'navigationOrder': PropertySchema(
-      id: 123,
+      id: 125,
       name: r'navigationOrder',
       type: IsarType.stringList,
     ),
     r'novelDisplayType': PropertySchema(
-      id: 124,
+      id: 126,
       name: r'novelDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsnovelDisplayTypeEnumValueMap,
     ),
     r'novelExtensionsRepo': PropertySchema(
-      id: 125,
+      id: 127,
       name: r'novelExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'novelFontSize': PropertySchema(
-      id: 126,
+      id: 128,
       name: r'novelFontSize',
       type: IsarType.long,
     ),
     r'novelGridSize': PropertySchema(
-      id: 127,
+      id: 129,
       name: r'novelGridSize',
       type: IsarType.long,
     ),
     r'novelLibraryDownloadedChapters': PropertySchema(
-      id: 128,
+      id: 130,
       name: r'novelLibraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'novelLibraryLocalSource': PropertySchema(
-      id: 129,
+      id: 131,
       name: r'novelLibraryLocalSource',
       type: IsarType.bool,
     ),
     r'novelLibraryShowCategoryTabs': PropertySchema(
-      id: 130,
+      id: 132,
       name: r'novelLibraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'novelLibraryShowContinueReadingButton': PropertySchema(
-      id: 131,
+      id: 133,
       name: r'novelLibraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'novelLibraryShowLanguage': PropertySchema(
-      id: 132,
+      id: 134,
       name: r'novelLibraryShowLanguage',
       type: IsarType.bool,
     ),
     r'novelLibraryShowNumbersOfItems': PropertySchema(
-      id: 133,
+      id: 135,
       name: r'novelLibraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'novelReaderLineHeight': PropertySchema(
-      id: 134,
+      id: 136,
       name: r'novelReaderLineHeight',
       type: IsarType.double,
     ),
     r'novelReaderPadding': PropertySchema(
-      id: 135,
+      id: 137,
       name: r'novelReaderPadding',
       type: IsarType.long,
     ),
     r'novelReaderTextColor': PropertySchema(
-      id: 136,
+      id: 138,
       name: r'novelReaderTextColor',
       type: IsarType.string,
     ),
     r'novelReaderTheme': PropertySchema(
-      id: 137,
+      id: 139,
       name: r'novelReaderTheme',
       type: IsarType.string,
     ),
     r'novelRemoveExtraParagraphSpacing': PropertySchema(
-      id: 138,
+      id: 140,
       name: r'novelRemoveExtraParagraphSpacing',
       type: IsarType.bool,
     ),
     r'novelShowScrollPercentage': PropertySchema(
-      id: 139,
+      id: 141,
       name: r'novelShowScrollPercentage',
       type: IsarType.bool,
     ),
     r'novelTapToScroll': PropertySchema(
-      id: 140,
+      id: 142,
       name: r'novelTapToScroll',
       type: IsarType.bool,
     ),
     r'novelTextAlign': PropertySchema(
-      id: 141,
+      id: 143,
       name: r'novelTextAlign',
       type: IsarType.byte,
       enumMap: _SettingsnovelTextAlignEnumValueMap,
     ),
     r'onlyIncludePinnedSources': PropertySchema(
-      id: 142,
+      id: 144,
       name: r'onlyIncludePinnedSources',
       type: IsarType.bool,
     ),
     r'pagePreloadAmount': PropertySchema(
-      id: 143,
+      id: 145,
       name: r'pagePreloadAmount',
       type: IsarType.long,
     ),
     r'personalPageModeList': PropertySchema(
-      id: 144,
+      id: 146,
       name: r'personalPageModeList',
       type: IsarType.objectList,
 
       target: r'PersonalPageMode',
     ),
     r'personalReaderModeList': PropertySchema(
-      id: 145,
+      id: 147,
       name: r'personalReaderModeList',
       type: IsarType.objectList,
 
       target: r'PersonalReaderMode',
     ),
     r'playerSubtitleSettings': PropertySchema(
-      id: 146,
+      id: 148,
       name: r'playerSubtitleSettings',
       type: IsarType.object,
 
       target: r'PlayerSubtitleSettings',
     ),
     r'pureBlackDarkMode': PropertySchema(
-      id: 147,
+      id: 149,
       name: r'pureBlackDarkMode',
       type: IsarType.bool,
     ),
     r'readerBrightness': PropertySchema(
-      id: 148,
+      id: 150,
       name: r'readerBrightness',
       type: IsarType.double,
     ),
     r'readerContrast': PropertySchema(
-      id: 149,
+      id: 151,
       name: r'readerContrast',
       type: IsarType.double,
     ),
     r'readerHideThreshold': PropertySchema(
-      id: 150,
+      id: 152,
       name: r'readerHideThreshold',
       type: IsarType.long,
     ),
     r'readerNavigationLayout': PropertySchema(
-      id: 151,
+      id: 153,
       name: r'readerNavigationLayout',
       type: IsarType.long,
     ),
     r'readerSaturation': PropertySchema(
-      id: 152,
+      id: 154,
       name: r'readerSaturation',
       type: IsarType.double,
     ),
     r'relativeTimesTamps': PropertySchema(
-      id: 153,
+      id: 155,
       name: r'relativeTimesTamps',
       type: IsarType.long,
     ),
     r'rpcShowCoverImage': PropertySchema(
-      id: 154,
+      id: 156,
       name: r'rpcShowCoverImage',
       type: IsarType.bool,
     ),
     r'rpcShowReadingWatchingProgress': PropertySchema(
-      id: 155,
+      id: 157,
       name: r'rpcShowReadingWatchingProgress',
       type: IsarType.bool,
     ),
     r'rpcShowTitle': PropertySchema(
-      id: 156,
+      id: 158,
       name: r'rpcShowTitle',
       type: IsarType.bool,
     ),
     r'saveAsCBZArchive': PropertySchema(
-      id: 157,
+      id: 159,
       name: r'saveAsCBZArchive',
       type: IsarType.bool,
     ),
     r'scaleType': PropertySchema(
-      id: 158,
+      id: 160,
       name: r'scaleType',
       type: IsarType.byte,
       enumMap: _SettingsscaleTypeEnumValueMap,
     ),
     r'showNSFW': PropertySchema(
-      id: 159,
+      id: 161,
       name: r'showNSFW',
       type: IsarType.bool,
     ),
     r'showNavigationOverlayOnStart': PropertySchema(
-      id: 160,
+      id: 162,
       name: r'showNavigationOverlayOnStart',
       type: IsarType.bool,
     ),
     r'showPageGaps': PropertySchema(
-      id: 161,
+      id: 163,
       name: r'showPageGaps',
       type: IsarType.bool,
     ),
     r'showPagesNumber': PropertySchema(
-      id: 162,
+      id: 164,
       name: r'showPagesNumber',
       type: IsarType.bool,
     ),
     r'sortChapterList': PropertySchema(
-      id: 163,
+      id: 165,
       name: r'sortChapterList',
       type: IsarType.objectList,
 
       target: r'SortChapter',
     ),
     r'sortLibraryAnime': PropertySchema(
-      id: 164,
+      id: 166,
       name: r'sortLibraryAnime',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryManga': PropertySchema(
-      id: 165,
+      id: 167,
       name: r'sortLibraryManga',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryNovel': PropertySchema(
-      id: 166,
+      id: 168,
       name: r'sortLibraryNovel',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'splitWidePages': PropertySchema(
-      id: 167,
+      id: 169,
       name: r'splitWidePages',
       type: IsarType.bool,
     ),
     r'startDatebackup': PropertySchema(
-      id: 168,
+      id: 170,
       name: r'startDatebackup',
       type: IsarType.long,
     ),
     r'tappingInversion': PropertySchema(
-      id: 169,
+      id: 171,
       name: r'tappingInversion',
       type: IsarType.long,
     ),
     r'themeIsDark': PropertySchema(
-      id: 170,
+      id: 172,
       name: r'themeIsDark',
       type: IsarType.bool,
     ),
     r'ttsLanguage': PropertySchema(
-      id: 171,
+      id: 173,
       name: r'ttsLanguage',
       type: IsarType.string,
     ),
     r'ttsPitch': PropertySchema(
-      id: 172,
+      id: 174,
       name: r'ttsPitch',
       type: IsarType.double,
     ),
     r'ttsSpeechRate': PropertySchema(
-      id: 173,
+      id: 175,
       name: r'ttsSpeechRate',
       type: IsarType.double,
     ),
     r'ttsVoice': PropertySchema(
-      id: 174,
+      id: 176,
       name: r'ttsVoice',
       type: IsarType.string,
     ),
     r'updateErrorsList': PropertySchema(
-      id: 175,
+      id: 177,
       name: r'updateErrorsList',
       type: IsarType.objectList,
 
       target: r'UpdateError',
     ),
     r'updateProgressAfterReading': PropertySchema(
-      id: 176,
+      id: 178,
       name: r'updateProgressAfterReading',
       type: IsarType.bool,
     ),
     r'updatedAt': PropertySchema(
-      id: 177,
+      id: 179,
       name: r'updatedAt',
       type: IsarType.long,
     ),
     r'useLibass': PropertySchema(
-      id: 178,
+      id: 180,
       name: r'useLibass',
       type: IsarType.bool,
     ),
     r'useMpvConfig': PropertySchema(
-      id: 179,
+      id: 181,
       name: r'useMpvConfig',
       type: IsarType.bool,
     ),
     r'usePageTapZones': PropertySchema(
-      id: 180,
+      id: 182,
       name: r'usePageTapZones',
       type: IsarType.bool,
     ),
     r'useYUV420P': PropertySchema(
-      id: 181,
+      id: 183,
       name: r'useYUV420P',
       type: IsarType.bool,
     ),
     r'userAgent': PropertySchema(
-      id: 182,
+      id: 184,
       name: r'userAgent',
       type: IsarType.string,
     ),
     r'volumeBoostCap': PropertySchema(
-      id: 183,
+      id: 185,
       name: r'volumeBoostCap',
       type: IsarType.long,
     ),
     r'webtoonDisableZoomOut': PropertySchema(
-      id: 184,
+      id: 186,
       name: r'webtoonDisableZoomOut',
       type: IsarType.bool,
     ),
     r'webtoonDoubleTapZoomEnabled': PropertySchema(
-      id: 185,
+      id: 187,
       name: r'webtoonDoubleTapZoomEnabled',
       type: IsarType.bool,
     ),
     r'webtoonSidePadding': PropertySchema(
-      id: 186,
+      id: 188,
       name: r'webtoonSidePadding',
       type: IsarType.long,
     ),
     r'zoomStartPosition': PropertySchema(
-      id: 187,
+      id: 189,
       name: r'zoomStartPosition',
       type: IsarType.long,
     ),
@@ -1139,6 +1149,12 @@ int _settingsEstimateSize(
     }
   }
   {
+    final value = object.cfProxyUrl;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
     final list = object.chapterFilterBookmarkedList;
     if (list != null) {
       bytesCount += 3 + list.length * 3;
@@ -1250,6 +1266,12 @@ int _settingsEstimateSize(
   }
   {
     final value = object.customDns;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.customDohUrl;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
     }
@@ -1591,266 +1613,268 @@ void _settingsSerialize(
   writer.writeLongList(offsets[25], object.backupListOptions);
   writer.writeString(offsets[26], object.btServerAddress);
   writer.writeLong(offsets[27], object.btServerPort);
+  writer.writeString(offsets[28], object.cfProxyUrl);
   writer.writeObjectList<ChapterFilterBookmarked>(
-    offsets[28],
+    offsets[29],
     allOffsets,
     ChapterFilterBookmarkedSchema.serialize,
     object.chapterFilterBookmarkedList,
   );
   writer.writeObjectList<ChapterFilterDownloaded>(
-    offsets[29],
+    offsets[30],
     allOffsets,
     ChapterFilterDownloadedSchema.serialize,
     object.chapterFilterDownloadedList,
   );
   writer.writeObjectList<ChapterFilterUnread>(
-    offsets[30],
+    offsets[31],
     allOffsets,
     ChapterFilterUnreadSchema.serialize,
     object.chapterFilterUnreadList,
   );
   writer.writeObjectList<ChapterPageIndex>(
-    offsets[31],
+    offsets[32],
     allOffsets,
     ChapterPageIndexSchema.serialize,
     object.chapterPageIndexList,
   );
   writer.writeObjectList<ChapterPageurls>(
-    offsets[32],
+    offsets[33],
     allOffsets,
     ChapterPageurlsSchema.serialize,
     object.chapterPageUrlsList,
   );
-  writer.writeBool(offsets[33], object.checkForAppUpdates);
-  writer.writeBool(offsets[34], object.checkForExtensionUpdates);
-  writer.writeBool(offsets[35], object.clearChapterCacheOnAppLaunch);
-  writer.writeByte(offsets[36], object.colorFilterBlendMode.index);
-  writer.writeLong(offsets[37], object.concurrentDownloads);
+  writer.writeBool(offsets[34], object.checkForAppUpdates);
+  writer.writeBool(offsets[35], object.checkForExtensionUpdates);
+  writer.writeBool(offsets[36], object.clearChapterCacheOnAppLaunch);
+  writer.writeByte(offsets[37], object.colorFilterBlendMode.index);
+  writer.writeLong(offsets[38], object.concurrentDownloads);
   writer.writeObjectList<MCookie>(
-    offsets[38],
+    offsets[39],
     allOffsets,
     MCookieSchema.serialize,
     object.cookiesList,
   );
-  writer.writeBool(offsets[39], object.cropBorders);
+  writer.writeBool(offsets[40], object.cropBorders);
   writer.writeObject<CustomColorFilter>(
-    offsets[40],
+    offsets[41],
     allOffsets,
     CustomColorFilterSchema.serialize,
     object.customColorFilter,
   );
-  writer.writeString(offsets[41], object.customDns);
-  writer.writeString(offsets[42], object.dateFormat);
-  writer.writeByte(offsets[43], object.debandingType.index);
-  writer.writeLong(offsets[44], object.defaultDoubleTapToSkipLength);
-  writer.writeDouble(offsets[45], object.defaultPlayBackSpeed);
-  writer.writeByte(offsets[46], object.defaultReaderMode.index);
-  writer.writeLong(offsets[47], object.defaultSkipIntroLength);
+  writer.writeString(offsets[42], object.customDns);
+  writer.writeString(offsets[43], object.customDohUrl);
+  writer.writeString(offsets[44], object.dateFormat);
+  writer.writeByte(offsets[45], object.debandingType.index);
+  writer.writeLong(offsets[46], object.defaultDoubleTapToSkipLength);
+  writer.writeDouble(offsets[47], object.defaultPlayBackSpeed);
+  writer.writeByte(offsets[48], object.defaultReaderMode.index);
+  writer.writeLong(offsets[49], object.defaultSkipIntroLength);
   writer.writeObject<L10nLocale>(
-    offsets[48],
+    offsets[50],
     allOffsets,
     L10nLocaleSchema.serialize,
     object.defaultSubtitleLang,
   );
-  writer.writeBool(offsets[49], object.deleteDownloadAfterReading);
-  writer.writeByte(offsets[50], object.disableSectionType.index);
-  writer.writeByte(offsets[51], object.displayType.index);
-  writer.writeBool(offsets[52], object.doHEnabled);
-  writer.writeLong(offsets[53], object.doHProviderId);
-  writer.writeLong(offsets[54], object.doubleTapAnimationSpeed);
-  writer.writeString(offsets[55], object.downloadLocation);
-  writer.writeBool(offsets[56], object.downloadOnlyOnWifi);
-  writer.writeBool(offsets[57], object.downloadedOnlyMode);
-  writer.writeBool(offsets[58], object.dualPageInvert);
-  writer.writeBool(offsets[59], object.dualPageRotateToFit);
-  writer.writeBool(offsets[60], object.dualPageRotateToFitInvert);
-  writer.writeBool(offsets[61], object.enableAniSkip);
-  writer.writeBool(offsets[62], object.enableAudioPitchCorrection);
-  writer.writeBool(offsets[63], object.enableAutoSkip);
-  writer.writeBool(offsets[64], object.enableCustomColorFilter);
-  writer.writeBool(offsets[65], object.enableDiscordRpc);
-  writer.writeBool(offsets[66], object.enableGpuNext);
-  writer.writeBool(offsets[67], object.enableHardwareAcceleration);
-  writer.writeBool(offsets[68], object.enableLogs);
-  writer.writeString(offsets[69], object.extensionServerPath);
+  writer.writeBool(offsets[51], object.deleteDownloadAfterReading);
+  writer.writeByte(offsets[52], object.disableSectionType.index);
+  writer.writeByte(offsets[53], object.displayType.index);
+  writer.writeBool(offsets[54], object.doHEnabled);
+  writer.writeLong(offsets[55], object.doHProviderId);
+  writer.writeLong(offsets[56], object.doubleTapAnimationSpeed);
+  writer.writeString(offsets[57], object.downloadLocation);
+  writer.writeBool(offsets[58], object.downloadOnlyOnWifi);
+  writer.writeBool(offsets[59], object.downloadedOnlyMode);
+  writer.writeBool(offsets[60], object.dualPageInvert);
+  writer.writeBool(offsets[61], object.dualPageRotateToFit);
+  writer.writeBool(offsets[62], object.dualPageRotateToFitInvert);
+  writer.writeBool(offsets[63], object.enableAniSkip);
+  writer.writeBool(offsets[64], object.enableAudioPitchCorrection);
+  writer.writeBool(offsets[65], object.enableAutoSkip);
+  writer.writeBool(offsets[66], object.enableCustomColorFilter);
+  writer.writeBool(offsets[67], object.enableDiscordRpc);
+  writer.writeBool(offsets[68], object.enableGpuNext);
+  writer.writeBool(offsets[69], object.enableHardwareAcceleration);
+  writer.writeBool(offsets[70], object.enableLogs);
+  writer.writeString(offsets[71], object.extensionServerPath);
   writer.writeObjectList<FilterScanlator>(
-    offsets[70],
+    offsets[72],
     allOffsets,
     FilterScanlatorSchema.serialize,
     object.filterScanlatorList,
   );
-  writer.writeLong(offsets[71], object.flashColor);
-  writer.writeLong(offsets[72], object.flashDuration);
-  writer.writeLong(offsets[73], object.flashInterval);
-  writer.writeBool(offsets[74], object.flashOnPageChange);
-  writer.writeDouble(offsets[75], object.flexColorSchemeBlendLevel);
-  writer.writeLong(offsets[76], object.flexSchemeColorIndex);
-  writer.writeBool(offsets[77], object.followSystemTheme);
-  writer.writeBool(offsets[78], object.forceLandscapePlayer);
-  writer.writeBool(offsets[79], object.fullScreenPlayer);
-  writer.writeBool(offsets[80], object.fullScreenReader);
-  writer.writeBool(offsets[81], object.grayscale);
-  writer.writeBool(offsets[82], object.hideDiscordRpcInIncognito);
-  writer.writeStringList(offsets[83], object.hideItems);
-  writer.writeString(offsets[84], object.hwdecMode);
-  writer.writeBool(offsets[85], object.incognitoMode);
-  writer.writeBool(offsets[86], object.invertColors);
-  writer.writeString(offsets[87], object.jrePath);
-  writer.writeBool(offsets[88], object.keepScreenOnReader);
-  writer.writeBool(offsets[89], object.landscapeZoom);
-  writer.writeString(offsets[90], object.lastTrackerLibraryLocation);
-  writer.writeBool(offsets[91], object.libraryDownloadedChapters);
-  writer.writeLong(offsets[92], object.libraryFilterAnimeBookMarkedType);
-  writer.writeLong(offsets[93], object.libraryFilterAnimeCompletedType);
-  writer.writeLong(offsets[94], object.libraryFilterAnimeDownloadType);
-  writer.writeLong(offsets[95], object.libraryFilterAnimeStartedType);
-  writer.writeLong(offsets[96], object.libraryFilterAnimeTrackingType);
-  writer.writeLong(offsets[97], object.libraryFilterAnimeUnreadType);
-  writer.writeLong(offsets[98], object.libraryFilterMangasBookMarkedType);
-  writer.writeLong(offsets[99], object.libraryFilterMangasCompletedType);
-  writer.writeLong(offsets[100], object.libraryFilterMangasDownloadType);
-  writer.writeLong(offsets[101], object.libraryFilterMangasStartedType);
-  writer.writeLong(offsets[102], object.libraryFilterMangasTrackingType);
-  writer.writeLong(offsets[103], object.libraryFilterMangasUnreadType);
-  writer.writeLong(offsets[104], object.libraryFilterNovelBookMarkedType);
-  writer.writeLong(offsets[105], object.libraryFilterNovelCompletedType);
-  writer.writeLong(offsets[106], object.libraryFilterNovelDownloadType);
-  writer.writeLong(offsets[107], object.libraryFilterNovelStartedType);
-  writer.writeLong(offsets[108], object.libraryFilterNovelTrackingType);
-  writer.writeLong(offsets[109], object.libraryFilterNovelUnreadType);
-  writer.writeBool(offsets[110], object.libraryLocalSource);
-  writer.writeBool(offsets[111], object.libraryShowCategoryTabs);
-  writer.writeBool(offsets[112], object.libraryShowContinueReadingButton);
-  writer.writeBool(offsets[113], object.libraryShowLanguage);
-  writer.writeBool(offsets[114], object.libraryShowNumbersOfItems);
-  writer.writeStringList(offsets[115], object.localFolders);
+  writer.writeLong(offsets[73], object.flashColor);
+  writer.writeLong(offsets[74], object.flashDuration);
+  writer.writeLong(offsets[75], object.flashInterval);
+  writer.writeBool(offsets[76], object.flashOnPageChange);
+  writer.writeDouble(offsets[77], object.flexColorSchemeBlendLevel);
+  writer.writeLong(offsets[78], object.flexSchemeColorIndex);
+  writer.writeBool(offsets[79], object.followSystemTheme);
+  writer.writeBool(offsets[80], object.forceLandscapePlayer);
+  writer.writeBool(offsets[81], object.fullScreenPlayer);
+  writer.writeBool(offsets[82], object.fullScreenReader);
+  writer.writeBool(offsets[83], object.grayscale);
+  writer.writeBool(offsets[84], object.hideDiscordRpcInIncognito);
+  writer.writeStringList(offsets[85], object.hideItems);
+  writer.writeString(offsets[86], object.hwdecMode);
+  writer.writeBool(offsets[87], object.incognitoMode);
+  writer.writeBool(offsets[88], object.invertColors);
+  writer.writeString(offsets[89], object.jrePath);
+  writer.writeBool(offsets[90], object.keepScreenOnReader);
+  writer.writeBool(offsets[91], object.landscapeZoom);
+  writer.writeString(offsets[92], object.lastTrackerLibraryLocation);
+  writer.writeBool(offsets[93], object.libraryDownloadedChapters);
+  writer.writeLong(offsets[94], object.libraryFilterAnimeBookMarkedType);
+  writer.writeLong(offsets[95], object.libraryFilterAnimeCompletedType);
+  writer.writeLong(offsets[96], object.libraryFilterAnimeDownloadType);
+  writer.writeLong(offsets[97], object.libraryFilterAnimeStartedType);
+  writer.writeLong(offsets[98], object.libraryFilterAnimeTrackingType);
+  writer.writeLong(offsets[99], object.libraryFilterAnimeUnreadType);
+  writer.writeLong(offsets[100], object.libraryFilterMangasBookMarkedType);
+  writer.writeLong(offsets[101], object.libraryFilterMangasCompletedType);
+  writer.writeLong(offsets[102], object.libraryFilterMangasDownloadType);
+  writer.writeLong(offsets[103], object.libraryFilterMangasStartedType);
+  writer.writeLong(offsets[104], object.libraryFilterMangasTrackingType);
+  writer.writeLong(offsets[105], object.libraryFilterMangasUnreadType);
+  writer.writeLong(offsets[106], object.libraryFilterNovelBookMarkedType);
+  writer.writeLong(offsets[107], object.libraryFilterNovelCompletedType);
+  writer.writeLong(offsets[108], object.libraryFilterNovelDownloadType);
+  writer.writeLong(offsets[109], object.libraryFilterNovelStartedType);
+  writer.writeLong(offsets[110], object.libraryFilterNovelTrackingType);
+  writer.writeLong(offsets[111], object.libraryFilterNovelUnreadType);
+  writer.writeBool(offsets[112], object.libraryLocalSource);
+  writer.writeBool(offsets[113], object.libraryShowCategoryTabs);
+  writer.writeBool(offsets[114], object.libraryShowContinueReadingButton);
+  writer.writeBool(offsets[115], object.libraryShowLanguage);
+  writer.writeBool(offsets[116], object.libraryShowNumbersOfItems);
+  writer.writeStringList(offsets[117], object.localFolders);
   writer.writeObject<L10nLocale>(
-    offsets[116],
+    offsets[118],
     allOffsets,
     L10nLocaleSchema.serialize,
     object.locale,
   );
   writer.writeObjectList<Repo>(
-    offsets[117],
+    offsets[119],
     allOffsets,
     RepoSchema.serialize,
     object.mangaExtensionsRepo,
   );
-  writer.writeLong(offsets[118], object.mangaGridSize);
-  writer.writeByte(offsets[119], object.mangaHomeDisplayType.index);
-  writer.writeLong(offsets[120], object.markEpisodeAsSeenType);
-  writer.writeBool(offsets[121], object.mergeLibraryNavMobile);
-  writer.writeBool(offsets[122], object.navigateToPan);
-  writer.writeStringList(offsets[123], object.navigationOrder);
-  writer.writeByte(offsets[124], object.novelDisplayType.index);
+  writer.writeLong(offsets[120], object.mangaGridSize);
+  writer.writeByte(offsets[121], object.mangaHomeDisplayType.index);
+  writer.writeLong(offsets[122], object.markEpisodeAsSeenType);
+  writer.writeBool(offsets[123], object.mergeLibraryNavMobile);
+  writer.writeBool(offsets[124], object.navigateToPan);
+  writer.writeStringList(offsets[125], object.navigationOrder);
+  writer.writeByte(offsets[126], object.novelDisplayType.index);
   writer.writeObjectList<Repo>(
-    offsets[125],
+    offsets[127],
     allOffsets,
     RepoSchema.serialize,
     object.novelExtensionsRepo,
   );
-  writer.writeLong(offsets[126], object.novelFontSize);
-  writer.writeLong(offsets[127], object.novelGridSize);
-  writer.writeBool(offsets[128], object.novelLibraryDownloadedChapters);
-  writer.writeBool(offsets[129], object.novelLibraryLocalSource);
-  writer.writeBool(offsets[130], object.novelLibraryShowCategoryTabs);
-  writer.writeBool(offsets[131], object.novelLibraryShowContinueReadingButton);
-  writer.writeBool(offsets[132], object.novelLibraryShowLanguage);
-  writer.writeBool(offsets[133], object.novelLibraryShowNumbersOfItems);
-  writer.writeDouble(offsets[134], object.novelReaderLineHeight);
-  writer.writeLong(offsets[135], object.novelReaderPadding);
-  writer.writeString(offsets[136], object.novelReaderTextColor);
-  writer.writeString(offsets[137], object.novelReaderTheme);
-  writer.writeBool(offsets[138], object.novelRemoveExtraParagraphSpacing);
-  writer.writeBool(offsets[139], object.novelShowScrollPercentage);
-  writer.writeBool(offsets[140], object.novelTapToScroll);
-  writer.writeByte(offsets[141], object.novelTextAlign.index);
-  writer.writeBool(offsets[142], object.onlyIncludePinnedSources);
-  writer.writeLong(offsets[143], object.pagePreloadAmount);
+  writer.writeLong(offsets[128], object.novelFontSize);
+  writer.writeLong(offsets[129], object.novelGridSize);
+  writer.writeBool(offsets[130], object.novelLibraryDownloadedChapters);
+  writer.writeBool(offsets[131], object.novelLibraryLocalSource);
+  writer.writeBool(offsets[132], object.novelLibraryShowCategoryTabs);
+  writer.writeBool(offsets[133], object.novelLibraryShowContinueReadingButton);
+  writer.writeBool(offsets[134], object.novelLibraryShowLanguage);
+  writer.writeBool(offsets[135], object.novelLibraryShowNumbersOfItems);
+  writer.writeDouble(offsets[136], object.novelReaderLineHeight);
+  writer.writeLong(offsets[137], object.novelReaderPadding);
+  writer.writeString(offsets[138], object.novelReaderTextColor);
+  writer.writeString(offsets[139], object.novelReaderTheme);
+  writer.writeBool(offsets[140], object.novelRemoveExtraParagraphSpacing);
+  writer.writeBool(offsets[141], object.novelShowScrollPercentage);
+  writer.writeBool(offsets[142], object.novelTapToScroll);
+  writer.writeByte(offsets[143], object.novelTextAlign.index);
+  writer.writeBool(offsets[144], object.onlyIncludePinnedSources);
+  writer.writeLong(offsets[145], object.pagePreloadAmount);
   writer.writeObjectList<PersonalPageMode>(
-    offsets[144],
+    offsets[146],
     allOffsets,
     PersonalPageModeSchema.serialize,
     object.personalPageModeList,
   );
   writer.writeObjectList<PersonalReaderMode>(
-    offsets[145],
+    offsets[147],
     allOffsets,
     PersonalReaderModeSchema.serialize,
     object.personalReaderModeList,
   );
   writer.writeObject<PlayerSubtitleSettings>(
-    offsets[146],
+    offsets[148],
     allOffsets,
     PlayerSubtitleSettingsSchema.serialize,
     object.playerSubtitleSettings,
   );
-  writer.writeBool(offsets[147], object.pureBlackDarkMode);
-  writer.writeDouble(offsets[148], object.readerBrightness);
-  writer.writeDouble(offsets[149], object.readerContrast);
-  writer.writeLong(offsets[150], object.readerHideThreshold);
-  writer.writeLong(offsets[151], object.readerNavigationLayout);
-  writer.writeDouble(offsets[152], object.readerSaturation);
-  writer.writeLong(offsets[153], object.relativeTimesTamps);
-  writer.writeBool(offsets[154], object.rpcShowCoverImage);
-  writer.writeBool(offsets[155], object.rpcShowReadingWatchingProgress);
-  writer.writeBool(offsets[156], object.rpcShowTitle);
-  writer.writeBool(offsets[157], object.saveAsCBZArchive);
-  writer.writeByte(offsets[158], object.scaleType.index);
-  writer.writeBool(offsets[159], object.showNSFW);
-  writer.writeBool(offsets[160], object.showNavigationOverlayOnStart);
-  writer.writeBool(offsets[161], object.showPageGaps);
-  writer.writeBool(offsets[162], object.showPagesNumber);
+  writer.writeBool(offsets[149], object.pureBlackDarkMode);
+  writer.writeDouble(offsets[150], object.readerBrightness);
+  writer.writeDouble(offsets[151], object.readerContrast);
+  writer.writeLong(offsets[152], object.readerHideThreshold);
+  writer.writeLong(offsets[153], object.readerNavigationLayout);
+  writer.writeDouble(offsets[154], object.readerSaturation);
+  writer.writeLong(offsets[155], object.relativeTimesTamps);
+  writer.writeBool(offsets[156], object.rpcShowCoverImage);
+  writer.writeBool(offsets[157], object.rpcShowReadingWatchingProgress);
+  writer.writeBool(offsets[158], object.rpcShowTitle);
+  writer.writeBool(offsets[159], object.saveAsCBZArchive);
+  writer.writeByte(offsets[160], object.scaleType.index);
+  writer.writeBool(offsets[161], object.showNSFW);
+  writer.writeBool(offsets[162], object.showNavigationOverlayOnStart);
+  writer.writeBool(offsets[163], object.showPageGaps);
+  writer.writeBool(offsets[164], object.showPagesNumber);
   writer.writeObjectList<SortChapter>(
-    offsets[163],
+    offsets[165],
     allOffsets,
     SortChapterSchema.serialize,
     object.sortChapterList,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[164],
+    offsets[166],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryAnime,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[165],
+    offsets[167],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryManga,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[166],
+    offsets[168],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryNovel,
   );
-  writer.writeBool(offsets[167], object.splitWidePages);
-  writer.writeLong(offsets[168], object.startDatebackup);
-  writer.writeLong(offsets[169], object.tappingInversion);
-  writer.writeBool(offsets[170], object.themeIsDark);
-  writer.writeString(offsets[171], object.ttsLanguage);
-  writer.writeDouble(offsets[172], object.ttsPitch);
-  writer.writeDouble(offsets[173], object.ttsSpeechRate);
-  writer.writeString(offsets[174], object.ttsVoice);
+  writer.writeBool(offsets[169], object.splitWidePages);
+  writer.writeLong(offsets[170], object.startDatebackup);
+  writer.writeLong(offsets[171], object.tappingInversion);
+  writer.writeBool(offsets[172], object.themeIsDark);
+  writer.writeString(offsets[173], object.ttsLanguage);
+  writer.writeDouble(offsets[174], object.ttsPitch);
+  writer.writeDouble(offsets[175], object.ttsSpeechRate);
+  writer.writeString(offsets[176], object.ttsVoice);
   writer.writeObjectList<UpdateError>(
-    offsets[175],
+    offsets[177],
     allOffsets,
     UpdateErrorSchema.serialize,
     object.updateErrorsList,
   );
-  writer.writeBool(offsets[176], object.updateProgressAfterReading);
-  writer.writeLong(offsets[177], object.updatedAt);
-  writer.writeBool(offsets[178], object.useLibass);
-  writer.writeBool(offsets[179], object.useMpvConfig);
-  writer.writeBool(offsets[180], object.usePageTapZones);
-  writer.writeBool(offsets[181], object.useYUV420P);
-  writer.writeString(offsets[182], object.userAgent);
-  writer.writeLong(offsets[183], object.volumeBoostCap);
-  writer.writeBool(offsets[184], object.webtoonDisableZoomOut);
-  writer.writeBool(offsets[185], object.webtoonDoubleTapZoomEnabled);
-  writer.writeLong(offsets[186], object.webtoonSidePadding);
-  writer.writeLong(offsets[187], object.zoomStartPosition);
+  writer.writeBool(offsets[178], object.updateProgressAfterReading);
+  writer.writeLong(offsets[179], object.updatedAt);
+  writer.writeBool(offsets[180], object.useLibass);
+  writer.writeBool(offsets[181], object.useMpvConfig);
+  writer.writeBool(offsets[182], object.usePageTapZones);
+  writer.writeBool(offsets[183], object.useYUV420P);
+  writer.writeString(offsets[184], object.userAgent);
+  writer.writeLong(offsets[185], object.volumeBoostCap);
+  writer.writeBool(offsets[186], object.webtoonDisableZoomOut);
+  writer.writeBool(offsets[187], object.webtoonDoubleTapZoomEnabled);
+  writer.writeLong(offsets[188], object.webtoonSidePadding);
+  writer.writeLong(offsets[189], object.zoomStartPosition);
 }
 
 Settings _settingsDeserialize(
@@ -1914,294 +1938,296 @@ Settings _settingsDeserialize(
     backupListOptions: reader.readLongList(offsets[25]),
     btServerAddress: reader.readStringOrNull(offsets[26]),
     btServerPort: reader.readLongOrNull(offsets[27]),
+    cfProxyUrl: reader.readStringOrNull(offsets[28]),
     chapterFilterDownloadedList: reader.readObjectList<ChapterFilterDownloaded>(
-      offsets[29],
+      offsets[30],
       ChapterFilterDownloadedSchema.deserialize,
       allOffsets,
       ChapterFilterDownloaded(),
     ),
     chapterPageIndexList: reader.readObjectList<ChapterPageIndex>(
-      offsets[31],
+      offsets[32],
       ChapterPageIndexSchema.deserialize,
       allOffsets,
       ChapterPageIndex(),
     ),
     chapterPageUrlsList: reader.readObjectList<ChapterPageurls>(
-      offsets[32],
+      offsets[33],
       ChapterPageurlsSchema.deserialize,
       allOffsets,
       ChapterPageurls(),
     ),
-    checkForAppUpdates: reader.readBoolOrNull(offsets[33]),
-    checkForExtensionUpdates: reader.readBoolOrNull(offsets[34]),
-    clearChapterCacheOnAppLaunch: reader.readBoolOrNull(offsets[35]),
+    checkForAppUpdates: reader.readBoolOrNull(offsets[34]),
+    checkForExtensionUpdates: reader.readBoolOrNull(offsets[35]),
+    clearChapterCacheOnAppLaunch: reader.readBoolOrNull(offsets[36]),
     colorFilterBlendMode:
         _SettingscolorFilterBlendModeValueEnumMap[reader.readByteOrNull(
-          offsets[36],
+          offsets[37],
         )] ??
         ColorFilterBlendMode.none,
-    concurrentDownloads: reader.readLongOrNull(offsets[37]),
+    concurrentDownloads: reader.readLongOrNull(offsets[38]),
     cookiesList: reader.readObjectList<MCookie>(
-      offsets[38],
+      offsets[39],
       MCookieSchema.deserialize,
       allOffsets,
       MCookie(),
     ),
-    cropBorders: reader.readBoolOrNull(offsets[39]),
+    cropBorders: reader.readBoolOrNull(offsets[40]),
     customColorFilter: reader.readObjectOrNull<CustomColorFilter>(
-      offsets[40],
+      offsets[41],
       CustomColorFilterSchema.deserialize,
       allOffsets,
     ),
-    customDns: reader.readStringOrNull(offsets[41]),
-    dateFormat: reader.readStringOrNull(offsets[42]),
+    customDns: reader.readStringOrNull(offsets[42]),
+    customDohUrl: reader.readStringOrNull(offsets[43]),
+    dateFormat: reader.readStringOrNull(offsets[44]),
     debandingType:
         _SettingsdebandingTypeValueEnumMap[reader.readByteOrNull(
-          offsets[43],
+          offsets[45],
         )] ??
         DebandingType.none,
-    defaultDoubleTapToSkipLength: reader.readLongOrNull(offsets[44]),
-    defaultPlayBackSpeed: reader.readDoubleOrNull(offsets[45]),
+    defaultDoubleTapToSkipLength: reader.readLongOrNull(offsets[46]),
+    defaultPlayBackSpeed: reader.readDoubleOrNull(offsets[47]),
     defaultReaderMode:
         _SettingsdefaultReaderModeValueEnumMap[reader.readByteOrNull(
-          offsets[46],
+          offsets[48],
         )] ??
         ReaderMode.vertical,
-    defaultSkipIntroLength: reader.readLongOrNull(offsets[47]),
-    deleteDownloadAfterReading: reader.readBoolOrNull(offsets[49]),
+    defaultSkipIntroLength: reader.readLongOrNull(offsets[49]),
+    deleteDownloadAfterReading: reader.readBoolOrNull(offsets[51]),
     disableSectionType:
         _SettingsdisableSectionTypeValueEnumMap[reader.readByteOrNull(
-          offsets[50],
+          offsets[52],
         )] ??
         SectionType.all,
     displayType:
-        _SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offsets[51])] ??
+        _SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offsets[53])] ??
         DisplayType.compactGrid,
-    doHEnabled: reader.readBoolOrNull(offsets[52]),
-    doHProviderId: reader.readLongOrNull(offsets[53]),
-    doubleTapAnimationSpeed: reader.readLongOrNull(offsets[54]),
-    downloadLocation: reader.readStringOrNull(offsets[55]),
-    downloadOnlyOnWifi: reader.readBoolOrNull(offsets[56]),
-    downloadedOnlyMode: reader.readBoolOrNull(offsets[57]),
-    dualPageInvert: reader.readBoolOrNull(offsets[58]),
-    dualPageRotateToFit: reader.readBoolOrNull(offsets[59]),
-    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[60]),
-    enableAniSkip: reader.readBoolOrNull(offsets[61]),
-    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[62]),
-    enableAutoSkip: reader.readBoolOrNull(offsets[63]),
-    enableCustomColorFilter: reader.readBoolOrNull(offsets[64]),
-    enableDiscordRpc: reader.readBoolOrNull(offsets[65]),
-    enableGpuNext: reader.readBoolOrNull(offsets[66]),
-    enableHardwareAcceleration: reader.readBoolOrNull(offsets[67]),
-    enableLogs: reader.readBoolOrNull(offsets[68]),
-    extensionServerPath: reader.readStringOrNull(offsets[69]),
-    flashColor: reader.readLongOrNull(offsets[71]),
-    flashDuration: reader.readLongOrNull(offsets[72]),
-    flashInterval: reader.readLongOrNull(offsets[73]),
-    flashOnPageChange: reader.readBoolOrNull(offsets[74]),
-    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[75]),
-    flexSchemeColorIndex: reader.readLongOrNull(offsets[76]),
-    followSystemTheme: reader.readBoolOrNull(offsets[77]),
-    forceLandscapePlayer: reader.readBoolOrNull(offsets[78]),
-    fullScreenPlayer: reader.readBoolOrNull(offsets[79]),
-    fullScreenReader: reader.readBoolOrNull(offsets[80]),
-    grayscale: reader.readBoolOrNull(offsets[81]),
-    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[82]),
-    hideItems: reader.readStringList(offsets[83]),
-    hwdecMode: reader.readStringOrNull(offsets[84]),
+    doHEnabled: reader.readBoolOrNull(offsets[54]),
+    doHProviderId: reader.readLongOrNull(offsets[55]),
+    doubleTapAnimationSpeed: reader.readLongOrNull(offsets[56]),
+    downloadLocation: reader.readStringOrNull(offsets[57]),
+    downloadOnlyOnWifi: reader.readBoolOrNull(offsets[58]),
+    downloadedOnlyMode: reader.readBoolOrNull(offsets[59]),
+    dualPageInvert: reader.readBoolOrNull(offsets[60]),
+    dualPageRotateToFit: reader.readBoolOrNull(offsets[61]),
+    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[62]),
+    enableAniSkip: reader.readBoolOrNull(offsets[63]),
+    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[64]),
+    enableAutoSkip: reader.readBoolOrNull(offsets[65]),
+    enableCustomColorFilter: reader.readBoolOrNull(offsets[66]),
+    enableDiscordRpc: reader.readBoolOrNull(offsets[67]),
+    enableGpuNext: reader.readBoolOrNull(offsets[68]),
+    enableHardwareAcceleration: reader.readBoolOrNull(offsets[69]),
+    enableLogs: reader.readBoolOrNull(offsets[70]),
+    extensionServerPath: reader.readStringOrNull(offsets[71]),
+    flashColor: reader.readLongOrNull(offsets[73]),
+    flashDuration: reader.readLongOrNull(offsets[74]),
+    flashInterval: reader.readLongOrNull(offsets[75]),
+    flashOnPageChange: reader.readBoolOrNull(offsets[76]),
+    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[77]),
+    flexSchemeColorIndex: reader.readLongOrNull(offsets[78]),
+    followSystemTheme: reader.readBoolOrNull(offsets[79]),
+    forceLandscapePlayer: reader.readBoolOrNull(offsets[80]),
+    fullScreenPlayer: reader.readBoolOrNull(offsets[81]),
+    fullScreenReader: reader.readBoolOrNull(offsets[82]),
+    grayscale: reader.readBoolOrNull(offsets[83]),
+    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[84]),
+    hideItems: reader.readStringList(offsets[85]),
+    hwdecMode: reader.readStringOrNull(offsets[86]),
     id: id,
-    incognitoMode: reader.readBoolOrNull(offsets[85]),
-    invertColors: reader.readBoolOrNull(offsets[86]),
-    jrePath: reader.readStringOrNull(offsets[87]),
-    keepScreenOnReader: reader.readBoolOrNull(offsets[88]),
-    landscapeZoom: reader.readBoolOrNull(offsets[89]),
-    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[90]),
-    libraryDownloadedChapters: reader.readBoolOrNull(offsets[91]),
-    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[92]),
-    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[93]),
-    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[94]),
-    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[95]),
-    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[96]),
-    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[97]),
-    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[98]),
-    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[99]),
-    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[100]),
-    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[101]),
-    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[102]),
-    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[103]),
-    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[104]),
-    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[105]),
-    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[106]),
-    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[107]),
-    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[108]),
-    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[109]),
-    libraryLocalSource: reader.readBoolOrNull(offsets[110]),
-    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[111]),
-    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[112]),
-    libraryShowLanguage: reader.readBoolOrNull(offsets[113]),
-    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[114]),
-    localFolders: reader.readStringList(offsets[115]),
+    incognitoMode: reader.readBoolOrNull(offsets[87]),
+    invertColors: reader.readBoolOrNull(offsets[88]),
+    jrePath: reader.readStringOrNull(offsets[89]),
+    keepScreenOnReader: reader.readBoolOrNull(offsets[90]),
+    landscapeZoom: reader.readBoolOrNull(offsets[91]),
+    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[92]),
+    libraryDownloadedChapters: reader.readBoolOrNull(offsets[93]),
+    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[94]),
+    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[95]),
+    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[96]),
+    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[97]),
+    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[98]),
+    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[99]),
+    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[100]),
+    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[101]),
+    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[102]),
+    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[103]),
+    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[104]),
+    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[105]),
+    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[106]),
+    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[107]),
+    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[108]),
+    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[109]),
+    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[110]),
+    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[111]),
+    libraryLocalSource: reader.readBoolOrNull(offsets[112]),
+    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[113]),
+    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[114]),
+    libraryShowLanguage: reader.readBoolOrNull(offsets[115]),
+    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[116]),
+    localFolders: reader.readStringList(offsets[117]),
     mangaExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[117],
+      offsets[119],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    mangaGridSize: reader.readLongOrNull(offsets[118]),
+    mangaGridSize: reader.readLongOrNull(offsets[120]),
     mangaHomeDisplayType:
         _SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[119],
+          offsets[121],
         )] ??
         DisplayType.comfortableGrid,
-    markEpisodeAsSeenType: reader.readLongOrNull(offsets[120]),
-    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[121]),
-    navigateToPan: reader.readBoolOrNull(offsets[122]),
-    navigationOrder: reader.readStringList(offsets[123]),
+    markEpisodeAsSeenType: reader.readLongOrNull(offsets[122]),
+    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[123]),
+    navigateToPan: reader.readBoolOrNull(offsets[124]),
+    navigationOrder: reader.readStringList(offsets[125]),
     novelDisplayType:
         _SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[124],
+          offsets[126],
         )] ??
         DisplayType.comfortableGrid,
     novelExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[125],
+      offsets[127],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    novelFontSize: reader.readLongOrNull(offsets[126]),
-    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[128]),
-    novelLibraryLocalSource: reader.readBoolOrNull(offsets[129]),
-    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[130]),
-    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[131]),
-    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[132]),
-    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[133]),
-    novelReaderLineHeight: reader.readDoubleOrNull(offsets[134]),
-    novelReaderPadding: reader.readLongOrNull(offsets[135]),
-    novelReaderTextColor: reader.readStringOrNull(offsets[136]),
-    novelReaderTheme: reader.readStringOrNull(offsets[137]),
-    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[138]),
-    novelShowScrollPercentage: reader.readBoolOrNull(offsets[139]),
-    novelTapToScroll: reader.readBoolOrNull(offsets[140]),
+    novelFontSize: reader.readLongOrNull(offsets[128]),
+    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[130]),
+    novelLibraryLocalSource: reader.readBoolOrNull(offsets[131]),
+    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[132]),
+    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[133]),
+    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[134]),
+    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[135]),
+    novelReaderLineHeight: reader.readDoubleOrNull(offsets[136]),
+    novelReaderPadding: reader.readLongOrNull(offsets[137]),
+    novelReaderTextColor: reader.readStringOrNull(offsets[138]),
+    novelReaderTheme: reader.readStringOrNull(offsets[139]),
+    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[140]),
+    novelShowScrollPercentage: reader.readBoolOrNull(offsets[141]),
+    novelTapToScroll: reader.readBoolOrNull(offsets[142]),
     novelTextAlign:
         _SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
-          offsets[141],
+          offsets[143],
         )] ??
         NovelTextAlign.left,
-    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[142]),
-    pagePreloadAmount: reader.readLongOrNull(offsets[143]),
+    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[144]),
+    pagePreloadAmount: reader.readLongOrNull(offsets[145]),
     personalPageModeList: reader.readObjectList<PersonalPageMode>(
-      offsets[144],
+      offsets[146],
       PersonalPageModeSchema.deserialize,
       allOffsets,
       PersonalPageMode(),
     ),
     personalReaderModeList: reader.readObjectList<PersonalReaderMode>(
-      offsets[145],
+      offsets[147],
       PersonalReaderModeSchema.deserialize,
       allOffsets,
       PersonalReaderMode(),
     ),
     playerSubtitleSettings: reader.readObjectOrNull<PlayerSubtitleSettings>(
-      offsets[146],
+      offsets[148],
       PlayerSubtitleSettingsSchema.deserialize,
       allOffsets,
     ),
-    pureBlackDarkMode: reader.readBoolOrNull(offsets[147]),
-    readerBrightness: reader.readDoubleOrNull(offsets[148]),
-    readerContrast: reader.readDoubleOrNull(offsets[149]),
-    readerHideThreshold: reader.readLongOrNull(offsets[150]),
-    readerNavigationLayout: reader.readLongOrNull(offsets[151]),
-    readerSaturation: reader.readDoubleOrNull(offsets[152]),
-    relativeTimesTamps: reader.readLongOrNull(offsets[153]),
-    rpcShowCoverImage: reader.readBoolOrNull(offsets[154]),
-    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[155]),
-    rpcShowTitle: reader.readBoolOrNull(offsets[156]),
-    saveAsCBZArchive: reader.readBoolOrNull(offsets[157]),
+    pureBlackDarkMode: reader.readBoolOrNull(offsets[149]),
+    readerBrightness: reader.readDoubleOrNull(offsets[150]),
+    readerContrast: reader.readDoubleOrNull(offsets[151]),
+    readerHideThreshold: reader.readLongOrNull(offsets[152]),
+    readerNavigationLayout: reader.readLongOrNull(offsets[153]),
+    readerSaturation: reader.readDoubleOrNull(offsets[154]),
+    relativeTimesTamps: reader.readLongOrNull(offsets[155]),
+    rpcShowCoverImage: reader.readBoolOrNull(offsets[156]),
+    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[157]),
+    rpcShowTitle: reader.readBoolOrNull(offsets[158]),
+    saveAsCBZArchive: reader.readBoolOrNull(offsets[159]),
     scaleType:
-        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[158])] ??
+        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[160])] ??
         ScaleType.fitScreen,
-    showNSFW: reader.readBoolOrNull(offsets[159]),
-    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[160]),
-    showPageGaps: reader.readBoolOrNull(offsets[161]),
-    showPagesNumber: reader.readBoolOrNull(offsets[162]),
+    showNSFW: reader.readBoolOrNull(offsets[161]),
+    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[162]),
+    showPageGaps: reader.readBoolOrNull(offsets[163]),
+    showPagesNumber: reader.readBoolOrNull(offsets[164]),
     sortChapterList: reader.readObjectList<SortChapter>(
-      offsets[163],
+      offsets[165],
       SortChapterSchema.deserialize,
       allOffsets,
       SortChapter(),
     ),
     sortLibraryAnime: reader.readObjectOrNull<SortLibraryManga>(
-      offsets[164],
-      SortLibraryMangaSchema.deserialize,
-      allOffsets,
-    ),
-    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
-      offsets[165],
-      SortLibraryMangaSchema.deserialize,
-      allOffsets,
-    ),
-    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
       offsets[166],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    splitWidePages: reader.readBoolOrNull(offsets[167]),
-    startDatebackup: reader.readLongOrNull(offsets[168]),
-    tappingInversion: reader.readLongOrNull(offsets[169]),
-    themeIsDark: reader.readBoolOrNull(offsets[170]),
-    ttsLanguage: reader.readStringOrNull(offsets[171]),
-    ttsPitch: reader.readDoubleOrNull(offsets[172]),
-    ttsSpeechRate: reader.readDoubleOrNull(offsets[173]),
-    ttsVoice: reader.readStringOrNull(offsets[174]),
+    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
+      offsets[167],
+      SortLibraryMangaSchema.deserialize,
+      allOffsets,
+    ),
+    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+      offsets[168],
+      SortLibraryMangaSchema.deserialize,
+      allOffsets,
+    ),
+    splitWidePages: reader.readBoolOrNull(offsets[169]),
+    startDatebackup: reader.readLongOrNull(offsets[170]),
+    tappingInversion: reader.readLongOrNull(offsets[171]),
+    themeIsDark: reader.readBoolOrNull(offsets[172]),
+    ttsLanguage: reader.readStringOrNull(offsets[173]),
+    ttsPitch: reader.readDoubleOrNull(offsets[174]),
+    ttsSpeechRate: reader.readDoubleOrNull(offsets[175]),
+    ttsVoice: reader.readStringOrNull(offsets[176]),
     updateErrorsList: reader.readObjectList<UpdateError>(
-      offsets[175],
+      offsets[177],
       UpdateErrorSchema.deserialize,
       allOffsets,
       UpdateError(),
     ),
-    updateProgressAfterReading: reader.readBoolOrNull(offsets[176]),
-    updatedAt: reader.readLongOrNull(offsets[177]),
-    useLibass: reader.readBoolOrNull(offsets[178]),
-    useMpvConfig: reader.readBoolOrNull(offsets[179]),
-    usePageTapZones: reader.readBoolOrNull(offsets[180]),
-    useYUV420P: reader.readBoolOrNull(offsets[181]),
-    userAgent: reader.readStringOrNull(offsets[182]),
-    volumeBoostCap: reader.readLongOrNull(offsets[183]),
-    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[184]),
-    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[185]),
-    webtoonSidePadding: reader.readLongOrNull(offsets[186]),
-    zoomStartPosition: reader.readLongOrNull(offsets[187]),
+    updateProgressAfterReading: reader.readBoolOrNull(offsets[178]),
+    updatedAt: reader.readLongOrNull(offsets[179]),
+    useLibass: reader.readBoolOrNull(offsets[180]),
+    useMpvConfig: reader.readBoolOrNull(offsets[181]),
+    usePageTapZones: reader.readBoolOrNull(offsets[182]),
+    useYUV420P: reader.readBoolOrNull(offsets[183]),
+    userAgent: reader.readStringOrNull(offsets[184]),
+    volumeBoostCap: reader.readLongOrNull(offsets[185]),
+    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[186]),
+    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[187]),
+    webtoonSidePadding: reader.readLongOrNull(offsets[188]),
+    zoomStartPosition: reader.readLongOrNull(offsets[189]),
   );
   object.chapterFilterBookmarkedList = reader
       .readObjectList<ChapterFilterBookmarked>(
-        offsets[28],
+        offsets[29],
         ChapterFilterBookmarkedSchema.deserialize,
         allOffsets,
         ChapterFilterBookmarked(),
       );
   object.chapterFilterUnreadList = reader.readObjectList<ChapterFilterUnread>(
-    offsets[30],
+    offsets[31],
     ChapterFilterUnreadSchema.deserialize,
     allOffsets,
     ChapterFilterUnread(),
   );
   object.defaultSubtitleLang = reader.readObjectOrNull<L10nLocale>(
-    offsets[48],
+    offsets[50],
     L10nLocaleSchema.deserialize,
     allOffsets,
   );
   object.filterScanlatorList = reader.readObjectList<FilterScanlator>(
-    offsets[70],
+    offsets[72],
     FilterScanlatorSchema.deserialize,
     allOffsets,
     FilterScanlator(),
   );
   object.locale = reader.readObjectOrNull<L10nLocale>(
-    offsets[116],
+    offsets[118],
     L10nLocaleSchema.deserialize,
     allOffsets,
   );
-  object.novelGridSize = reader.readLongOrNull(offsets[127]);
+  object.novelGridSize = reader.readLongOrNull(offsets[129]);
   return object;
 }
 
@@ -2298,6 +2324,8 @@ P _settingsDeserializeProp<P>(
     case 27:
       return (reader.readLongOrNull(offset)) as P;
     case 28:
+      return (reader.readStringOrNull(offset)) as P;
+    case 29:
       return (reader.readObjectList<ChapterFilterBookmarked>(
             offset,
             ChapterFilterBookmarkedSchema.deserialize,
@@ -2305,7 +2333,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterBookmarked(),
           ))
           as P;
-    case 29:
+    case 30:
       return (reader.readObjectList<ChapterFilterDownloaded>(
             offset,
             ChapterFilterDownloadedSchema.deserialize,
@@ -2313,7 +2341,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterDownloaded(),
           ))
           as P;
-    case 30:
+    case 31:
       return (reader.readObjectList<ChapterFilterUnread>(
             offset,
             ChapterFilterUnreadSchema.deserialize,
@@ -2321,7 +2349,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterUnread(),
           ))
           as P;
-    case 31:
+    case 32:
       return (reader.readObjectList<ChapterPageIndex>(
             offset,
             ChapterPageIndexSchema.deserialize,
@@ -2329,7 +2357,7 @@ P _settingsDeserializeProp<P>(
             ChapterPageIndex(),
           ))
           as P;
-    case 32:
+    case 33:
       return (reader.readObjectList<ChapterPageurls>(
             offset,
             ChapterPageurlsSchema.deserialize,
@@ -2337,21 +2365,21 @@ P _settingsDeserializeProp<P>(
             ChapterPageurls(),
           ))
           as P;
-    case 33:
-      return (reader.readBoolOrNull(offset)) as P;
     case 34:
       return (reader.readBoolOrNull(offset)) as P;
     case 35:
       return (reader.readBoolOrNull(offset)) as P;
     case 36:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 37:
       return (_SettingscolorFilterBlendModeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               ColorFilterBlendMode.none)
           as P;
-    case 37:
-      return (reader.readLongOrNull(offset)) as P;
     case 38:
+      return (reader.readLongOrNull(offset)) as P;
+    case 39:
       return (reader.readObjectList<MCookie>(
             offset,
             MCookieSchema.deserialize,
@@ -2359,68 +2387,66 @@ P _settingsDeserializeProp<P>(
             MCookie(),
           ))
           as P;
-    case 39:
-      return (reader.readBoolOrNull(offset)) as P;
     case 40:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 41:
       return (reader.readObjectOrNull<CustomColorFilter>(
             offset,
             CustomColorFilterSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 41:
-      return (reader.readStringOrNull(offset)) as P;
     case 42:
       return (reader.readStringOrNull(offset)) as P;
     case 43:
+      return (reader.readStringOrNull(offset)) as P;
+    case 44:
+      return (reader.readStringOrNull(offset)) as P;
+    case 45:
       return (_SettingsdebandingTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DebandingType.none)
           as P;
-    case 44:
-      return (reader.readLongOrNull(offset)) as P;
-    case 45:
-      return (reader.readDoubleOrNull(offset)) as P;
     case 46:
+      return (reader.readLongOrNull(offset)) as P;
+    case 47:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 48:
       return (_SettingsdefaultReaderModeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               ReaderMode.vertical)
           as P;
-    case 47:
+    case 49:
       return (reader.readLongOrNull(offset)) as P;
-    case 48:
+    case 50:
       return (reader.readObjectOrNull<L10nLocale>(
             offset,
             L10nLocaleSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 49:
+    case 51:
       return (reader.readBoolOrNull(offset)) as P;
-    case 50:
+    case 52:
       return (_SettingsdisableSectionTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               SectionType.all)
           as P;
-    case 51:
+    case 53:
       return (_SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offset)] ??
               DisplayType.compactGrid)
           as P;
-    case 52:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 53:
-      return (reader.readLongOrNull(offset)) as P;
     case 54:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 55:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 56:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 57:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 58:
       return (reader.readBoolOrNull(offset)) as P;
     case 59:
@@ -2444,8 +2470,12 @@ P _settingsDeserializeProp<P>(
     case 68:
       return (reader.readBoolOrNull(offset)) as P;
     case 69:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 70:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 71:
+      return (reader.readStringOrNull(offset)) as P;
+    case 72:
       return (reader.readObjectList<FilterScanlator>(
             offset,
             FilterScanlatorSchema.deserialize,
@@ -2453,22 +2483,18 @@ P _settingsDeserializeProp<P>(
             FilterScanlator(),
           ))
           as P;
-    case 71:
-      return (reader.readLongOrNull(offset)) as P;
-    case 72:
-      return (reader.readLongOrNull(offset)) as P;
     case 73:
       return (reader.readLongOrNull(offset)) as P;
     case 74:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 75:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 76:
       return (reader.readLongOrNull(offset)) as P;
+    case 75:
+      return (reader.readLongOrNull(offset)) as P;
+    case 76:
+      return (reader.readBoolOrNull(offset)) as P;
     case 77:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 78:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 79:
       return (reader.readBoolOrNull(offset)) as P;
     case 80:
@@ -2478,27 +2504,27 @@ P _settingsDeserializeProp<P>(
     case 82:
       return (reader.readBoolOrNull(offset)) as P;
     case 83:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 84:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 85:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringList(offset)) as P;
     case 86:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 87:
       return (reader.readStringOrNull(offset)) as P;
+    case 87:
+      return (reader.readBoolOrNull(offset)) as P;
     case 88:
       return (reader.readBoolOrNull(offset)) as P;
     case 89:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 90:
       return (reader.readStringOrNull(offset)) as P;
+    case 90:
+      return (reader.readBoolOrNull(offset)) as P;
     case 91:
       return (reader.readBoolOrNull(offset)) as P;
     case 92:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 93:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 94:
       return (reader.readLongOrNull(offset)) as P;
     case 95:
@@ -2532,9 +2558,9 @@ P _settingsDeserializeProp<P>(
     case 109:
       return (reader.readLongOrNull(offset)) as P;
     case 110:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 111:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 112:
       return (reader.readBoolOrNull(offset)) as P;
     case 113:
@@ -2542,15 +2568,19 @@ P _settingsDeserializeProp<P>(
     case 114:
       return (reader.readBoolOrNull(offset)) as P;
     case 115:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 116:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 117:
+      return (reader.readStringList(offset)) as P;
+    case 118:
       return (reader.readObjectOrNull<L10nLocale>(
             offset,
             L10nLocaleSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 117:
+    case 119:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2558,29 +2588,29 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 118:
+    case 120:
       return (reader.readLongOrNull(offset)) as P;
-    case 119:
+    case 121:
       return (_SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 120:
-      return (reader.readLongOrNull(offset)) as P;
-    case 121:
-      return (reader.readBoolOrNull(offset)) as P;
     case 122:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 123:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 124:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 125:
+      return (reader.readStringList(offset)) as P;
+    case 126:
       return (_SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 125:
+    case 127:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2588,14 +2618,10 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 126:
-      return (reader.readLongOrNull(offset)) as P;
-    case 127:
-      return (reader.readLongOrNull(offset)) as P;
     case 128:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 129:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 130:
       return (reader.readBoolOrNull(offset)) as P;
     case 131:
@@ -2605,30 +2631,34 @@ P _settingsDeserializeProp<P>(
     case 133:
       return (reader.readBoolOrNull(offset)) as P;
     case 134:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 135:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 136:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 137:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 138:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 139:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 140:
       return (reader.readBoolOrNull(offset)) as P;
     case 141:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 142:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 143:
       return (_SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               NovelTextAlign.left)
           as P;
-    case 142:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 143:
-      return (reader.readLongOrNull(offset)) as P;
     case 144:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 145:
+      return (reader.readLongOrNull(offset)) as P;
+    case 146:
       return (reader.readObjectList<PersonalPageMode>(
             offset,
             PersonalPageModeSchema.deserialize,
@@ -2636,7 +2666,7 @@ P _settingsDeserializeProp<P>(
             PersonalPageMode(),
           ))
           as P;
-    case 145:
+    case 147:
       return (reader.readObjectList<PersonalReaderMode>(
             offset,
             PersonalReaderModeSchema.deserialize,
@@ -2644,67 +2674,53 @@ P _settingsDeserializeProp<P>(
             PersonalReaderMode(),
           ))
           as P;
-    case 146:
+    case 148:
       return (reader.readObjectOrNull<PlayerSubtitleSettings>(
             offset,
             PlayerSubtitleSettingsSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 147:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 148:
-      return (reader.readDoubleOrNull(offset)) as P;
     case 149:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 150:
-      return (reader.readLongOrNull(offset)) as P;
-    case 151:
-      return (reader.readLongOrNull(offset)) as P;
-    case 152:
       return (reader.readDoubleOrNull(offset)) as P;
+    case 151:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 152:
+      return (reader.readLongOrNull(offset)) as P;
     case 153:
       return (reader.readLongOrNull(offset)) as P;
     case 154:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 155:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 156:
       return (reader.readBoolOrNull(offset)) as P;
     case 157:
       return (reader.readBoolOrNull(offset)) as P;
     case 158:
-      return (_SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offset)] ??
-              ScaleType.fitScreen)
-          as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 159:
       return (reader.readBoolOrNull(offset)) as P;
     case 160:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (_SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offset)] ??
+              ScaleType.fitScreen)
+          as P;
     case 161:
       return (reader.readBoolOrNull(offset)) as P;
     case 162:
       return (reader.readBoolOrNull(offset)) as P;
     case 163:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 164:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 165:
       return (reader.readObjectList<SortChapter>(
             offset,
             SortChapterSchema.deserialize,
             allOffsets,
             SortChapter(),
-          ))
-          as P;
-    case 164:
-      return (reader.readObjectOrNull<SortLibraryManga>(
-            offset,
-            SortLibraryMangaSchema.deserialize,
-            allOffsets,
-          ))
-          as P;
-    case 165:
-      return (reader.readObjectOrNull<SortLibraryManga>(
-            offset,
-            SortLibraryMangaSchema.deserialize,
-            allOffsets,
           ))
           as P;
     case 166:
@@ -2715,22 +2731,36 @@ P _settingsDeserializeProp<P>(
           ))
           as P;
     case 167:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readObjectOrNull<SortLibraryManga>(
+            offset,
+            SortLibraryMangaSchema.deserialize,
+            allOffsets,
+          ))
+          as P;
     case 168:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readObjectOrNull<SortLibraryManga>(
+            offset,
+            SortLibraryMangaSchema.deserialize,
+            allOffsets,
+          ))
+          as P;
     case 169:
-      return (reader.readLongOrNull(offset)) as P;
-    case 170:
       return (reader.readBoolOrNull(offset)) as P;
+    case 170:
+      return (reader.readLongOrNull(offset)) as P;
     case 171:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 172:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 173:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 174:
       return (reader.readStringOrNull(offset)) as P;
+    case 174:
+      return (reader.readDoubleOrNull(offset)) as P;
     case 175:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 176:
+      return (reader.readStringOrNull(offset)) as P;
+    case 177:
       return (reader.readObjectList<UpdateError>(
             offset,
             UpdateErrorSchema.deserialize,
@@ -2738,29 +2768,29 @@ P _settingsDeserializeProp<P>(
             UpdateError(),
           ))
           as P;
-    case 176:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 177:
-      return (reader.readLongOrNull(offset)) as P;
     case 178:
       return (reader.readBoolOrNull(offset)) as P;
     case 179:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 180:
       return (reader.readBoolOrNull(offset)) as P;
     case 181:
       return (reader.readBoolOrNull(offset)) as P;
     case 182:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 183:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 184:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 185:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 186:
       return (reader.readLongOrNull(offset)) as P;
+    case 186:
+      return (reader.readBoolOrNull(offset)) as P;
     case 187:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 188:
+      return (reader.readLongOrNull(offset)) as P;
+    case 189:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -5024,6 +5054,170 @@ extension SettingsQueryFilter
     });
   }
 
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> cfProxyUrlIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'cfProxyUrl'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  cfProxyUrlIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'cfProxyUrl'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> cfProxyUrlEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'cfProxyUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> cfProxyUrlGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'cfProxyUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> cfProxyUrlLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'cfProxyUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> cfProxyUrlBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'cfProxyUrl',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> cfProxyUrlStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'cfProxyUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> cfProxyUrlEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'cfProxyUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> cfProxyUrlContains(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'cfProxyUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> cfProxyUrlMatches(
+    String pattern, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'cfProxyUrl',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> cfProxyUrlIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'cfProxyUrl', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  cfProxyUrlIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'cfProxyUrl', value: ''),
+      );
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterFilterCondition>
   chapterFilterBookmarkedListIsNull() {
     return QueryBuilder.apply(this, (query) {
@@ -5996,6 +6190,170 @@ extension SettingsQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(
         FilterCondition.greaterThan(property: r'customDns', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> customDohUrlIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'customDohUrl'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  customDohUrlIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'customDohUrl'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> customDohUrlEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'customDohUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  customDohUrlGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'customDohUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> customDohUrlLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'customDohUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> customDohUrlBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'customDohUrl',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  customDohUrlStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'customDohUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> customDohUrlEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'customDohUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> customDohUrlContains(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'customDohUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition> customDohUrlMatches(
+    String pattern, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'customDohUrl',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  customDohUrlIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'customDohUrl', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  customDohUrlIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'customDohUrl', value: ''),
       );
     });
   }
@@ -15952,6 +16310,18 @@ extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
     });
   }
 
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByCfProxyUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cfProxyUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByCfProxyUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cfProxyUrl', Sort.desc);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterSortBy> sortByCheckForAppUpdates() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'checkForAppUpdates', Sort.asc);
@@ -16040,6 +16410,18 @@ extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
   QueryBuilder<Settings, Settings, QAfterSortBy> sortByCustomDnsDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'customDns', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByCustomDohUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'customDohUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByCustomDohUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'customDohUrl', Sort.desc);
     });
   }
 
@@ -18046,6 +18428,18 @@ extension SettingsQuerySortThenBy
     });
   }
 
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByCfProxyUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cfProxyUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByCfProxyUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cfProxyUrl', Sort.desc);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterSortBy> thenByCheckForAppUpdates() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'checkForAppUpdates', Sort.asc);
@@ -18134,6 +18528,18 @@ extension SettingsQuerySortThenBy
   QueryBuilder<Settings, Settings, QAfterSortBy> thenByCustomDnsDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'customDns', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByCustomDohUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'customDohUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByCustomDohUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'customDohUrl', Sort.desc);
     });
   }
 
@@ -20017,6 +20423,14 @@ extension SettingsQueryWhereDistinct
     });
   }
 
+  QueryBuilder<Settings, Settings, QDistinct> distinctByCfProxyUrl({
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'cfProxyUrl', caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QDistinct> distinctByCheckForAppUpdates() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'checkForAppUpdates');
@@ -20060,6 +20474,14 @@ extension SettingsQueryWhereDistinct
   }) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'customDns', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QDistinct> distinctByCustomDohUrl({
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'customDohUrl', caseSensitive: caseSensitive);
     });
   }
 
@@ -21146,6 +21568,12 @@ extension SettingsQueryProperty
     });
   }
 
+  QueryBuilder<Settings, String?, QQueryOperations> cfProxyUrlProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'cfProxyUrl');
+    });
+  }
+
   QueryBuilder<Settings, List<ChapterFilterBookmarked>?, QQueryOperations>
   chapterFilterBookmarkedListProperty() {
     return QueryBuilder.apply(this, (query) {
@@ -21237,6 +21665,12 @@ extension SettingsQueryProperty
   QueryBuilder<Settings, String?, QQueryOperations> customDnsProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'customDns');
+    });
+  }
+
+  QueryBuilder<Settings, String?, QQueryOperations> customDohUrlProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'customDohUrl');
     });
   }
 

--- a/lib/modules/more/settings/general/general_screen.dart
+++ b/lib/modules/more/settings/general/general_screen.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/modules/more/settings/general/providers/general_state_
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/modules/more/settings/general/providers/doh_provider_notifier.dart';
 import 'package:mangayomi/services/http/doh/doh_custom_store.dart';
+import 'package:mangayomi/services/http/cf_proxy_store.dart';
 import 'package:mangayomi/services/http/doh/doh_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
@@ -171,6 +172,16 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
               title: Text(context.l10n.default_user_agent),
               subtitle: Text(
                 userAgent,
+                style: TextStyle(fontSize: 11, color: context.secondaryColor),
+              ),
+            ),
+            ListTile(
+              onTap: () => _showCfProxyDialog(context),
+              title: const Text('Cloudflare bypass proxy'),
+              subtitle: Text(
+                CfProxyStore.url.isEmpty
+                    ? 'Optional FlareSolverr / Byparr URL'
+                    : CfProxyStore.url,
                 style: TextStyle(fontSize: 11, color: context.secondaryColor),
               ),
             ),
@@ -479,6 +490,82 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
                                   .read(doHProviderStateProvider.notifier)
                                   .setCustomDoH(url.trim());
                               Navigator.pop(context);
+                            }
+                          : null,
+                      child: Text(context.l10n.dialog_confirm),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  void _showCfProxyDialog(BuildContext context) {
+    final controller = TextEditingController(text: CfProxyStore.url);
+    String url = CfProxyStore.url;
+    showDialog(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (dialogContext, setLocalState) {
+          final trimmed = url.trim();
+          final isValid =
+              trimmed.isEmpty || trimmed.startsWith('http://') ||
+              trimmed.startsWith('https://');
+          return AlertDialog(
+            title: const Text(
+              'Cloudflare bypass proxy',
+              style: TextStyle(fontSize: 24),
+            ),
+            content: SizedBox(
+              width: context.width(0.8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 10),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                    child: TextFormField(
+                      controller: controller,
+                      autofocus: true,
+                      keyboardType: TextInputType.url,
+                      onChanged: (value) => setLocalState(() => url = value),
+                      decoration: InputDecoration(
+                        hintText: 'http://localhost:8191/v1',
+                        helperText:
+                            'FlareSolverr / Byparr endpoint. Leave empty to '
+                            'disable.',
+                        helperMaxLines: 2,
+                        filled: false,
+                        contentPadding: const EdgeInsets.all(12),
+                        enabledBorder: OutlineInputBorder(
+                          borderSide: const BorderSide(width: 0.4),
+                          borderRadius: BorderRadius.circular(5),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderSide: const BorderSide(),
+                          borderRadius: BorderRadius.circular(5),
+                        ),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(5),
+                          borderSide: const BorderSide(),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  SizedBox(
+                    width: context.width(1),
+                    child: ElevatedButton(
+                      onPressed: isValid
+                          ? () {
+                              CfProxyStore.setUrl(trimmed);
+                              Navigator.pop(dialogContext);
+                              if (mounted) setState(() {});
                             }
                           : null,
                       child: Text(context.l10n.dialog_confirm),

--- a/lib/modules/more/settings/general/general_screen.dart
+++ b/lib/modules/more/settings/general/general_screen.dart
@@ -81,7 +81,9 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
                     ),
                   ),
                   onTap: () {
-                    final providerId = doHState.providerId ?? 1;
+                    // Default to Cloudflare (id 0) to match the subtitle, so the
+                    // dialog doesn't preselect a different provider than shown.
+                    final providerId = doHState.providerId ?? 0;
                     final rootContext = context;
                     showDialog(
                       context: context,
@@ -426,7 +428,11 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
       context: context,
       builder: (context) => StatefulBuilder(
         builder: (context, setState) {
-          final isValid = url.trim().startsWith('https://');
+          final parsed = Uri.tryParse(url.trim());
+          final isValid =
+              parsed != null &&
+              parsed.scheme == 'https' &&
+              parsed.host.isNotEmpty;
           return AlertDialog(
             title: const Text('Custom DoH URL', style: TextStyle(fontSize: 24)),
             content: SizedBox(

--- a/lib/modules/more/settings/general/general_screen.dart
+++ b/lib/modules/more/settings/general/general_screen.dart
@@ -7,6 +7,8 @@ import 'package:mangayomi/modules/more/providers/algorithm_weights_state_provide
 import 'package:mangayomi/modules/more/settings/general/providers/general_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/modules/more/settings/general/providers/doh_provider_notifier.dart';
+import 'package:mangayomi/services/http/doh/doh_custom_store.dart';
+import 'package:mangayomi/services/http/doh/doh_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
@@ -67,7 +69,12 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
                 ListTile(
                   title: Text(l10n.dns_provider),
                   subtitle: Text(
-                    availableProviders[doHState.providerId ?? 1].name,
+                    doHState.providerId == DoHProviders.customId
+                        ? (DohCustomStore.url.trim().isEmpty
+                              ? 'Custom'
+                              : 'Custom · ${DohCustomStore.url.trim()}')
+                        : (DoHProviders.byId[doHState.providerId ?? 0]?.name ??
+                              DoHProviders.cloudflare.name),
                     style: TextStyle(
                       fontSize: 11,
                       color: context.secondaryColor,
@@ -75,6 +82,7 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
                   ),
                   onTap: () {
                     final providerId = doHState.providerId ?? 1;
+                    final rootContext = context;
                     showDialog(
                       context: context,
                       builder: (context) {
@@ -85,17 +93,32 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
                             child: RadioGroup(
                               groupValue: providerId,
                               onChanged: (value) {
-                                ref
-                                    .read(doHProviderStateProvider.notifier)
-                                    .setDoHProvider(value!);
-                                if (context.mounted) {
-                                  Navigator.pop(context);
+                                Navigator.pop(context);
+                                if (value == DoHProviders.customId) {
+                                  _showCustomDohDialog(
+                                    rootContext,
+                                    ref,
+                                    DohCustomStore.url,
+                                  );
+                                } else {
+                                  ref
+                                      .read(doHProviderStateProvider.notifier)
+                                      .setDoHProvider(value!);
                                 }
                               },
                               child: SuperListView.builder(
                                 shrinkWrap: true,
-                                itemCount: availableProviders.length,
+                                itemCount: availableProviders.length + 1,
                                 itemBuilder: (context, index) {
+                                  // Last row: the user-supplied custom endpoint.
+                                  if (index == availableProviders.length) {
+                                    return const RadioListTile(
+                                      dense: true,
+                                      contentPadding: EdgeInsets.all(0),
+                                      value: DoHProviders.customId,
+                                      title: Text('Custom'),
+                                    );
+                                  }
                                   final provider = availableProviders[index];
                                   return RadioListTile(
                                     dense: true,
@@ -388,6 +411,78 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  void _showCustomDohDialog(
+    BuildContext context,
+    WidgetRef ref,
+    String customDohUrl,
+  ) {
+    final controller = TextEditingController(text: customDohUrl);
+    String url = customDohUrl;
+    showDialog(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) {
+          final isValid = url.trim().startsWith('https://');
+          return AlertDialog(
+            title: const Text('Custom DoH URL', style: TextStyle(fontSize: 24)),
+            content: SizedBox(
+              width: context.width(0.8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 10),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                    child: TextFormField(
+                      controller: controller,
+                      autofocus: true,
+                      keyboardType: TextInputType.url,
+                      onChanged: (value) => setState(() => url = value),
+                      decoration: InputDecoration(
+                        hintText: 'https://example.com/dns-query',
+                        helperText: 'Must be an https DoH (JSON) endpoint',
+                        filled: false,
+                        contentPadding: const EdgeInsets.all(12),
+                        enabledBorder: OutlineInputBorder(
+                          borderSide: const BorderSide(width: 0.4),
+                          borderRadius: BorderRadius.circular(5),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderSide: const BorderSide(),
+                          borderRadius: BorderRadius.circular(5),
+                        ),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(5),
+                          borderSide: const BorderSide(),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  SizedBox(
+                    width: context.width(1),
+                    child: ElevatedButton(
+                      onPressed: isValid
+                          ? () {
+                              ref
+                                  .read(doHProviderStateProvider.notifier)
+                                  .setCustomDoH(url.trim());
+                              Navigator.pop(context);
+                            }
+                          : null,
+                      child: Text(context.l10n.dialog_confirm),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/modules/more/settings/general/providers/doh_provider_notifier.dart
+++ b/lib/modules/more/settings/general/providers/doh_provider_notifier.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/services/http/doh/doh_custom_store.dart';
 import 'package:mangayomi/services/http/doh/doh_providers.dart';
 
 class DoHProviderState {
@@ -57,6 +58,23 @@ class DoHProviderNotifier extends Notifier<DoHProviderState> {
       isar.settings.putSync(settings);
     });
     state = state.copyWith(enabled: true, providerId: providerId);
+  }
+
+  /// Selects a user-supplied custom DoH endpoint: persists the [url] (Hive)
+  /// and points the existing provider-id setting at the custom sentinel.
+  void setCustomDoH(String url) {
+    DohCustomStore.setUrl(url.trim());
+
+    final settings = isar.settings.getSync(227)!;
+    settings.doHProviderId = DoHProviders.customId;
+    settings.doHEnabled = true;
+    isar.writeTxnSync(() {
+      isar.settings.putSync(settings);
+    });
+    state = state.copyWith(
+      enabled: true,
+      providerId: DoHProviders.customId,
+    );
   }
 }
 

--- a/lib/services/http/cf_proxy_store.dart
+++ b/lib/services/http/cf_proxy_store.dart
@@ -1,37 +1,22 @@
-import 'package:hive/hive.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/settings.dart';
 
-/// Persists the URL of an external Cloudflare-bypass proxy
-/// (FlareSolverr / Byparr), e.g. `http://localhost:8191/v1`.
+/// Accessor for the external Cloudflare-bypass proxy URL (FlareSolverr /
+/// Byparr), e.g. `http://localhost:8191/v1`.
 ///
-/// Stored in Hive rather than the Isar `Settings` collection so the feature
-/// needs no generated schema field. The box is opened once at startup (see
-/// [openBox]); reads return an empty string when it isn't open (e.g. a
-/// background isolate), which callers treat as "no proxy configured".
+/// Stored on the Settings collection (`cfProxyUrl`), alongside the rest of the
+/// app's preferences.
 class CfProxyStore {
-  static const _boxName = 'cf_prefs';
-  static const _urlKey = 'cf_proxy_url';
+  /// The saved proxy URL, or an empty string if none.
+  static String get url => isar.settings.getSync(227)?.cfProxyUrl ?? '';
 
-  /// Opens the backing box. Called once during app startup.
-  static Future<void> openBox() async {
-    // Best-effort: this is an optional preference store, so a failure to open
-    // (corruption, permissions, ...) must not block startup. Reads then fall
-    // back to "no proxy configured".
-    try {
-      if (!Hive.isBoxOpen(_boxName)) {
-        await Hive.openBox(_boxName);
-      }
-    } catch (_) {}
-  }
-
-  /// The saved proxy URL, or an empty string if none / box not open.
-  static String get url => Hive.isBoxOpen(_boxName)
-      ? (Hive.box(_boxName).get(_urlKey, defaultValue: '') as String)
-      : '';
-
-  /// Persists [value] as the proxy URL (best-effort if the box is open).
+  /// Persists [value] as the proxy URL.
   static void setUrl(String value) {
-    if (Hive.isBoxOpen(_boxName)) {
-      Hive.box(_boxName).put(_urlKey, value);
-    }
+    isar.writeTxnSync(() {
+      final settings = isar.settings.getSync(227);
+      if (settings != null) {
+        isar.settings.putSync(settings..cfProxyUrl = value);
+      }
+    });
   }
 }

--- a/lib/services/http/cf_proxy_store.dart
+++ b/lib/services/http/cf_proxy_store.dart
@@ -1,0 +1,37 @@
+import 'package:hive/hive.dart';
+
+/// Persists the URL of an external Cloudflare-bypass proxy
+/// (FlareSolverr / Byparr), e.g. `http://localhost:8191/v1`.
+///
+/// Stored in Hive rather than the Isar `Settings` collection so the feature
+/// needs no generated schema field. The box is opened once at startup (see
+/// [openBox]); reads return an empty string when it isn't open (e.g. a
+/// background isolate), which callers treat as "no proxy configured".
+class CfProxyStore {
+  static const _boxName = 'cf_prefs';
+  static const _urlKey = 'cf_proxy_url';
+
+  /// Opens the backing box. Called once during app startup.
+  static Future<void> openBox() async {
+    // Best-effort: this is an optional preference store, so a failure to open
+    // (corruption, permissions, ...) must not block startup. Reads then fall
+    // back to "no proxy configured".
+    try {
+      if (!Hive.isBoxOpen(_boxName)) {
+        await Hive.openBox(_boxName);
+      }
+    } catch (_) {}
+  }
+
+  /// The saved proxy URL, or an empty string if none / box not open.
+  static String get url => Hive.isBoxOpen(_boxName)
+      ? (Hive.box(_boxName).get(_urlKey, defaultValue: '') as String)
+      : '';
+
+  /// Persists [value] as the proxy URL (best-effort if the box is open).
+  static void setUrl(String value) {
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_urlKey, value);
+    }
+  }
+}

--- a/lib/services/http/doh/doh_custom_store.dart
+++ b/lib/services/http/doh/doh_custom_store.dart
@@ -1,0 +1,31 @@
+import 'package:hive/hive.dart';
+
+/// Persists the user's custom DNS-over-HTTPS endpoint URL.
+///
+/// Stored in Hive rather than the Isar `Settings` collection so the feature
+/// doesn't require a new generated schema field. The box is opened once at
+/// startup (see `openBox`); reads return an empty string when it isn't open
+/// (e.g. a background isolate), which the callers treat as "no custom URL".
+class DohCustomStore {
+  static const _boxName = 'network_prefs';
+  static const _urlKey = 'custom_doh_url';
+
+  /// Opens the backing box. Called once during app startup.
+  static Future<void> openBox() async {
+    if (!Hive.isBoxOpen(_boxName)) {
+      await Hive.openBox(_boxName);
+    }
+  }
+
+  /// The saved custom DoH URL, or an empty string if none / box not open.
+  static String get url => Hive.isBoxOpen(_boxName)
+      ? (Hive.box(_boxName).get(_urlKey, defaultValue: '') as String)
+      : '';
+
+  /// Persists [value] as the custom DoH URL (best-effort if the box is open).
+  static void setUrl(String value) {
+    if (Hive.isBoxOpen(_boxName)) {
+      Hive.box(_boxName).put(_urlKey, value);
+    }
+  }
+}

--- a/lib/services/http/doh/doh_custom_store.dart
+++ b/lib/services/http/doh/doh_custom_store.dart
@@ -18,9 +18,12 @@ class DohCustomStore {
   }
 
   /// The saved custom DoH URL, or an empty string if none / box not open.
-  static String get url => Hive.isBoxOpen(_boxName)
-      ? (Hive.box(_boxName).get(_urlKey, defaultValue: '') as String)
-      : '';
+  /// Reads defensively so a missing or non-String value can't throw.
+  static String get url {
+    if (!Hive.isBoxOpen(_boxName)) return '';
+    final value = Hive.box(_boxName).get(_urlKey);
+    return value is String ? value : '';
+  }
 
   /// Persists [value] as the custom DoH URL (best-effort if the box is open).
   static void setUrl(String value) {

--- a/lib/services/http/doh/doh_custom_store.dart
+++ b/lib/services/http/doh/doh_custom_store.dart
@@ -1,34 +1,21 @@
-import 'package:hive/hive.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/settings.dart';
 
-/// Persists the user's custom DNS-over-HTTPS endpoint URL.
+/// Accessor for the user's custom DNS-over-HTTPS endpoint URL.
 ///
-/// Stored in Hive rather than the Isar `Settings` collection so the feature
-/// doesn't require a new generated schema field. The box is opened once at
-/// startup (see `openBox`); reads return an empty string when it isn't open
-/// (e.g. a background isolate), which the callers treat as "no custom URL".
+/// Stored on the Settings collection (`customDohUrl`), next to the DoH provider
+/// selection, alongside the rest of the app's preferences.
 class DohCustomStore {
-  static const _boxName = 'network_prefs';
-  static const _urlKey = 'custom_doh_url';
+  /// The saved custom DoH URL, or an empty string if none.
+  static String get url => isar.settings.getSync(227)?.customDohUrl ?? '';
 
-  /// Opens the backing box. Called once during app startup.
-  static Future<void> openBox() async {
-    if (!Hive.isBoxOpen(_boxName)) {
-      await Hive.openBox(_boxName);
-    }
-  }
-
-  /// The saved custom DoH URL, or an empty string if none / box not open.
-  /// Reads defensively so a missing or non-String value can't throw.
-  static String get url {
-    if (!Hive.isBoxOpen(_boxName)) return '';
-    final value = Hive.box(_boxName).get(_urlKey);
-    return value is String ? value : '';
-  }
-
-  /// Persists [value] as the custom DoH URL (best-effort if the box is open).
+  /// Persists [value] as the custom DoH URL.
   static void setUrl(String value) {
-    if (Hive.isBoxOpen(_boxName)) {
-      Hive.box(_boxName).put(_urlKey, value);
-    }
+    isar.writeTxnSync(() {
+      final settings = isar.settings.getSync(227);
+      if (settings != null) {
+        isar.settings.putSync(settings..customDohUrl = value);
+      }
+    });
   }
 }

--- a/lib/services/http/doh/doh_providers.dart
+++ b/lib/services/http/doh/doh_providers.dart
@@ -37,7 +37,7 @@ final class DoHProviders {
   /// Sentinel id for a user-supplied custom DoH endpoint. Kept well clear of
   /// the preset ids so it survives in the existing `doHProviderId` setting
   /// without needing a new schema field. The URL itself lives in
-  /// [DohCustomStore]; build the provider with [custom].
+  /// `DohCustomStore`; build the provider with [custom].
   static const int customId = 999;
 
   /// Builds a [DoHProvider] from a user-supplied [url]. Bootstrap IPs are only

--- a/lib/services/http/doh/doh_providers.dart
+++ b/lib/services/http/doh/doh_providers.dart
@@ -34,6 +34,24 @@ class DoHProvider {
 
 /// All available DoH providers
 final class DoHProviders {
+  /// Sentinel id for a user-supplied custom DoH endpoint. Kept well clear of
+  /// the preset ids so it survives in the existing `doHProviderId` setting
+  /// without needing a new schema field. The URL itself lives in
+  /// [DohCustomStore]; build the provider with [custom].
+  static const int customId = 999;
+
+  /// Builds a [DoHProvider] from a user-supplied [url]. Bootstrap IPs are only
+  /// required to be non-empty by the resolver (it connects via the endpoint
+  /// hostname using the platform resolver), so sane public defaults are fine.
+  static DoHProvider custom(String url) => DoHProvider(
+    id: customId,
+    name: 'Custom',
+    url: url,
+    bootstrapIPs: const ['1.1.1.1', '8.8.8.8'],
+    description: 'Custom DoH endpoint',
+    region: 'Custom',
+  );
+
   /// Cloudflare DNS - Fast, privacy-first
   static const cloudflare = DoHProvider(
     id: 0,

--- a/lib/services/http/m_client.dart
+++ b/lib/services/http/m_client.dart
@@ -16,6 +16,7 @@ import 'package:mangayomi/utils/log/log.dart';
 import 'package:mangayomi/services/http/rhttp/rhttp.dart' as rhttp;
 import 'package:mangayomi/services/http/doh/doh_resolver.dart';
 import 'package:mangayomi/services/http/doh/doh_providers.dart';
+import 'package:mangayomi/services/http/doh/doh_custom_store.dart';
 
 class MClient {
   MClient();
@@ -65,8 +66,13 @@ class MClient {
     DnsSettings? dnsSettings;
 
     if (useDoH && doHProviderId != null) {
-      // Use DoH resolver with specific provider
-      final provider = DoHProviders.byId[doHProviderId];
+      // Use DoH resolver with the selected provider — either a preset or, when
+      // the custom sentinel id is set, one built from the user's saved URL.
+      final provider = doHProviderId == DoHProviders.customId
+          ? (DohCustomStore.url.trim().isNotEmpty
+                ? DoHProviders.custom(DohCustomStore.url.trim())
+                : null)
+          : DoHProviders.byId[doHProviderId];
       if (provider != null) {
         dnsSettings = DnsSettings.dynamic(
           resolver: (host) => DoHResolver.resolve(host, provider: provider),

--- a/lib/services/http/m_client.dart
+++ b/lib/services/http/m_client.dart
@@ -17,6 +17,7 @@ import 'package:mangayomi/services/http/rhttp/rhttp.dart' as rhttp;
 import 'package:mangayomi/services/http/doh/doh_resolver.dart';
 import 'package:mangayomi/services/http/doh/doh_providers.dart';
 import 'package:mangayomi/services/http/doh/doh_custom_store.dart';
+import 'package:mangayomi/services/http/cf_proxy_store.dart';
 
 class MClient {
   MClient();
@@ -286,28 +287,81 @@ class ResolveCloudFlareChallenge extends RetryPolicy {
   int get maxRetryAttempts => 2;
   @override
   Future<bool> shouldAttemptRetryOnResponse(BaseResponse response) async {
-    if (!showCloudFlareError || Platform.isLinux) return false;
-    bool isCloudFlare = isCloudflare(response);
-    if (isCloudFlare) {
-      try {
-        return http
-            .post(
-              Uri.parse('http://localhost:$cfPort/resolve_cf'),
-              headers: {HttpHeaders.contentTypeHeader: 'application/json'},
-              body: jsonEncode({'url': response.request!.url.toString()}),
-            )
-            .then((res) {
-              if (res.statusCode == 200) {
-                final data = jsonDecode(res.body) as Map<String, dynamic>;
-                return data['result'] as bool;
-              }
-              return false;
-            });
-      } catch (e) {
-        return false;
-      }
+    if (!showCloudFlareError) return false;
+    if (!isCloudflare(response)) return false;
+    final url = response.request!.url.toString();
+
+    // Prefer an external Cloudflare-bypass proxy (FlareSolverr / Byparr) when
+    // one is configured. It also works on Linux, where the in-app webview
+    // resolver below is disabled.
+    final proxyUrl = CfProxyStore.url.trim();
+    if (proxyUrl.isNotEmpty) {
+      return _solveWithCfProxy(proxyUrl, url);
     }
 
+    // Fall back to the bundled webview resolver (not available on Linux).
+    if (Platform.isLinux) return false;
+    try {
+      return http
+          .post(
+            Uri.parse('http://localhost:$cfPort/resolve_cf'),
+            headers: {HttpHeaders.contentTypeHeader: 'application/json'},
+            body: jsonEncode({'url': url}),
+          )
+          .then((res) {
+            if (res.statusCode == 200) {
+              final data = jsonDecode(res.body) as Map<String, dynamic>;
+              return data['result'] as bool;
+            }
+            return false;
+          });
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+/// Solves a Cloudflare challenge for [targetUrl] through a FlareSolverr- /
+/// Byparr-compatible proxy at [proxyUrl] (e.g. `http://localhost:8191/v1`).
+///
+/// On success it stores the returned `cf_clearance` cookies + user-agent via
+/// [MClient.setCookie] (exactly like the webview resolver does), so the retried
+/// request carries them, and returns `true` to trigger the retry.
+Future<bool> _solveWithCfProxy(String proxyUrl, String targetUrl) async {
+  try {
+    final res = await http
+        .post(
+          Uri.parse(proxyUrl),
+          headers: {HttpHeaders.contentTypeHeader: 'application/json'},
+          body: jsonEncode({
+            'cmd': 'request.get',
+            'url': targetUrl,
+            'maxTimeout': 60000,
+          }),
+        )
+        .timeout(const Duration(seconds: 70));
+    if (res.statusCode != 200) return false;
+
+    final data = jsonDecode(res.body) as Map<String, dynamic>;
+    if (data['status'] != 'ok') return false;
+
+    final solution = data['solution'] as Map<String, dynamic>?;
+    if (solution == null) return false;
+
+    final cookieList = (solution['cookies'] as List?) ?? [];
+    final cookie = cookieList
+        .whereType<Map>()
+        .map((c) => "${c['name']}=${c['value']}")
+        .join('; ');
+    if (cookie.isEmpty) return false;
+
+    final ua = (solution['userAgent'] as String?) ?? '';
+    await MClient.setCookie(targetUrl, ua, null, cookie: cookie);
+    return true;
+  } catch (e) {
+    if (kDebugMode) {
+      debugPrint('CF proxy solve failed: $e');
+    }
     return false;
   }
 }


### PR DESCRIPTION
Consolidates the networking feature and the CI checks. Rebased on current main, analyze clean (0 errors). CI is the build gate.

## Folds in
- #804 custom network endpoints: user-supplied DoH endpoint (#704) and a custom Cloudflare bypass proxy / FlareSolverr / Byparr (#709). URLs persist on the Isar `Settings` collection.
- #770 CI: analyze + debug-build checks on pull requests and main; the vendored rust_builder build tool is excluded from analysis.

## Not included
- Blank-screen-on-launch (#758): left open. Its `main.dart` change re-adds `storage.requestPermission()` at startup, which contradicts main's deliberate removal of the forced all-files-access prompt (#740), and it restructures launch-critical code that cannot be verified without a real device boot. It needs a focused, testable rebase rather than a blind batch merge.

## Notes
- New preferences persist on the Isar `Settings` collection, not Hive.
- Generated `settings.g.dart` regenerated via build_runner for the new fields.
