### PR TITLE
fix: offline novel reading, episode duplication on update, tracker sheet padding

### DIFF
--- a/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
+++ b/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
@@ -85,10 +85,33 @@ Future<dynamic> updateMangaDetail(
       // loadSync() was called before the transaction; the set is still valid
       // here because we haven't written to chapters yet.
       final existingChapters = manga.chapters.toList();
-      final existingByUrl = <String, Chapter>{
-        for (final c in existingChapters)
-          if (c.url?.isNotEmpty == true) c.url!.trim(): c,
-      };
+      // Match by the domain-less URL (path + query), not the full URL. Sources
+      // (anime ones especially) migrate domains, so the stored URL keeps the old
+      // host while a fresh fetch returns the new one — matching on the full URL
+      // then misses and re-adds every chapter each update, which is how episodes
+      // ended up duplicated/tripled.
+      final existingByUrl = <String, Chapter>{};
+      // IDs of pre-existing duplicates (same domain-less URL) to remove, so the
+      // list stops showing copies created before this fix. The read/started copy
+      // is the one kept.
+      final duplicateIds = <int>[];
+      for (final c in existingChapters) {
+        final u = c.url?.trim();
+        if (u == null || u.isEmpty) continue;
+        final key = u.getUrlWithoutDomain;
+        final prior = existingByUrl[key];
+        if (prior == null) {
+          existingByUrl[key] = c;
+        } else {
+          // Keep the copy with reading state; drop the other.
+          final priorHasState =
+              (prior.isRead ?? false) || (prior.lastPageRead ?? '').isNotEmpty;
+          final keep = priorHasState ? prior : c;
+          final drop = identical(keep, prior) ? c : prior;
+          existingByUrl[key] = keep;
+          if (drop.id != null) duplicateIds.add(drop.id!);
+        }
+      }
 
       // Build a chapterNumber -> isRead map so that when a new scanlator covers
       // a chapter the user has already read, the new entry is pre-marked read.
@@ -105,11 +128,15 @@ Future<dynamic> updateMangaDetail(
       }
 
       final newChapters = <Chapter>[];
+      // Guards against a source repeating the same episode within one fetch.
+      final seenKeys = <String>{};
 
       for (final chap in chaps) {
         final url = chap.url?.trim();
         if (url == null || url.isEmpty) continue;
-        final existing = existingByUrl[url];
+        final key = url.getUrlWithoutDomain;
+        if (!seenKeys.add(key)) continue;
+        final existing = existingByUrl[key];
 
         if (existing == null) {
           // Determine whether this chapter number has already been read under
@@ -178,11 +205,22 @@ Future<dynamic> updateMangaDetail(
           }
         }
       }
+      // Remove pre-existing duplicate chapters (from before the domain-less
+      // match), keeping the read/started copy chosen above.
+      for (final id in duplicateIds) {
+        await isar.chapters.delete(id);
+      }
+
       // Calculate fetch interval:
       // median of gaps between recent distinct chapter dates, clamped [1, 28].
-      final allChapters = newChapters.isEmpty
+      final dedupedExisting = duplicateIds.isEmpty
           ? existingChapters
-          : [...existingChapters, ...newChapters];
+          : existingChapters
+                .where((c) => c.id == null || !duplicateIds.contains(c.id))
+                .toList();
+      final allChapters = newChapters.isEmpty
+          ? dedupedExisting
+          : [...dedupedExisting, ...newChapters];
       if (allChapters.isNotEmpty) {
         final interval = FetchInterval.calculateInterval(allChapters);
         manga

--- a/lib/modules/manga/detail/widgets/tracking_menu.dart
+++ b/lib/modules/manga/detail/widgets/tracking_menu.dart
@@ -47,7 +47,15 @@ void openTrackingMenu({
             borderRadius: BorderRadius.circular(20),
             clipBehavior: Clip.antiAlias,
             child: Padding(
-              padding: const EdgeInsets.all(8.0),
+              // Breathing room at the bottom, plus clearance for the system
+              // navigation bar / gesture area so the last tracker row is not
+              // flush against (or behind) the on-screen buttons on Android.
+              padding: EdgeInsets.fromLTRB(
+                8,
+                8,
+                8,
+                8 + MediaQuery.viewPaddingOf(context).bottom,
+              ),
               child: SuperListView.separated(
                 padding: const EdgeInsets.all(0),
                 itemCount: entries.length,

--- a/lib/services/get_html_content.dart
+++ b/lib/services/get_html_content.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 import 'package:mangayomi/src/rust/api/epub.dart';
-import 'package:path/path.dart' as p;
 import 'package:html/parser.dart';
 import 'package:mangayomi/eval/lib.dart';
 import 'package:mangayomi/models/chapter.dart';
@@ -61,32 +60,54 @@ Future<(String, EpubNovel?)> getHtmlContent(
         mangaMainDirectory: mangaMainDirectory,
       ))!;
 
-      final htmlPath = p.join(chapterDirectory.path, "${chapter.name}.html");
-
-      final htmlFile = File(htmlPath);
-      String? htmlContent;
-      if (await htmlFile.exists()) {
-        htmlContent = await htmlFile.readAsString();
+      // Locate the downloaded file by globbing for the single *.html in the
+      // chapter directory rather than reconstructing its name. The downloader
+      // sanitises forbidden characters to spaces while getMangaChapterDirectory
+      // uses underscores, and the old lookup used the raw chapter.name, so any
+      // title containing a colon (etc.) never matched: htmlFile.exists() was
+      // always false and offline reading fell through to the network and hung.
+      // A folder holds exactly one file, so a glob is correct regardless of
+      // which sanitiser wrote it. See #817.
+      File? localFile;
+      if (chapterDirectory.existsSync()) {
+        for (final entity in chapterDirectory.listSync()) {
+          if (entity is File && entity.path.toLowerCase().endsWith('.html')) {
+            localFile = entity;
+            break;
+          }
+        }
       }
-      final source = getSource(
-        chapter.manga.value!.lang!,
-        chapter.manga.value!.source!,
-        chapter.manga.value!.sourceId,
-      );
-      final proxyServer = ref.read(androidProxyServerStateProvider);
-      final html = await withExtensionService(source!, proxyServer, (
-        service,
-      ) async {
-        if (htmlContent != null) {
-          return await service.cleanHtmlContent(htmlContent);
-        } else {
-          return await service.getHtmlContent(
+
+      if (localFile != null) {
+        // Downloaded: render straight from disk, so it works fully offline with
+        // no extension service or network. The file holds the raw getHtmlContent
+        // output (quote-wrapped, like the network path); routing it back through
+        // cleanHtmlContent renders a blank page, so strip the outer quotes and
+        // hand it to _buildHtml directly.
+        final raw = await localFile.readAsString();
+        final stripped =
+            raw.length >= 2 && raw.startsWith('"') && raw.endsWith('"')
+            ? raw.substring(1, raw.length - 1)
+            : raw;
+        result = (_buildHtml(stripped), null);
+      } else {
+        // Not downloaded: fetch from the source (needs network).
+        final source = getSource(
+          chapter.manga.value!.lang!,
+          chapter.manga.value!.source!,
+          chapter.manga.value!.sourceId,
+        );
+        final proxyServer = ref.read(androidProxyServerStateProvider);
+        final html = await withExtensionService(
+          source!,
+          proxyServer,
+          (service) async => await service.getHtmlContent(
             chapter.manga.value!.name!,
             chapter.url!,
-          );
-        }
-      });
-      result = (_buildHtml(html.substring(1, html.length - 1)), null);
+          ),
+        );
+        result = (_buildHtml(html.substring(1, html.length - 1)), null);
+      }
     }
 
     keepAlive.close();


### PR DESCRIPTION
Three fixes for reported bugs, off current main. Analyze is clean (0 errors, 0 warnings). Not build-tested locally, so CI is the gate.

## Fixes

### Downloaded novel chapters now open offline (closes #817)
The reader rebuilt the file name from the raw `chapter.name`, but the downloader writes it with forbidden characters replaced by spaces and the folder uses underscores, so for any title containing a colon (etc.) the local file was never found and it fell through to a network fetch, which offline hangs forever. Now it globs for the single `.html` in the chapter directory (correct regardless of which sanitiser wrote it) and renders it via `_buildHtml` directly, stripping the outer quotes like the network path, with no extension service involved. Manga and anime already read their downloads directly; this brings novels in line. Diagnosis and verified approach are from #817.

### Episodes/chapters no longer duplicate on library update
Chapter dedup matched on the full URL. Sources (anime ones especially) migrate domains, so a stored chapter kept the old host while a fresh fetch returned the new one; the match missed and re-added every chapter on each update, duplicating (and over several runs tripling) episodes. Now it matches on the domain-less URL (path + query), skips repeats within a single fetch, and collapses the duplicates earlier builds already created, keeping the read/started copy. Reported on Discord.

### Tracker sheet bottom padding
The tracker list sheet used a flat 8px padding, so the last row sat flush against (or behind) the Android navigation bar / gesture area. Added the system bottom inset plus a little breathing room. Reported on Discord.

## Notes
- No schema changes; no build_runner needed.
- The duplicate-collapse is the only data-touching change: within a manga, same domain-less URL means the same chapter, and the read/started copy is the one kept.

Closes #796
