### PR TITLE
fix: download stalls/truncation and anime resume position

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -919,14 +919,25 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     }
   }
 
-  Future<void> _openMedia(VideoPrefs prefs, [Duration? position]) {
-    return _player.open(
-      Media(
-        prefs.videoTrack!.id,
-        httpHeaders: prefs.headers,
-        start: position ?? _currentPosition.value,
-      ),
+  Future<void> _openMedia(VideoPrefs prefs, [Duration? position]) async {
+    final start = position ?? _currentPosition.value;
+    await _player.open(
+      Media(prefs.videoTrack!.id, httpHeaders: prefs.headers, start: start),
     );
+    if (start > Duration.zero) {
+      // media_kit's Media(start:) is unreliable for some sources — playback can
+      // begin at 0 even though the resume position was passed. Seek explicitly
+      // once the media reports a duration (i.e. it has loaded). Fire-and-forget
+      // so open() isn't delayed; the timeout guards a source that never reports
+      // one, and a redundant seek (when start: did work) is harmless.
+      unawaited(
+        _player.stream.duration
+            .firstWhere((d) => d > Duration.zero)
+            .timeout(const Duration(seconds: 8))
+            .then((_) => _player.seek(start))
+            .catchError((_) {}),
+      );
+    }
   }
 
   Future<void> _loadAndroidFont() async {

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -315,6 +315,24 @@ Future<void> downloadChapter(
     }
 
     if (pageUrls.isNotEmpty) {
+      // A stalled or failed attempt can leave a partial single-file download
+      // (anime .mp4, novel .html) on disk. The existence check below would then
+      // treat it as already downloaded and mark it complete — a truncated but
+      // "finished" file. If this chapter's download record is not actually
+      // complete, delete any such leftover first so it re-downloads fresh.
+      final downloadRecord = isar.downloads.getSync(chapter.id!);
+      if (!(downloadRecord?.isDownload ?? false)) {
+        for (final leftover in [
+          File(p.join(mangaMainDirectory!.path, "$chapterName.mp4")),
+          File(p.join(mangaMainDirectory.path, "$chapterName.html")),
+        ]) {
+          if (leftover.existsSync()) {
+            try {
+              leftover.deleteSync();
+            } catch (_) {}
+          }
+        }
+      }
       bool cbzFileExist =
           await File(
             p.join(mangaMainDirectory!.path, "${chapter.name}.cbz"),

--- a/lib/services/download_manager/download_isolate_pool.dart
+++ b/lib/services/download_manager/download_isolate_pool.dart
@@ -514,7 +514,15 @@ Future<void> _downloadFile(
         final file = File(pageUrl.fileName!);
         final sink = file.openWrite();
         try {
-          await for (var value in response.stream) {
+          // Idle timeout: if no bytes arrive for 30s the connection has
+          // stalled, so fail (and retry) instead of hanging the whole
+          // download forever with no progress.
+          await for (var value in response.stream.timeout(
+            const Duration(seconds: 30),
+            onTimeout: (sink) => sink.addError(
+              TimeoutException('Download stalled (no data for 30s)'),
+            ),
+          )) {
             sink.add(value);
             received += value.length;
             try {
@@ -621,7 +629,14 @@ Future<void> _downloadSegment(
 
     final sink = file.openWrite();
     try {
-      await for (var chunk in response.stream) {
+      // Idle timeout: a segment whose connection stalls (no bytes for 30s)
+      // fails and retries instead of hanging the whole download forever.
+      await for (var chunk in response.stream.timeout(
+        const Duration(seconds: 30),
+        onTimeout: (sink) => sink.addError(
+          TimeoutException('Segment stalled (no data for 30s)'),
+        ),
+      )) {
         sink.add(chunk);
       }
     } finally {


### PR DESCRIPTION
Three fixes for the download / playback issues reported today. Analyze is clean (0 errors, 0 warnings); not device-tested here, so these want a real download + playback pass.

## Downloads stall forever
Both the m3u8 segment download and the direct page/file download streamed the response body with no timeout, so a connection that stalls mid-transfer (no bytes arriving) hung the whole download indefinitely with no progress and no error. More parallel downloads means more connections exposed to this, which is why higher concurrency made it worse. Added a 30s idle timeout on both streams, so a stalled transfer fails (and retries) instead of hanging.

## Restarting a stalled download marks it complete but truncated
Starting a download ran an "already downloaded?" check that only tested whether the target file exists. A stalled attempt leaves a partial single-file download (anime .mp4, novel .html) on disk, so the check saw the file, skipped downloading and marked it complete — a truncated but "finished" file. Now, before that check, if the chapter's download record is not actually complete, any such leftover is deleted so it re-downloads from scratch.

## Anime resume plays from the start despite the right timestamp
The saved position (stored and read in ms, so the timestamp itself was correct) was passed via media_kit's `Media(start:)`, which some sources ignore, starting playback at 0. After opening, the player now seeks explicitly to the saved position once the media reports a duration. Fire-and-forget with a timeout so open isn't delayed; a redundant seek (when `start:` did work) is harmless.

Note: the download stall/truncation lives in the pre-existing downloader, not in the reorder-queue change in #815, so they don't conflict.
