### PR TITLE
feat(library): let a running library update be stopped

### DIFF
--- a/lib/modules/library/widgets/library_app_bar.dart
+++ b/lib/modules/library/widgets/library_app_bar.dart
@@ -164,6 +164,18 @@ class LibraryAppBar extends ConsumerWidget implements PreferredSizeWidget {
               ],
             ),
       actions: [
+        // Stop a running library update. Only shown while one is in progress.
+        if (ref.watch(libraryUpdateProvider).running)
+          IconButton(
+            splashRadius: 20,
+            tooltip: l10n.cancel,
+            focusColor: Theme.of(
+              context,
+            ).colorScheme.primary.withValues(alpha: 0.4),
+            onPressed: () =>
+                ref.read(libraryUpdateProvider.notifier).requestCancel(),
+            icon: const Icon(Icons.stop_circle_outlined),
+          ),
         isSearch
             ? SeachFormTextField(
                 onChanged: (_) => onSearchClear(),

--- a/lib/services/library_updater.dart
+++ b/lib/services/library_updater.dart
@@ -10,6 +10,38 @@ import 'package:mangayomi/utils/log/logger.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/services/update_errors_provider.dart';
 
+/// Tracks whether a library update is running and lets the UI request its
+/// cancellation. The update loop checks [LibraryUpdateState.cancelRequested]
+/// between entries and stops early.
+class LibraryUpdateState {
+  final bool running;
+  final bool cancelRequested;
+  const LibraryUpdateState({
+    this.running = false,
+    this.cancelRequested = false,
+  });
+  LibraryUpdateState copyWith({bool? running, bool? cancelRequested}) =>
+      LibraryUpdateState(
+        running: running ?? this.running,
+        cancelRequested: cancelRequested ?? this.cancelRequested,
+      );
+}
+
+class LibraryUpdateNotifier extends Notifier<LibraryUpdateState> {
+  @override
+  LibraryUpdateState build() => const LibraryUpdateState();
+  void begin() => state = const LibraryUpdateState(running: true);
+  void requestCancel() {
+    if (state.running) state = state.copyWith(cancelRequested: true);
+  }
+  void end() => state = const LibraryUpdateState();
+}
+
+final libraryUpdateProvider =
+    NotifierProvider<LibraryUpdateNotifier, LibraryUpdateState>(
+      LibraryUpdateNotifier.new,
+    );
+
 Future<void> updateLibrary({
   required WidgetRef ref,
   required BuildContext context,
@@ -22,6 +54,9 @@ Future<void> updateLibrary({
     AppLogger.log("$itemtype library is empty. Nothing to update.");
     return;
   }
+  // Don't start a second concurrent run.
+  if (ref.read(libraryUpdateProvider).running) return;
+  ref.read(libraryUpdateProvider.notifier).begin();
   bool isDark = ref.read(themeModeStateProvider);
   botToast(
     context.l10n.updating_library("0", "0", "0"),
@@ -33,6 +68,8 @@ Future<void> updateLibrary({
   int failed = 0;
   List<UpdateError> failures = [];
   for (var i = 0; i < mangaList.length; i++) {
+    // Stop early if the user pressed Stop.
+    if (ref.read(libraryUpdateProvider).cancelRequested) break;
     final manga = mangaList[i];
     try {
       await ref.read(
@@ -67,6 +104,7 @@ Future<void> updateLibrary({
       );
     }
   }
+  ref.read(libraryUpdateProvider.notifier).end();
   await Future.delayed(const Duration(seconds: 1));
   BotToast.cleanAll();
   // Persist this run's failures (empty list clears any previous ones) so they


### PR DESCRIPTION
Adds a way to stop a library update that is already running.

A library update loops through every entry sequentially and, once started, could not be stopped, so a large library keeps hammering sources until it finishes (and there was no affordance to interrupt it). This wires a cancel path:

- `updateLibrary` tracks a running state and checks a cancel flag between entries, breaking out cleanly and clearing the progress toast.
- The library app bar shows a **Stop** button while an update is in progress; pressing it requests cancellation.
- Guards against starting a second concurrent run.

Both the app-bar refresh and pull-to-refresh go through `updateLibrary`, so both are stoppable. No schema changes.
