### PR TITLE
fix(android-tv): dialog + source-page focus fixes

### DIFF
--- a/lib/modules/library/widgets/search_text_form_field.dart
+++ b/lib/modules/library/widgets/search_text_form_field.dart
@@ -8,6 +8,7 @@ class SeachFormTextField extends StatelessWidget {
   final TextEditingController controller;
   final Function(String)? onFieldSubmitted;
   final bool autofocus;
+  final FocusNode? focusNode;
   const SeachFormTextField({
     super.key,
     required this.onChanged,
@@ -16,6 +17,7 @@ class SeachFormTextField extends StatelessWidget {
     this.onFieldSubmitted,
     required this.onSuffixPressed,
     this.autofocus = true,
+    this.focusNode,
   });
 
   @override
@@ -24,6 +26,7 @@ class SeachFormTextField extends StatelessWidget {
     return Flexible(
       child: TextFormField(
         autofocus: autofocus,
+        focusNode: focusNode,
         controller: controller,
         keyboardType: TextInputType.text,
         onChanged: onChanged,

--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -157,6 +157,8 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     _textEditingController.dispose();
+    _searchFieldFocus.dispose();
+    _postSearchFocus.dispose();
     super.dispose();
   }
 
@@ -181,6 +183,11 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
   }
 
   late final _textEditingController = TextEditingController(text: widget.query);
+  // TV search focus flow: opening search puts focus on the field; submitting
+  // hands focus to the next button in the row, so it never reverts to Popular /
+  // Latest (which, on revert, would re-select and close the search field).
+  final _searchFieldFocus = FocusNode();
+  final _postSearchFocus = FocusNode();
   late String _query = widget.query;
   late bool _isSearch = widget.isSearch;
   AsyncValue<MPages?>? _getManga;
@@ -273,6 +280,13 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                       }
                       _page = 1;
                     });
+                    // Hand focus to the next button in the row so it never
+                    // reverts to Popular / Latest.
+                    if (isTv) {
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (mounted) _postSearchFocus.requestFocus();
+                      });
+                    }
                   },
                   onChanged: (value) {},
                   onSuffixPressed: () {
@@ -297,6 +311,7 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                     });
                   },
                   controller: _textEditingController,
+                  focusNode: _searchFieldFocus,
                 )
               : IconButton(
                   splashRadius: 20,
@@ -304,6 +319,13 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                     setState(() {
                       _isSearch = true;
                     });
+                    // Force focus onto the field so it doesn't revert to the
+                    // previously focused pill while the search button unmounts.
+                    if (isTv) {
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (mounted) _searchFieldFocus.requestFocus();
+                      });
+                    }
                   },
                   focusColor: isTv
                       ? context.primaryColor.withValues(alpha: 0.4)
@@ -312,6 +334,7 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                 ),
           if (isTv)
             IconButton(
+              focusNode: _postSearchFocus,
               focusColor: context.primaryColor.withValues(alpha: 0.4),
               icon: Icon(displayTypeIcon),
               onPressed: () async {

--- a/lib/modules/more/categories/widgets/custom_textfield.dart
+++ b/lib/modules/more/categories/widgets/custom_textfield.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mangayomi/models/category.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
@@ -25,7 +26,7 @@ class CustomTextFormField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = l10nLocalizations(context);
-    return TextFormField(
+    final Widget field = TextFormField(
       autofocus: !isTv,
       controller: controller,
       keyboardType: TextInputType.text,
@@ -75,6 +76,20 @@ class CustomTextFormField extends StatelessWidget {
           ),
         ),
       ),
+    );
+    if (!isTv) return field;
+    // A single-line field consumes Up/Down for the cursor and traps focus on a
+    // remote. Remap them to move focus so the dialog buttons are reachable.
+    return Shortcuts(
+      shortcuts: const <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(
+          TraversalDirection.down,
+        ),
+        SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(
+          TraversalDirection.up,
+        ),
+      },
+      child: field,
     );
   }
 }

--- a/lib/modules/more/settings/appearance/providers/theme_provider.dart
+++ b/lib/modules/more/settings/appearance/providers/theme_provider.dart
@@ -12,11 +12,33 @@ import 'package:mangayomi/utils/platform_utils.dart';
 /// across a room. Tinting it with the scheme's primary makes every focusable
 /// built on an InkResponse legible with a remote: popup menu buttons and
 /// their items, list tiles, icon buttons. Off-TV the theme is untouched.
-ThemeData _tvFocus(ThemeData theme) => isTv
-    ? theme.copyWith(
-        focusColor: theme.colorScheme.primary.withValues(alpha: 0.45),
-      )
-    : theme;
+ThemeData _tvFocus(ThemeData theme) {
+  if (!isTv) return theme;
+  // A focused button drew only a faint focusColor overlay, which is invisible on
+  // a filled button (e.g. a dialog's Add/OK) — you can't tell it is focused.
+  // Add a high-contrast ring on the focused state so any button reads clearly on
+  // a TV, filled or not. Buttons that carry no border otherwise (Text/Elevated/
+  // Filled) get the ring only while focused.
+  final ring = WidgetStateProperty.resolveWith<BorderSide?>(
+    (states) => states.contains(WidgetState.focused)
+        ? BorderSide(color: theme.colorScheme.onSurface, width: 2.5)
+        : null,
+  );
+  ButtonStyle withRing(ButtonStyle? base) =>
+      (base ?? const ButtonStyle()).copyWith(side: ring);
+  return theme.copyWith(
+    focusColor: theme.colorScheme.primary.withValues(alpha: 0.45),
+    textButtonTheme: TextButtonThemeData(
+      style: withRing(theme.textButtonTheme.style),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: withRing(theme.elevatedButtonTheme.style),
+    ),
+    filledButtonTheme: FilledButtonThemeData(
+      style: withRing(theme.filledButtonTheme.style),
+    ),
+  );
+}
 
 /// Provides the light theme for the app, recomputed only when
 /// flex scheme colors, blend level, or font family change.

--- a/lib/modules/widgets/tv_pill.dart
+++ b/lib/modules/widgets/tv_pill.dart
@@ -48,6 +48,12 @@ class TvPill extends StatefulWidget {
 class _TvPillState extends State<TvPill> {
   bool _focused = false;
   bool _held = false;
+  // True only between a Select KeyDown and its KeyUp on THIS pill. Guards
+  // against a stray KeyUp arriving without its KeyDown: activating a control
+  // that removes itself (e.g. the source page's search button) reverts focus to
+  // the previously focused pill, and the trailing KeyUp would otherwise fire its
+  // onTap — re-selecting Popular/Latest and closing the search field.
+  bool _pressed = false;
 
   @override
   Widget build(BuildContext context) {
@@ -90,13 +96,17 @@ class _TvPillState extends State<TvPill> {
         // opens never inherits the rest of that press.
         if (event is KeyDownEvent) {
           _held = false;
+          _pressed = true;
           return KeyEventResult.handled;
         }
         if (event is KeyRepeatEvent) {
-          _held = true;
+          if (_pressed) _held = true;
           return KeyEventResult.handled;
         }
         if (event is KeyUpEvent) {
+          // A KeyUp without the matching KeyDown here is a leaked press from a
+          // control that just removed itself; drop it so it can't fire onTap.
+          if (!_pressed) return KeyEventResult.ignored;
           final longPress = widget.onLongPress;
           if (_held && longPress != null) {
             longPress();
@@ -104,6 +114,7 @@ class _TvPillState extends State<TvPill> {
             widget.onTap();
           }
           _held = false;
+          _pressed = false;
           return KeyEventResult.handled;
         }
         return KeyEventResult.ignored;


### PR DESCRIPTION
A few Android TV focus fixes for dialogs and the source page.

**Source-page search focus.** Opening search could revert focus to Popular / Latest and re-select them, closing the search field. On TV, tapping search now forces focus onto the text field (winning the race against focus restoration to the unmounting button) and submitting hands focus to the next button in the row.

**TvPill stray key-up guard.** A pill fired onTap on any Select KeyUp, including one whose KeyDown hit a different control, so focus reverting to a pill mid-press re-selected it. Now a pill only acts on a KeyUp with its matching KeyDown on the same pill (same guard the cover cards use). Hardens every pill (home categories, browse tabs) too.

**Dialog buttons and text fields.** App-wide: a focused button drew only a faint overlay, invisible on a filled Add/OK button, so you could not tell it was focused — added a high-contrast focus ring on Text/Elevated/Filled buttons via the theme. And a single-line text field consumed Up/Down for the cursor, trapping focus so Cancel/Add were unreachable — remapped Up/Down to move focus on the shared category field.
