### PR TITLE
feat(downloads): concurrency toggle + rate limit (#621)

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -901,5 +901,9 @@
   "reader_hide_threshold_high": "High (13 px)",
   "reader_hide_threshold_low": "Low (31 px)",
   "reader_hide_threshold_lowest": "Lowest (47 px)",
-  "error_no_pages_available": "Error: no pages available"
+  "error_no_pages_available": "Error: no pages available",
+  "allow_concurrent_downloads": "Allow concurrent downloads",
+  "allow_concurrent_downloads_subtitle": "Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.",
+  "download_delay": "Download delay",
+  "download_delay_subtitle": "Off. Add a wait with random jitter between chapters to be gentler on sources."
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -4546,6 +4546,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Error: no pages available'**
   String get error_no_pages_available;
+
+  /// No description provided for @allow_concurrent_downloads.
+  ///
+  /// In en, this message translates to:
+  /// **'Allow concurrent downloads'**
+  String get allow_concurrent_downloads;
+
+  /// No description provided for @allow_concurrent_downloads_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.'**
+  String get allow_concurrent_downloads_subtitle;
+
+  /// No description provided for @download_delay.
+  ///
+  /// In en, this message translates to:
+  /// **'Download delay'**
+  String get download_delay;
+
+  /// No description provided for @download_delay_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Off. Add a wait with random jitter between chapters to be gentler on sources.'**
+  String get download_delay_subtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -2456,4 +2456,18 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'خطأ: لا توجد صفحات متاحة';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -2456,4 +2456,18 @@ class AppLocalizationsAs extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Error: no pages available';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -2471,4 +2471,18 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Fehler: Keine Seiten verfügbar';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -2449,4 +2449,18 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Error: no pages available';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -2481,6 +2481,20 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Error: no hay páginas disponibles';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -2481,4 +2481,18 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Erreur : aucune page disponible';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -2454,4 +2454,18 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'त्रुटि: कोई पन्ने उपलब्ध नहीं हैं';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -2460,4 +2460,18 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get error_no_pages_available =>
       'Kesalahan: tidak ada halaman tersedia';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -2482,4 +2482,18 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Errore: nessuna pagina disponibile';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -2418,4 +2418,18 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'エラー：利用可能なページがありません';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -2476,6 +2476,20 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Erro: nenhuma página disponível';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -2491,4 +2491,18 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Ошибка: нет доступных страниц';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -2451,4 +2451,18 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get error_no_pages_available =>
       'เกิดข้อผิดพลาด: ไม่มีหน้าที่พร้อมใช้งาน';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -2463,4 +2463,18 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Hata: kullanılabilir sayfa yok';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2380,4 +2380,18 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get error_no_pages_available => '错误：无可用页面';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -90,6 +90,8 @@ class Settings {
   bool? deleteDownloadAfterReading;
 
   int? concurrentDownloads;
+  bool? allowConcurrentDownloads;
+  int? downloadDelaySeconds;
 
   String? downloadLocation;
 
@@ -434,6 +436,8 @@ class Settings {
     this.saveAsCBZArchive = false,
     this.deleteDownloadAfterReading = false,
     this.concurrentDownloads = 2,
+    this.allowConcurrentDownloads = true,
+    this.downloadDelaySeconds = 0,
     this.downloadLocation = "",
     this.cropBorders = false,
     this.libraryLocalSource,
@@ -652,6 +656,8 @@ class Settings {
     downloadLocation = json['downloadLocation'];
     downloadOnlyOnWifi = json['downloadOnlyOnWifi'];
     concurrentDownloads = json['concurrentDownloads'];
+    allowConcurrentDownloads = json['allowConcurrentDownloads'] ?? true;
+    downloadDelaySeconds = json['downloadDelaySeconds'] ?? 0;
     filterScanlatorList = (json['filterScanlatorList'] as List?)
         ?.map((e) => FilterScanlator.fromJson(e))
         .toList();
@@ -940,6 +946,8 @@ class Settings {
     'downloadLocation': downloadLocation,
     'downloadOnlyOnWifi': downloadOnlyOnWifi,
     'concurrentDownloads': concurrentDownloads,
+    'allowConcurrentDownloads': allowConcurrentDownloads,
+    'downloadDelaySeconds': downloadDelaySeconds,
     'filterScanlatorList': filterScanlatorList,
     'flexColorSchemeBlendLevel': flexColorSchemeBlendLevel,
     'flexSchemeColorIndex': flexSchemeColorIndex,

--- a/lib/models/settings.g.dart
+++ b/lib/models/settings.g.dart
@@ -24,1025 +24,1035 @@ const SettingsSchema = CollectionSchema(
 
       target: r'AlgorithmWeights',
     ),
-    r'androidProxyServer': PropertySchema(
+    r'allowConcurrentDownloads': PropertySchema(
       id: 1,
+      name: r'allowConcurrentDownloads',
+      type: IsarType.bool,
+    ),
+    r'androidProxyServer': PropertySchema(
+      id: 2,
       name: r'androidProxyServer',
       type: IsarType.string,
     ),
     r'aniSkipTimeoutLength': PropertySchema(
-      id: 2,
+      id: 3,
       name: r'aniSkipTimeoutLength',
       type: IsarType.long,
     ),
     r'animatePageTransitions': PropertySchema(
-      id: 3,
+      id: 4,
       name: r'animatePageTransitions',
       type: IsarType.bool,
     ),
     r'animeDisplayType': PropertySchema(
-      id: 4,
+      id: 5,
       name: r'animeDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsanimeDisplayTypeEnumValueMap,
     ),
     r'animeExtensionsRepo': PropertySchema(
-      id: 5,
+      id: 6,
       name: r'animeExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'animeGridSize': PropertySchema(
-      id: 6,
+      id: 7,
       name: r'animeGridSize',
       type: IsarType.long,
     ),
     r'animeLibraryDownloadedChapters': PropertySchema(
-      id: 7,
+      id: 8,
       name: r'animeLibraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'animeLibraryLocalSource': PropertySchema(
-      id: 8,
+      id: 9,
       name: r'animeLibraryLocalSource',
       type: IsarType.bool,
     ),
     r'animeLibraryShowCategoryTabs': PropertySchema(
-      id: 9,
+      id: 10,
       name: r'animeLibraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'animeLibraryShowContinueReadingButton': PropertySchema(
-      id: 10,
+      id: 11,
       name: r'animeLibraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'animeLibraryShowLanguage': PropertySchema(
-      id: 11,
+      id: 12,
       name: r'animeLibraryShowLanguage',
       type: IsarType.bool,
     ),
     r'animeLibraryShowNumbersOfItems': PropertySchema(
-      id: 12,
+      id: 13,
       name: r'animeLibraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'appFontFamily': PropertySchema(
-      id: 13,
+      id: 14,
       name: r'appFontFamily',
       type: IsarType.string,
     ),
     r'appLockEnabled': PropertySchema(
-      id: 14,
+      id: 15,
       name: r'appLockEnabled',
       type: IsarType.bool,
     ),
     r'audioChannels': PropertySchema(
-      id: 15,
+      id: 16,
       name: r'audioChannels',
       type: IsarType.byte,
       enumMap: _SettingsaudioChannelsEnumValueMap,
     ),
     r'audioPreferredLanguages': PropertySchema(
-      id: 16,
+      id: 17,
       name: r'audioPreferredLanguages',
       type: IsarType.string,
     ),
     r'autoBackupLocation': PropertySchema(
-      id: 17,
+      id: 18,
       name: r'autoBackupLocation',
       type: IsarType.string,
     ),
     r'autoExtensionsUpdates': PropertySchema(
-      id: 18,
+      id: 19,
       name: r'autoExtensionsUpdates',
       type: IsarType.bool,
     ),
     r'autoPlayNextEpisode': PropertySchema(
-      id: 19,
+      id: 20,
       name: r'autoPlayNextEpisode',
       type: IsarType.bool,
     ),
     r'autoReadDuplicateChapters': PropertySchema(
-      id: 20,
+      id: 21,
       name: r'autoReadDuplicateChapters',
       type: IsarType.bool,
     ),
     r'autoScrollPages': PropertySchema(
-      id: 21,
+      id: 22,
       name: r'autoScrollPages',
       type: IsarType.objectList,
 
       target: r'AutoScrollPages',
     ),
     r'automaticBackground': PropertySchema(
-      id: 22,
+      id: 23,
       name: r'automaticBackground',
       type: IsarType.bool,
     ),
     r'backgroundColor': PropertySchema(
-      id: 23,
+      id: 24,
       name: r'backgroundColor',
       type: IsarType.byte,
       enumMap: _SettingsbackgroundColorEnumValueMap,
     ),
     r'backupCompressionLevel': PropertySchema(
-      id: 24,
+      id: 25,
       name: r'backupCompressionLevel',
       type: IsarType.long,
     ),
     r'backupFrequency': PropertySchema(
-      id: 25,
+      id: 26,
       name: r'backupFrequency',
       type: IsarType.long,
     ),
     r'backupListOptions': PropertySchema(
-      id: 26,
+      id: 27,
       name: r'backupListOptions',
       type: IsarType.longList,
     ),
     r'btServerAddress': PropertySchema(
-      id: 27,
+      id: 28,
       name: r'btServerAddress',
       type: IsarType.string,
     ),
     r'btServerPort': PropertySchema(
-      id: 28,
+      id: 29,
       name: r'btServerPort',
       type: IsarType.long,
     ),
     r'cfProxyUrl': PropertySchema(
-      id: 29,
+      id: 30,
       name: r'cfProxyUrl',
       type: IsarType.string,
     ),
     r'chapterFilterBookmarkedList': PropertySchema(
-      id: 30,
+      id: 31,
       name: r'chapterFilterBookmarkedList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterBookmarked',
     ),
     r'chapterFilterDownloadedList': PropertySchema(
-      id: 31,
+      id: 32,
       name: r'chapterFilterDownloadedList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterDownloaded',
     ),
     r'chapterFilterUnreadList': PropertySchema(
-      id: 32,
+      id: 33,
       name: r'chapterFilterUnreadList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterUnread',
     ),
     r'chapterPageIndexList': PropertySchema(
-      id: 33,
+      id: 34,
       name: r'chapterPageIndexList',
       type: IsarType.objectList,
 
       target: r'ChapterPageIndex',
     ),
     r'chapterPageUrlsList': PropertySchema(
-      id: 34,
+      id: 35,
       name: r'chapterPageUrlsList',
       type: IsarType.objectList,
 
       target: r'ChapterPageurls',
     ),
     r'checkForAppUpdates': PropertySchema(
-      id: 35,
+      id: 36,
       name: r'checkForAppUpdates',
       type: IsarType.bool,
     ),
     r'checkForExtensionUpdates': PropertySchema(
-      id: 36,
+      id: 37,
       name: r'checkForExtensionUpdates',
       type: IsarType.bool,
     ),
     r'clearChapterCacheOnAppLaunch': PropertySchema(
-      id: 37,
+      id: 38,
       name: r'clearChapterCacheOnAppLaunch',
       type: IsarType.bool,
     ),
     r'colorFilterBlendMode': PropertySchema(
-      id: 38,
+      id: 39,
       name: r'colorFilterBlendMode',
       type: IsarType.byte,
       enumMap: _SettingscolorFilterBlendModeEnumValueMap,
     ),
     r'concurrentDownloads': PropertySchema(
-      id: 39,
+      id: 40,
       name: r'concurrentDownloads',
       type: IsarType.long,
     ),
     r'cookiesList': PropertySchema(
-      id: 40,
+      id: 41,
       name: r'cookiesList',
       type: IsarType.objectList,
 
       target: r'MCookie',
     ),
     r'cropBorders': PropertySchema(
-      id: 41,
+      id: 42,
       name: r'cropBorders',
       type: IsarType.bool,
     ),
     r'customColorFilter': PropertySchema(
-      id: 42,
+      id: 43,
       name: r'customColorFilter',
       type: IsarType.object,
 
       target: r'CustomColorFilter',
     ),
     r'customDns': PropertySchema(
-      id: 43,
+      id: 44,
       name: r'customDns',
       type: IsarType.string,
     ),
     r'customDohUrl': PropertySchema(
-      id: 44,
+      id: 45,
       name: r'customDohUrl',
       type: IsarType.string,
     ),
     r'dateFormat': PropertySchema(
-      id: 45,
+      id: 46,
       name: r'dateFormat',
       type: IsarType.string,
     ),
     r'debandingType': PropertySchema(
-      id: 46,
+      id: 47,
       name: r'debandingType',
       type: IsarType.byte,
       enumMap: _SettingsdebandingTypeEnumValueMap,
     ),
     r'defaultDoubleTapToSkipLength': PropertySchema(
-      id: 47,
+      id: 48,
       name: r'defaultDoubleTapToSkipLength',
       type: IsarType.long,
     ),
     r'defaultPlayBackSpeed': PropertySchema(
-      id: 48,
+      id: 49,
       name: r'defaultPlayBackSpeed',
       type: IsarType.double,
     ),
     r'defaultReaderMode': PropertySchema(
-      id: 49,
+      id: 50,
       name: r'defaultReaderMode',
       type: IsarType.byte,
       enumMap: _SettingsdefaultReaderModeEnumValueMap,
     ),
     r'defaultSkipIntroLength': PropertySchema(
-      id: 50,
+      id: 51,
       name: r'defaultSkipIntroLength',
       type: IsarType.long,
     ),
     r'defaultSubtitleLang': PropertySchema(
-      id: 51,
+      id: 52,
       name: r'defaultSubtitleLang',
       type: IsarType.object,
 
       target: r'L10nLocale',
     ),
     r'deleteDownloadAfterReading': PropertySchema(
-      id: 52,
+      id: 53,
       name: r'deleteDownloadAfterReading',
       type: IsarType.bool,
     ),
     r'disableSectionType': PropertySchema(
-      id: 53,
+      id: 54,
       name: r'disableSectionType',
       type: IsarType.byte,
       enumMap: _SettingsdisableSectionTypeEnumValueMap,
     ),
     r'displayType': PropertySchema(
-      id: 54,
+      id: 55,
       name: r'displayType',
       type: IsarType.byte,
       enumMap: _SettingsdisplayTypeEnumValueMap,
     ),
     r'doHEnabled': PropertySchema(
-      id: 55,
+      id: 56,
       name: r'doHEnabled',
       type: IsarType.bool,
     ),
     r'doHProviderId': PropertySchema(
-      id: 56,
+      id: 57,
       name: r'doHProviderId',
       type: IsarType.long,
     ),
     r'doubleTapAnimationSpeed': PropertySchema(
-      id: 57,
+      id: 58,
       name: r'doubleTapAnimationSpeed',
       type: IsarType.long,
     ),
+    r'downloadDelaySeconds': PropertySchema(
+      id: 59,
+      name: r'downloadDelaySeconds',
+      type: IsarType.long,
+    ),
     r'downloadLocation': PropertySchema(
-      id: 58,
+      id: 60,
       name: r'downloadLocation',
       type: IsarType.string,
     ),
     r'downloadOnlyOnWifi': PropertySchema(
-      id: 59,
+      id: 61,
       name: r'downloadOnlyOnWifi',
       type: IsarType.bool,
     ),
     r'downloadedOnlyMode': PropertySchema(
-      id: 60,
+      id: 62,
       name: r'downloadedOnlyMode',
       type: IsarType.bool,
     ),
     r'dualPageInvert': PropertySchema(
-      id: 61,
+      id: 63,
       name: r'dualPageInvert',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFit': PropertySchema(
-      id: 62,
+      id: 64,
       name: r'dualPageRotateToFit',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFitInvert': PropertySchema(
-      id: 63,
+      id: 65,
       name: r'dualPageRotateToFitInvert',
       type: IsarType.bool,
     ),
     r'enableAniSkip': PropertySchema(
-      id: 64,
+      id: 66,
       name: r'enableAniSkip',
       type: IsarType.bool,
     ),
     r'enableAudioPitchCorrection': PropertySchema(
-      id: 65,
+      id: 67,
       name: r'enableAudioPitchCorrection',
       type: IsarType.bool,
     ),
     r'enableAutoSkip': PropertySchema(
-      id: 66,
+      id: 68,
       name: r'enableAutoSkip',
       type: IsarType.bool,
     ),
     r'enableCustomColorFilter': PropertySchema(
-      id: 67,
+      id: 69,
       name: r'enableCustomColorFilter',
       type: IsarType.bool,
     ),
     r'enableDiscordRpc': PropertySchema(
-      id: 68,
+      id: 70,
       name: r'enableDiscordRpc',
       type: IsarType.bool,
     ),
     r'enableGpuNext': PropertySchema(
-      id: 69,
+      id: 71,
       name: r'enableGpuNext',
       type: IsarType.bool,
     ),
     r'enableHardwareAcceleration': PropertySchema(
-      id: 70,
+      id: 72,
       name: r'enableHardwareAcceleration',
       type: IsarType.bool,
     ),
     r'enableLogs': PropertySchema(
-      id: 71,
+      id: 73,
       name: r'enableLogs',
       type: IsarType.bool,
     ),
     r'extensionServerPath': PropertySchema(
-      id: 72,
+      id: 74,
       name: r'extensionServerPath',
       type: IsarType.string,
     ),
     r'filterScanlatorList': PropertySchema(
-      id: 73,
+      id: 75,
       name: r'filterScanlatorList',
       type: IsarType.objectList,
 
       target: r'FilterScanlator',
     ),
     r'flashColor': PropertySchema(
-      id: 74,
+      id: 76,
       name: r'flashColor',
       type: IsarType.long,
     ),
     r'flashDuration': PropertySchema(
-      id: 75,
+      id: 77,
       name: r'flashDuration',
       type: IsarType.long,
     ),
     r'flashInterval': PropertySchema(
-      id: 76,
+      id: 78,
       name: r'flashInterval',
       type: IsarType.long,
     ),
     r'flashOnPageChange': PropertySchema(
-      id: 77,
+      id: 79,
       name: r'flashOnPageChange',
       type: IsarType.bool,
     ),
     r'flexColorSchemeBlendLevel': PropertySchema(
-      id: 78,
+      id: 80,
       name: r'flexColorSchemeBlendLevel',
       type: IsarType.double,
     ),
     r'flexSchemeColorIndex': PropertySchema(
-      id: 79,
+      id: 81,
       name: r'flexSchemeColorIndex',
       type: IsarType.long,
     ),
     r'followSystemTheme': PropertySchema(
-      id: 80,
+      id: 82,
       name: r'followSystemTheme',
       type: IsarType.bool,
     ),
     r'forceLandscapePlayer': PropertySchema(
-      id: 81,
+      id: 83,
       name: r'forceLandscapePlayer',
       type: IsarType.bool,
     ),
     r'fullScreenPlayer': PropertySchema(
-      id: 82,
+      id: 84,
       name: r'fullScreenPlayer',
       type: IsarType.bool,
     ),
     r'fullScreenReader': PropertySchema(
-      id: 83,
+      id: 85,
       name: r'fullScreenReader',
       type: IsarType.bool,
     ),
     r'grayscale': PropertySchema(
-      id: 84,
+      id: 86,
       name: r'grayscale',
       type: IsarType.bool,
     ),
     r'hideDiscordRpcInIncognito': PropertySchema(
-      id: 85,
+      id: 87,
       name: r'hideDiscordRpcInIncognito',
       type: IsarType.bool,
     ),
     r'hideItems': PropertySchema(
-      id: 86,
+      id: 88,
       name: r'hideItems',
       type: IsarType.stringList,
     ),
     r'hwdecMode': PropertySchema(
-      id: 87,
+      id: 89,
       name: r'hwdecMode',
       type: IsarType.string,
     ),
     r'incognitoMode': PropertySchema(
-      id: 88,
+      id: 90,
       name: r'incognitoMode',
       type: IsarType.bool,
     ),
     r'invertColors': PropertySchema(
-      id: 89,
+      id: 91,
       name: r'invertColors',
       type: IsarType.bool,
     ),
-    r'jrePath': PropertySchema(id: 90, name: r'jrePath', type: IsarType.string),
+    r'jrePath': PropertySchema(id: 92, name: r'jrePath', type: IsarType.string),
     r'keepScreenOnReader': PropertySchema(
-      id: 91,
+      id: 93,
       name: r'keepScreenOnReader',
       type: IsarType.bool,
     ),
     r'landscapeZoom': PropertySchema(
-      id: 92,
+      id: 94,
       name: r'landscapeZoom',
       type: IsarType.bool,
     ),
     r'lastTrackerLibraryLocation': PropertySchema(
-      id: 93,
+      id: 95,
       name: r'lastTrackerLibraryLocation',
       type: IsarType.string,
     ),
     r'libraryDownloadedChapters': PropertySchema(
-      id: 94,
+      id: 96,
       name: r'libraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'libraryFilterAnimeBookMarkedType': PropertySchema(
-      id: 95,
+      id: 97,
       name: r'libraryFilterAnimeBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeCompletedType': PropertySchema(
-      id: 96,
+      id: 98,
       name: r'libraryFilterAnimeCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeDownloadType': PropertySchema(
-      id: 97,
+      id: 99,
       name: r'libraryFilterAnimeDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeStartedType': PropertySchema(
-      id: 98,
+      id: 100,
       name: r'libraryFilterAnimeStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeTrackingType': PropertySchema(
-      id: 99,
+      id: 101,
       name: r'libraryFilterAnimeTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeUnreadType': PropertySchema(
-      id: 100,
+      id: 102,
       name: r'libraryFilterAnimeUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasBookMarkedType': PropertySchema(
-      id: 101,
+      id: 103,
       name: r'libraryFilterMangasBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasCompletedType': PropertySchema(
-      id: 102,
+      id: 104,
       name: r'libraryFilterMangasCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasDownloadType': PropertySchema(
-      id: 103,
+      id: 105,
       name: r'libraryFilterMangasDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasStartedType': PropertySchema(
-      id: 104,
+      id: 106,
       name: r'libraryFilterMangasStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasTrackingType': PropertySchema(
-      id: 105,
+      id: 107,
       name: r'libraryFilterMangasTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasUnreadType': PropertySchema(
-      id: 106,
+      id: 108,
       name: r'libraryFilterMangasUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelBookMarkedType': PropertySchema(
-      id: 107,
+      id: 109,
       name: r'libraryFilterNovelBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelCompletedType': PropertySchema(
-      id: 108,
+      id: 110,
       name: r'libraryFilterNovelCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelDownloadType': PropertySchema(
-      id: 109,
+      id: 111,
       name: r'libraryFilterNovelDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelStartedType': PropertySchema(
-      id: 110,
+      id: 112,
       name: r'libraryFilterNovelStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelTrackingType': PropertySchema(
-      id: 111,
+      id: 113,
       name: r'libraryFilterNovelTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelUnreadType': PropertySchema(
-      id: 112,
+      id: 114,
       name: r'libraryFilterNovelUnreadType',
       type: IsarType.long,
     ),
     r'libraryLocalSource': PropertySchema(
-      id: 113,
+      id: 115,
       name: r'libraryLocalSource',
       type: IsarType.bool,
     ),
     r'libraryShowCategoryTabs': PropertySchema(
-      id: 114,
+      id: 116,
       name: r'libraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'libraryShowContinueReadingButton': PropertySchema(
-      id: 115,
+      id: 117,
       name: r'libraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'libraryShowLanguage': PropertySchema(
-      id: 116,
+      id: 118,
       name: r'libraryShowLanguage',
       type: IsarType.bool,
     ),
     r'libraryShowNumbersOfItems': PropertySchema(
-      id: 117,
+      id: 119,
       name: r'libraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'localFolders': PropertySchema(
-      id: 118,
+      id: 120,
       name: r'localFolders',
       type: IsarType.stringList,
     ),
     r'locale': PropertySchema(
-      id: 119,
+      id: 121,
       name: r'locale',
       type: IsarType.object,
 
       target: r'L10nLocale',
     ),
     r'mangaExtensionsRepo': PropertySchema(
-      id: 120,
+      id: 122,
       name: r'mangaExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'mangaGridSize': PropertySchema(
-      id: 121,
+      id: 123,
       name: r'mangaGridSize',
       type: IsarType.long,
     ),
     r'mangaHomeDisplayType': PropertySchema(
-      id: 122,
+      id: 124,
       name: r'mangaHomeDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsmangaHomeDisplayTypeEnumValueMap,
     ),
     r'markEpisodeAsSeenType': PropertySchema(
-      id: 123,
+      id: 125,
       name: r'markEpisodeAsSeenType',
       type: IsarType.long,
     ),
     r'mergeLibraryNavMobile': PropertySchema(
-      id: 124,
+      id: 126,
       name: r'mergeLibraryNavMobile',
       type: IsarType.bool,
     ),
     r'navigateToPan': PropertySchema(
-      id: 125,
+      id: 127,
       name: r'navigateToPan',
       type: IsarType.bool,
     ),
     r'navigationOrder': PropertySchema(
-      id: 126,
+      id: 128,
       name: r'navigationOrder',
       type: IsarType.stringList,
     ),
     r'novelDisplayType': PropertySchema(
-      id: 127,
+      id: 129,
       name: r'novelDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsnovelDisplayTypeEnumValueMap,
     ),
     r'novelExtensionsRepo': PropertySchema(
-      id: 128,
+      id: 130,
       name: r'novelExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'novelFontSize': PropertySchema(
-      id: 129,
+      id: 131,
       name: r'novelFontSize',
       type: IsarType.long,
     ),
     r'novelGridSize': PropertySchema(
-      id: 130,
+      id: 132,
       name: r'novelGridSize',
       type: IsarType.long,
     ),
     r'novelLibraryDownloadedChapters': PropertySchema(
-      id: 131,
+      id: 133,
       name: r'novelLibraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'novelLibraryLocalSource': PropertySchema(
-      id: 132,
+      id: 134,
       name: r'novelLibraryLocalSource',
       type: IsarType.bool,
     ),
     r'novelLibraryShowCategoryTabs': PropertySchema(
-      id: 133,
+      id: 135,
       name: r'novelLibraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'novelLibraryShowContinueReadingButton': PropertySchema(
-      id: 134,
+      id: 136,
       name: r'novelLibraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'novelLibraryShowLanguage': PropertySchema(
-      id: 135,
+      id: 137,
       name: r'novelLibraryShowLanguage',
       type: IsarType.bool,
     ),
     r'novelLibraryShowNumbersOfItems': PropertySchema(
-      id: 136,
+      id: 138,
       name: r'novelLibraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'novelReaderLineHeight': PropertySchema(
-      id: 137,
+      id: 139,
       name: r'novelReaderLineHeight',
       type: IsarType.double,
     ),
     r'novelReaderPadding': PropertySchema(
-      id: 138,
+      id: 140,
       name: r'novelReaderPadding',
       type: IsarType.long,
     ),
     r'novelReaderTextColor': PropertySchema(
-      id: 139,
+      id: 141,
       name: r'novelReaderTextColor',
       type: IsarType.string,
     ),
     r'novelReaderTheme': PropertySchema(
-      id: 140,
+      id: 142,
       name: r'novelReaderTheme',
       type: IsarType.string,
     ),
     r'novelRemoveExtraParagraphSpacing': PropertySchema(
-      id: 141,
+      id: 143,
       name: r'novelRemoveExtraParagraphSpacing',
       type: IsarType.bool,
     ),
     r'novelShowScrollPercentage': PropertySchema(
-      id: 142,
+      id: 144,
       name: r'novelShowScrollPercentage',
       type: IsarType.bool,
     ),
     r'novelTapToScroll': PropertySchema(
-      id: 143,
+      id: 145,
       name: r'novelTapToScroll',
       type: IsarType.bool,
     ),
     r'novelTextAlign': PropertySchema(
-      id: 144,
+      id: 146,
       name: r'novelTextAlign',
       type: IsarType.byte,
       enumMap: _SettingsnovelTextAlignEnumValueMap,
     ),
     r'onlyIncludePinnedSources': PropertySchema(
-      id: 145,
+      id: 147,
       name: r'onlyIncludePinnedSources',
       type: IsarType.bool,
     ),
     r'pagePreloadAmount': PropertySchema(
-      id: 146,
+      id: 148,
       name: r'pagePreloadAmount',
       type: IsarType.long,
     ),
     r'personalPageModeList': PropertySchema(
-      id: 147,
+      id: 149,
       name: r'personalPageModeList',
       type: IsarType.objectList,
 
       target: r'PersonalPageMode',
     ),
     r'personalReaderModeList': PropertySchema(
-      id: 148,
+      id: 150,
       name: r'personalReaderModeList',
       type: IsarType.objectList,
 
       target: r'PersonalReaderMode',
     ),
     r'playerSubtitleSettings': PropertySchema(
-      id: 149,
+      id: 151,
       name: r'playerSubtitleSettings',
       type: IsarType.object,
 
       target: r'PlayerSubtitleSettings',
     ),
     r'pureBlackDarkMode': PropertySchema(
-      id: 150,
+      id: 152,
       name: r'pureBlackDarkMode',
       type: IsarType.bool,
     ),
     r'readerBrightness': PropertySchema(
-      id: 151,
+      id: 153,
       name: r'readerBrightness',
       type: IsarType.double,
     ),
     r'readerContrast': PropertySchema(
-      id: 152,
+      id: 154,
       name: r'readerContrast',
       type: IsarType.double,
     ),
     r'readerHideThreshold': PropertySchema(
-      id: 153,
+      id: 155,
       name: r'readerHideThreshold',
       type: IsarType.long,
     ),
     r'readerNavigationLayout': PropertySchema(
-      id: 154,
+      id: 156,
       name: r'readerNavigationLayout',
       type: IsarType.long,
     ),
     r'readerSaturation': PropertySchema(
-      id: 155,
+      id: 157,
       name: r'readerSaturation',
       type: IsarType.double,
     ),
     r'relativeTimesTamps': PropertySchema(
-      id: 156,
+      id: 158,
       name: r'relativeTimesTamps',
       type: IsarType.long,
     ),
     r'rpcShowCoverImage': PropertySchema(
-      id: 157,
+      id: 159,
       name: r'rpcShowCoverImage',
       type: IsarType.bool,
     ),
     r'rpcShowReadingWatchingProgress': PropertySchema(
-      id: 158,
+      id: 160,
       name: r'rpcShowReadingWatchingProgress',
       type: IsarType.bool,
     ),
     r'rpcShowTitle': PropertySchema(
-      id: 159,
+      id: 161,
       name: r'rpcShowTitle',
       type: IsarType.bool,
     ),
     r'saveAsCBZArchive': PropertySchema(
-      id: 160,
+      id: 162,
       name: r'saveAsCBZArchive',
       type: IsarType.bool,
     ),
     r'scaleType': PropertySchema(
-      id: 161,
+      id: 163,
       name: r'scaleType',
       type: IsarType.byte,
       enumMap: _SettingsscaleTypeEnumValueMap,
     ),
     r'showNSFW': PropertySchema(
-      id: 162,
+      id: 164,
       name: r'showNSFW',
       type: IsarType.bool,
     ),
     r'showNavigationOverlayOnStart': PropertySchema(
-      id: 163,
+      id: 165,
       name: r'showNavigationOverlayOnStart',
       type: IsarType.bool,
     ),
     r'showPageGaps': PropertySchema(
-      id: 164,
+      id: 166,
       name: r'showPageGaps',
       type: IsarType.bool,
     ),
     r'showPagesNumber': PropertySchema(
-      id: 165,
+      id: 167,
       name: r'showPagesNumber',
       type: IsarType.bool,
     ),
     r'sortChapterList': PropertySchema(
-      id: 166,
+      id: 168,
       name: r'sortChapterList',
       type: IsarType.objectList,
 
       target: r'SortChapter',
     ),
     r'sortLibraryAnime': PropertySchema(
-      id: 167,
+      id: 169,
       name: r'sortLibraryAnime',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryManga': PropertySchema(
-      id: 168,
+      id: 170,
       name: r'sortLibraryManga',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryNovel': PropertySchema(
-      id: 169,
+      id: 171,
       name: r'sortLibraryNovel',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'splitWidePages': PropertySchema(
-      id: 170,
+      id: 172,
       name: r'splitWidePages',
       type: IsarType.bool,
     ),
     r'startDatebackup': PropertySchema(
-      id: 171,
+      id: 173,
       name: r'startDatebackup',
       type: IsarType.long,
     ),
     r'tappingInversion': PropertySchema(
-      id: 172,
+      id: 174,
       name: r'tappingInversion',
       type: IsarType.long,
     ),
     r'themeIsDark': PropertySchema(
-      id: 173,
+      id: 175,
       name: r'themeIsDark',
       type: IsarType.bool,
     ),
     r'ttsLanguage': PropertySchema(
-      id: 174,
+      id: 176,
       name: r'ttsLanguage',
       type: IsarType.string,
     ),
     r'ttsPitch': PropertySchema(
-      id: 175,
+      id: 177,
       name: r'ttsPitch',
       type: IsarType.double,
     ),
     r'ttsSpeechRate': PropertySchema(
-      id: 176,
+      id: 178,
       name: r'ttsSpeechRate',
       type: IsarType.double,
     ),
     r'ttsVoice': PropertySchema(
-      id: 177,
+      id: 179,
       name: r'ttsVoice',
       type: IsarType.string,
     ),
     r'tvAnimeOnlyOverride': PropertySchema(
-      id: 178,
+      id: 180,
       name: r'tvAnimeOnlyOverride',
       type: IsarType.bool,
     ),
     r'tvHomeGenreRows': PropertySchema(
-      id: 179,
+      id: 181,
       name: r'tvHomeGenreRows',
       type: IsarType.bool,
     ),
     r'tvHomeStyle': PropertySchema(
-      id: 180,
+      id: 182,
       name: r'tvHomeStyle',
       type: IsarType.bool,
     ),
     r'tvPlayerStyle': PropertySchema(
-      id: 181,
+      id: 183,
       name: r'tvPlayerStyle',
       type: IsarType.bool,
     ),
     r'updateErrorsList': PropertySchema(
-      id: 182,
+      id: 184,
       name: r'updateErrorsList',
       type: IsarType.objectList,
 
       target: r'UpdateError',
     ),
     r'updateProgressAfterReading': PropertySchema(
-      id: 183,
+      id: 185,
       name: r'updateProgressAfterReading',
       type: IsarType.bool,
     ),
     r'updatedAt': PropertySchema(
-      id: 184,
+      id: 186,
       name: r'updatedAt',
       type: IsarType.long,
     ),
     r'useLibass': PropertySchema(
-      id: 185,
+      id: 187,
       name: r'useLibass',
       type: IsarType.bool,
     ),
     r'useMpvConfig': PropertySchema(
-      id: 186,
+      id: 188,
       name: r'useMpvConfig',
       type: IsarType.bool,
     ),
     r'usePageTapZones': PropertySchema(
-      id: 187,
+      id: 189,
       name: r'usePageTapZones',
       type: IsarType.bool,
     ),
     r'useYUV420P': PropertySchema(
-      id: 188,
+      id: 190,
       name: r'useYUV420P',
       type: IsarType.bool,
     ),
     r'userAgent': PropertySchema(
-      id: 189,
+      id: 191,
       name: r'userAgent',
       type: IsarType.string,
     ),
     r'volumeBoostCap': PropertySchema(
-      id: 190,
+      id: 192,
       name: r'volumeBoostCap',
       type: IsarType.long,
     ),
     r'webtoonDisableZoomOut': PropertySchema(
-      id: 191,
+      id: 193,
       name: r'webtoonDisableZoomOut',
       type: IsarType.bool,
     ),
     r'webtoonDoubleTapZoomEnabled': PropertySchema(
-      id: 192,
+      id: 194,
       name: r'webtoonDoubleTapZoomEnabled',
       type: IsarType.bool,
     ),
     r'webtoonSidePadding': PropertySchema(
-      id: 193,
+      id: 195,
       name: r'webtoonSidePadding',
       type: IsarType.long,
     ),
     r'zoomStartPosition': PropertySchema(
-      id: 194,
+      id: 196,
       name: r'zoomStartPosition',
       type: IsarType.long,
     ),
@@ -1601,310 +1611,312 @@ void _settingsSerialize(
     AlgorithmWeightsSchema.serialize,
     object.algorithmWeights,
   );
-  writer.writeString(offsets[1], object.androidProxyServer);
-  writer.writeLong(offsets[2], object.aniSkipTimeoutLength);
-  writer.writeBool(offsets[3], object.animatePageTransitions);
-  writer.writeByte(offsets[4], object.animeDisplayType.index);
+  writer.writeBool(offsets[1], object.allowConcurrentDownloads);
+  writer.writeString(offsets[2], object.androidProxyServer);
+  writer.writeLong(offsets[3], object.aniSkipTimeoutLength);
+  writer.writeBool(offsets[4], object.animatePageTransitions);
+  writer.writeByte(offsets[5], object.animeDisplayType.index);
   writer.writeObjectList<Repo>(
-    offsets[5],
+    offsets[6],
     allOffsets,
     RepoSchema.serialize,
     object.animeExtensionsRepo,
   );
-  writer.writeLong(offsets[6], object.animeGridSize);
-  writer.writeBool(offsets[7], object.animeLibraryDownloadedChapters);
-  writer.writeBool(offsets[8], object.animeLibraryLocalSource);
-  writer.writeBool(offsets[9], object.animeLibraryShowCategoryTabs);
-  writer.writeBool(offsets[10], object.animeLibraryShowContinueReadingButton);
-  writer.writeBool(offsets[11], object.animeLibraryShowLanguage);
-  writer.writeBool(offsets[12], object.animeLibraryShowNumbersOfItems);
-  writer.writeString(offsets[13], object.appFontFamily);
-  writer.writeBool(offsets[14], object.appLockEnabled);
-  writer.writeByte(offsets[15], object.audioChannels.index);
-  writer.writeString(offsets[16], object.audioPreferredLanguages);
-  writer.writeString(offsets[17], object.autoBackupLocation);
-  writer.writeBool(offsets[18], object.autoExtensionsUpdates);
-  writer.writeBool(offsets[19], object.autoPlayNextEpisode);
-  writer.writeBool(offsets[20], object.autoReadDuplicateChapters);
+  writer.writeLong(offsets[7], object.animeGridSize);
+  writer.writeBool(offsets[8], object.animeLibraryDownloadedChapters);
+  writer.writeBool(offsets[9], object.animeLibraryLocalSource);
+  writer.writeBool(offsets[10], object.animeLibraryShowCategoryTabs);
+  writer.writeBool(offsets[11], object.animeLibraryShowContinueReadingButton);
+  writer.writeBool(offsets[12], object.animeLibraryShowLanguage);
+  writer.writeBool(offsets[13], object.animeLibraryShowNumbersOfItems);
+  writer.writeString(offsets[14], object.appFontFamily);
+  writer.writeBool(offsets[15], object.appLockEnabled);
+  writer.writeByte(offsets[16], object.audioChannels.index);
+  writer.writeString(offsets[17], object.audioPreferredLanguages);
+  writer.writeString(offsets[18], object.autoBackupLocation);
+  writer.writeBool(offsets[19], object.autoExtensionsUpdates);
+  writer.writeBool(offsets[20], object.autoPlayNextEpisode);
+  writer.writeBool(offsets[21], object.autoReadDuplicateChapters);
   writer.writeObjectList<AutoScrollPages>(
-    offsets[21],
+    offsets[22],
     allOffsets,
     AutoScrollPagesSchema.serialize,
     object.autoScrollPages,
   );
-  writer.writeBool(offsets[22], object.automaticBackground);
-  writer.writeByte(offsets[23], object.backgroundColor.index);
-  writer.writeLong(offsets[24], object.backupCompressionLevel);
-  writer.writeLong(offsets[25], object.backupFrequency);
-  writer.writeLongList(offsets[26], object.backupListOptions);
-  writer.writeString(offsets[27], object.btServerAddress);
-  writer.writeLong(offsets[28], object.btServerPort);
-  writer.writeString(offsets[29], object.cfProxyUrl);
+  writer.writeBool(offsets[23], object.automaticBackground);
+  writer.writeByte(offsets[24], object.backgroundColor.index);
+  writer.writeLong(offsets[25], object.backupCompressionLevel);
+  writer.writeLong(offsets[26], object.backupFrequency);
+  writer.writeLongList(offsets[27], object.backupListOptions);
+  writer.writeString(offsets[28], object.btServerAddress);
+  writer.writeLong(offsets[29], object.btServerPort);
+  writer.writeString(offsets[30], object.cfProxyUrl);
   writer.writeObjectList<ChapterFilterBookmarked>(
-    offsets[30],
+    offsets[31],
     allOffsets,
     ChapterFilterBookmarkedSchema.serialize,
     object.chapterFilterBookmarkedList,
   );
   writer.writeObjectList<ChapterFilterDownloaded>(
-    offsets[31],
+    offsets[32],
     allOffsets,
     ChapterFilterDownloadedSchema.serialize,
     object.chapterFilterDownloadedList,
   );
   writer.writeObjectList<ChapterFilterUnread>(
-    offsets[32],
+    offsets[33],
     allOffsets,
     ChapterFilterUnreadSchema.serialize,
     object.chapterFilterUnreadList,
   );
   writer.writeObjectList<ChapterPageIndex>(
-    offsets[33],
+    offsets[34],
     allOffsets,
     ChapterPageIndexSchema.serialize,
     object.chapterPageIndexList,
   );
   writer.writeObjectList<ChapterPageurls>(
-    offsets[34],
+    offsets[35],
     allOffsets,
     ChapterPageurlsSchema.serialize,
     object.chapterPageUrlsList,
   );
-  writer.writeBool(offsets[35], object.checkForAppUpdates);
-  writer.writeBool(offsets[36], object.checkForExtensionUpdates);
-  writer.writeBool(offsets[37], object.clearChapterCacheOnAppLaunch);
-  writer.writeByte(offsets[38], object.colorFilterBlendMode.index);
-  writer.writeLong(offsets[39], object.concurrentDownloads);
+  writer.writeBool(offsets[36], object.checkForAppUpdates);
+  writer.writeBool(offsets[37], object.checkForExtensionUpdates);
+  writer.writeBool(offsets[38], object.clearChapterCacheOnAppLaunch);
+  writer.writeByte(offsets[39], object.colorFilterBlendMode.index);
+  writer.writeLong(offsets[40], object.concurrentDownloads);
   writer.writeObjectList<MCookie>(
-    offsets[40],
+    offsets[41],
     allOffsets,
     MCookieSchema.serialize,
     object.cookiesList,
   );
-  writer.writeBool(offsets[41], object.cropBorders);
+  writer.writeBool(offsets[42], object.cropBorders);
   writer.writeObject<CustomColorFilter>(
-    offsets[42],
+    offsets[43],
     allOffsets,
     CustomColorFilterSchema.serialize,
     object.customColorFilter,
   );
-  writer.writeString(offsets[43], object.customDns);
-  writer.writeString(offsets[44], object.customDohUrl);
-  writer.writeString(offsets[45], object.dateFormat);
-  writer.writeByte(offsets[46], object.debandingType.index);
-  writer.writeLong(offsets[47], object.defaultDoubleTapToSkipLength);
-  writer.writeDouble(offsets[48], object.defaultPlayBackSpeed);
-  writer.writeByte(offsets[49], object.defaultReaderMode.index);
-  writer.writeLong(offsets[50], object.defaultSkipIntroLength);
+  writer.writeString(offsets[44], object.customDns);
+  writer.writeString(offsets[45], object.customDohUrl);
+  writer.writeString(offsets[46], object.dateFormat);
+  writer.writeByte(offsets[47], object.debandingType.index);
+  writer.writeLong(offsets[48], object.defaultDoubleTapToSkipLength);
+  writer.writeDouble(offsets[49], object.defaultPlayBackSpeed);
+  writer.writeByte(offsets[50], object.defaultReaderMode.index);
+  writer.writeLong(offsets[51], object.defaultSkipIntroLength);
   writer.writeObject<L10nLocale>(
-    offsets[51],
+    offsets[52],
     allOffsets,
     L10nLocaleSchema.serialize,
     object.defaultSubtitleLang,
   );
-  writer.writeBool(offsets[52], object.deleteDownloadAfterReading);
-  writer.writeByte(offsets[53], object.disableSectionType.index);
-  writer.writeByte(offsets[54], object.displayType.index);
-  writer.writeBool(offsets[55], object.doHEnabled);
-  writer.writeLong(offsets[56], object.doHProviderId);
-  writer.writeLong(offsets[57], object.doubleTapAnimationSpeed);
-  writer.writeString(offsets[58], object.downloadLocation);
-  writer.writeBool(offsets[59], object.downloadOnlyOnWifi);
-  writer.writeBool(offsets[60], object.downloadedOnlyMode);
-  writer.writeBool(offsets[61], object.dualPageInvert);
-  writer.writeBool(offsets[62], object.dualPageRotateToFit);
-  writer.writeBool(offsets[63], object.dualPageRotateToFitInvert);
-  writer.writeBool(offsets[64], object.enableAniSkip);
-  writer.writeBool(offsets[65], object.enableAudioPitchCorrection);
-  writer.writeBool(offsets[66], object.enableAutoSkip);
-  writer.writeBool(offsets[67], object.enableCustomColorFilter);
-  writer.writeBool(offsets[68], object.enableDiscordRpc);
-  writer.writeBool(offsets[69], object.enableGpuNext);
-  writer.writeBool(offsets[70], object.enableHardwareAcceleration);
-  writer.writeBool(offsets[71], object.enableLogs);
-  writer.writeString(offsets[72], object.extensionServerPath);
+  writer.writeBool(offsets[53], object.deleteDownloadAfterReading);
+  writer.writeByte(offsets[54], object.disableSectionType.index);
+  writer.writeByte(offsets[55], object.displayType.index);
+  writer.writeBool(offsets[56], object.doHEnabled);
+  writer.writeLong(offsets[57], object.doHProviderId);
+  writer.writeLong(offsets[58], object.doubleTapAnimationSpeed);
+  writer.writeLong(offsets[59], object.downloadDelaySeconds);
+  writer.writeString(offsets[60], object.downloadLocation);
+  writer.writeBool(offsets[61], object.downloadOnlyOnWifi);
+  writer.writeBool(offsets[62], object.downloadedOnlyMode);
+  writer.writeBool(offsets[63], object.dualPageInvert);
+  writer.writeBool(offsets[64], object.dualPageRotateToFit);
+  writer.writeBool(offsets[65], object.dualPageRotateToFitInvert);
+  writer.writeBool(offsets[66], object.enableAniSkip);
+  writer.writeBool(offsets[67], object.enableAudioPitchCorrection);
+  writer.writeBool(offsets[68], object.enableAutoSkip);
+  writer.writeBool(offsets[69], object.enableCustomColorFilter);
+  writer.writeBool(offsets[70], object.enableDiscordRpc);
+  writer.writeBool(offsets[71], object.enableGpuNext);
+  writer.writeBool(offsets[72], object.enableHardwareAcceleration);
+  writer.writeBool(offsets[73], object.enableLogs);
+  writer.writeString(offsets[74], object.extensionServerPath);
   writer.writeObjectList<FilterScanlator>(
-    offsets[73],
+    offsets[75],
     allOffsets,
     FilterScanlatorSchema.serialize,
     object.filterScanlatorList,
   );
-  writer.writeLong(offsets[74], object.flashColor);
-  writer.writeLong(offsets[75], object.flashDuration);
-  writer.writeLong(offsets[76], object.flashInterval);
-  writer.writeBool(offsets[77], object.flashOnPageChange);
-  writer.writeDouble(offsets[78], object.flexColorSchemeBlendLevel);
-  writer.writeLong(offsets[79], object.flexSchemeColorIndex);
-  writer.writeBool(offsets[80], object.followSystemTheme);
-  writer.writeBool(offsets[81], object.forceLandscapePlayer);
-  writer.writeBool(offsets[82], object.fullScreenPlayer);
-  writer.writeBool(offsets[83], object.fullScreenReader);
-  writer.writeBool(offsets[84], object.grayscale);
-  writer.writeBool(offsets[85], object.hideDiscordRpcInIncognito);
-  writer.writeStringList(offsets[86], object.hideItems);
-  writer.writeString(offsets[87], object.hwdecMode);
-  writer.writeBool(offsets[88], object.incognitoMode);
-  writer.writeBool(offsets[89], object.invertColors);
-  writer.writeString(offsets[90], object.jrePath);
-  writer.writeBool(offsets[91], object.keepScreenOnReader);
-  writer.writeBool(offsets[92], object.landscapeZoom);
-  writer.writeString(offsets[93], object.lastTrackerLibraryLocation);
-  writer.writeBool(offsets[94], object.libraryDownloadedChapters);
-  writer.writeLong(offsets[95], object.libraryFilterAnimeBookMarkedType);
-  writer.writeLong(offsets[96], object.libraryFilterAnimeCompletedType);
-  writer.writeLong(offsets[97], object.libraryFilterAnimeDownloadType);
-  writer.writeLong(offsets[98], object.libraryFilterAnimeStartedType);
-  writer.writeLong(offsets[99], object.libraryFilterAnimeTrackingType);
-  writer.writeLong(offsets[100], object.libraryFilterAnimeUnreadType);
-  writer.writeLong(offsets[101], object.libraryFilterMangasBookMarkedType);
-  writer.writeLong(offsets[102], object.libraryFilterMangasCompletedType);
-  writer.writeLong(offsets[103], object.libraryFilterMangasDownloadType);
-  writer.writeLong(offsets[104], object.libraryFilterMangasStartedType);
-  writer.writeLong(offsets[105], object.libraryFilterMangasTrackingType);
-  writer.writeLong(offsets[106], object.libraryFilterMangasUnreadType);
-  writer.writeLong(offsets[107], object.libraryFilterNovelBookMarkedType);
-  writer.writeLong(offsets[108], object.libraryFilterNovelCompletedType);
-  writer.writeLong(offsets[109], object.libraryFilterNovelDownloadType);
-  writer.writeLong(offsets[110], object.libraryFilterNovelStartedType);
-  writer.writeLong(offsets[111], object.libraryFilterNovelTrackingType);
-  writer.writeLong(offsets[112], object.libraryFilterNovelUnreadType);
-  writer.writeBool(offsets[113], object.libraryLocalSource);
-  writer.writeBool(offsets[114], object.libraryShowCategoryTabs);
-  writer.writeBool(offsets[115], object.libraryShowContinueReadingButton);
-  writer.writeBool(offsets[116], object.libraryShowLanguage);
-  writer.writeBool(offsets[117], object.libraryShowNumbersOfItems);
-  writer.writeStringList(offsets[118], object.localFolders);
+  writer.writeLong(offsets[76], object.flashColor);
+  writer.writeLong(offsets[77], object.flashDuration);
+  writer.writeLong(offsets[78], object.flashInterval);
+  writer.writeBool(offsets[79], object.flashOnPageChange);
+  writer.writeDouble(offsets[80], object.flexColorSchemeBlendLevel);
+  writer.writeLong(offsets[81], object.flexSchemeColorIndex);
+  writer.writeBool(offsets[82], object.followSystemTheme);
+  writer.writeBool(offsets[83], object.forceLandscapePlayer);
+  writer.writeBool(offsets[84], object.fullScreenPlayer);
+  writer.writeBool(offsets[85], object.fullScreenReader);
+  writer.writeBool(offsets[86], object.grayscale);
+  writer.writeBool(offsets[87], object.hideDiscordRpcInIncognito);
+  writer.writeStringList(offsets[88], object.hideItems);
+  writer.writeString(offsets[89], object.hwdecMode);
+  writer.writeBool(offsets[90], object.incognitoMode);
+  writer.writeBool(offsets[91], object.invertColors);
+  writer.writeString(offsets[92], object.jrePath);
+  writer.writeBool(offsets[93], object.keepScreenOnReader);
+  writer.writeBool(offsets[94], object.landscapeZoom);
+  writer.writeString(offsets[95], object.lastTrackerLibraryLocation);
+  writer.writeBool(offsets[96], object.libraryDownloadedChapters);
+  writer.writeLong(offsets[97], object.libraryFilterAnimeBookMarkedType);
+  writer.writeLong(offsets[98], object.libraryFilterAnimeCompletedType);
+  writer.writeLong(offsets[99], object.libraryFilterAnimeDownloadType);
+  writer.writeLong(offsets[100], object.libraryFilterAnimeStartedType);
+  writer.writeLong(offsets[101], object.libraryFilterAnimeTrackingType);
+  writer.writeLong(offsets[102], object.libraryFilterAnimeUnreadType);
+  writer.writeLong(offsets[103], object.libraryFilterMangasBookMarkedType);
+  writer.writeLong(offsets[104], object.libraryFilterMangasCompletedType);
+  writer.writeLong(offsets[105], object.libraryFilterMangasDownloadType);
+  writer.writeLong(offsets[106], object.libraryFilterMangasStartedType);
+  writer.writeLong(offsets[107], object.libraryFilterMangasTrackingType);
+  writer.writeLong(offsets[108], object.libraryFilterMangasUnreadType);
+  writer.writeLong(offsets[109], object.libraryFilterNovelBookMarkedType);
+  writer.writeLong(offsets[110], object.libraryFilterNovelCompletedType);
+  writer.writeLong(offsets[111], object.libraryFilterNovelDownloadType);
+  writer.writeLong(offsets[112], object.libraryFilterNovelStartedType);
+  writer.writeLong(offsets[113], object.libraryFilterNovelTrackingType);
+  writer.writeLong(offsets[114], object.libraryFilterNovelUnreadType);
+  writer.writeBool(offsets[115], object.libraryLocalSource);
+  writer.writeBool(offsets[116], object.libraryShowCategoryTabs);
+  writer.writeBool(offsets[117], object.libraryShowContinueReadingButton);
+  writer.writeBool(offsets[118], object.libraryShowLanguage);
+  writer.writeBool(offsets[119], object.libraryShowNumbersOfItems);
+  writer.writeStringList(offsets[120], object.localFolders);
   writer.writeObject<L10nLocale>(
-    offsets[119],
+    offsets[121],
     allOffsets,
     L10nLocaleSchema.serialize,
     object.locale,
   );
   writer.writeObjectList<Repo>(
-    offsets[120],
+    offsets[122],
     allOffsets,
     RepoSchema.serialize,
     object.mangaExtensionsRepo,
   );
-  writer.writeLong(offsets[121], object.mangaGridSize);
-  writer.writeByte(offsets[122], object.mangaHomeDisplayType.index);
-  writer.writeLong(offsets[123], object.markEpisodeAsSeenType);
-  writer.writeBool(offsets[124], object.mergeLibraryNavMobile);
-  writer.writeBool(offsets[125], object.navigateToPan);
-  writer.writeStringList(offsets[126], object.navigationOrder);
-  writer.writeByte(offsets[127], object.novelDisplayType.index);
+  writer.writeLong(offsets[123], object.mangaGridSize);
+  writer.writeByte(offsets[124], object.mangaHomeDisplayType.index);
+  writer.writeLong(offsets[125], object.markEpisodeAsSeenType);
+  writer.writeBool(offsets[126], object.mergeLibraryNavMobile);
+  writer.writeBool(offsets[127], object.navigateToPan);
+  writer.writeStringList(offsets[128], object.navigationOrder);
+  writer.writeByte(offsets[129], object.novelDisplayType.index);
   writer.writeObjectList<Repo>(
-    offsets[128],
+    offsets[130],
     allOffsets,
     RepoSchema.serialize,
     object.novelExtensionsRepo,
   );
-  writer.writeLong(offsets[129], object.novelFontSize);
-  writer.writeLong(offsets[130], object.novelGridSize);
-  writer.writeBool(offsets[131], object.novelLibraryDownloadedChapters);
-  writer.writeBool(offsets[132], object.novelLibraryLocalSource);
-  writer.writeBool(offsets[133], object.novelLibraryShowCategoryTabs);
-  writer.writeBool(offsets[134], object.novelLibraryShowContinueReadingButton);
-  writer.writeBool(offsets[135], object.novelLibraryShowLanguage);
-  writer.writeBool(offsets[136], object.novelLibraryShowNumbersOfItems);
-  writer.writeDouble(offsets[137], object.novelReaderLineHeight);
-  writer.writeLong(offsets[138], object.novelReaderPadding);
-  writer.writeString(offsets[139], object.novelReaderTextColor);
-  writer.writeString(offsets[140], object.novelReaderTheme);
-  writer.writeBool(offsets[141], object.novelRemoveExtraParagraphSpacing);
-  writer.writeBool(offsets[142], object.novelShowScrollPercentage);
-  writer.writeBool(offsets[143], object.novelTapToScroll);
-  writer.writeByte(offsets[144], object.novelTextAlign.index);
-  writer.writeBool(offsets[145], object.onlyIncludePinnedSources);
-  writer.writeLong(offsets[146], object.pagePreloadAmount);
+  writer.writeLong(offsets[131], object.novelFontSize);
+  writer.writeLong(offsets[132], object.novelGridSize);
+  writer.writeBool(offsets[133], object.novelLibraryDownloadedChapters);
+  writer.writeBool(offsets[134], object.novelLibraryLocalSource);
+  writer.writeBool(offsets[135], object.novelLibraryShowCategoryTabs);
+  writer.writeBool(offsets[136], object.novelLibraryShowContinueReadingButton);
+  writer.writeBool(offsets[137], object.novelLibraryShowLanguage);
+  writer.writeBool(offsets[138], object.novelLibraryShowNumbersOfItems);
+  writer.writeDouble(offsets[139], object.novelReaderLineHeight);
+  writer.writeLong(offsets[140], object.novelReaderPadding);
+  writer.writeString(offsets[141], object.novelReaderTextColor);
+  writer.writeString(offsets[142], object.novelReaderTheme);
+  writer.writeBool(offsets[143], object.novelRemoveExtraParagraphSpacing);
+  writer.writeBool(offsets[144], object.novelShowScrollPercentage);
+  writer.writeBool(offsets[145], object.novelTapToScroll);
+  writer.writeByte(offsets[146], object.novelTextAlign.index);
+  writer.writeBool(offsets[147], object.onlyIncludePinnedSources);
+  writer.writeLong(offsets[148], object.pagePreloadAmount);
   writer.writeObjectList<PersonalPageMode>(
-    offsets[147],
+    offsets[149],
     allOffsets,
     PersonalPageModeSchema.serialize,
     object.personalPageModeList,
   );
   writer.writeObjectList<PersonalReaderMode>(
-    offsets[148],
+    offsets[150],
     allOffsets,
     PersonalReaderModeSchema.serialize,
     object.personalReaderModeList,
   );
   writer.writeObject<PlayerSubtitleSettings>(
-    offsets[149],
+    offsets[151],
     allOffsets,
     PlayerSubtitleSettingsSchema.serialize,
     object.playerSubtitleSettings,
   );
-  writer.writeBool(offsets[150], object.pureBlackDarkMode);
-  writer.writeDouble(offsets[151], object.readerBrightness);
-  writer.writeDouble(offsets[152], object.readerContrast);
-  writer.writeLong(offsets[153], object.readerHideThreshold);
-  writer.writeLong(offsets[154], object.readerNavigationLayout);
-  writer.writeDouble(offsets[155], object.readerSaturation);
-  writer.writeLong(offsets[156], object.relativeTimesTamps);
-  writer.writeBool(offsets[157], object.rpcShowCoverImage);
-  writer.writeBool(offsets[158], object.rpcShowReadingWatchingProgress);
-  writer.writeBool(offsets[159], object.rpcShowTitle);
-  writer.writeBool(offsets[160], object.saveAsCBZArchive);
-  writer.writeByte(offsets[161], object.scaleType.index);
-  writer.writeBool(offsets[162], object.showNSFW);
-  writer.writeBool(offsets[163], object.showNavigationOverlayOnStart);
-  writer.writeBool(offsets[164], object.showPageGaps);
-  writer.writeBool(offsets[165], object.showPagesNumber);
+  writer.writeBool(offsets[152], object.pureBlackDarkMode);
+  writer.writeDouble(offsets[153], object.readerBrightness);
+  writer.writeDouble(offsets[154], object.readerContrast);
+  writer.writeLong(offsets[155], object.readerHideThreshold);
+  writer.writeLong(offsets[156], object.readerNavigationLayout);
+  writer.writeDouble(offsets[157], object.readerSaturation);
+  writer.writeLong(offsets[158], object.relativeTimesTamps);
+  writer.writeBool(offsets[159], object.rpcShowCoverImage);
+  writer.writeBool(offsets[160], object.rpcShowReadingWatchingProgress);
+  writer.writeBool(offsets[161], object.rpcShowTitle);
+  writer.writeBool(offsets[162], object.saveAsCBZArchive);
+  writer.writeByte(offsets[163], object.scaleType.index);
+  writer.writeBool(offsets[164], object.showNSFW);
+  writer.writeBool(offsets[165], object.showNavigationOverlayOnStart);
+  writer.writeBool(offsets[166], object.showPageGaps);
+  writer.writeBool(offsets[167], object.showPagesNumber);
   writer.writeObjectList<SortChapter>(
-    offsets[166],
+    offsets[168],
     allOffsets,
     SortChapterSchema.serialize,
     object.sortChapterList,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[167],
+    offsets[169],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryAnime,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[168],
+    offsets[170],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryManga,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[169],
+    offsets[171],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryNovel,
   );
-  writer.writeBool(offsets[170], object.splitWidePages);
-  writer.writeLong(offsets[171], object.startDatebackup);
-  writer.writeLong(offsets[172], object.tappingInversion);
-  writer.writeBool(offsets[173], object.themeIsDark);
-  writer.writeString(offsets[174], object.ttsLanguage);
-  writer.writeDouble(offsets[175], object.ttsPitch);
-  writer.writeDouble(offsets[176], object.ttsSpeechRate);
-  writer.writeString(offsets[177], object.ttsVoice);
-  writer.writeBool(offsets[178], object.tvAnimeOnlyOverride);
-  writer.writeBool(offsets[179], object.tvHomeGenreRows);
-  writer.writeBool(offsets[180], object.tvHomeStyle);
-  writer.writeBool(offsets[181], object.tvPlayerStyle);
+  writer.writeBool(offsets[172], object.splitWidePages);
+  writer.writeLong(offsets[173], object.startDatebackup);
+  writer.writeLong(offsets[174], object.tappingInversion);
+  writer.writeBool(offsets[175], object.themeIsDark);
+  writer.writeString(offsets[176], object.ttsLanguage);
+  writer.writeDouble(offsets[177], object.ttsPitch);
+  writer.writeDouble(offsets[178], object.ttsSpeechRate);
+  writer.writeString(offsets[179], object.ttsVoice);
+  writer.writeBool(offsets[180], object.tvAnimeOnlyOverride);
+  writer.writeBool(offsets[181], object.tvHomeGenreRows);
+  writer.writeBool(offsets[182], object.tvHomeStyle);
+  writer.writeBool(offsets[183], object.tvPlayerStyle);
   writer.writeObjectList<UpdateError>(
-    offsets[182],
+    offsets[184],
     allOffsets,
     UpdateErrorSchema.serialize,
     object.updateErrorsList,
   );
-  writer.writeBool(offsets[183], object.updateProgressAfterReading);
-  writer.writeLong(offsets[184], object.updatedAt);
-  writer.writeBool(offsets[185], object.useLibass);
-  writer.writeBool(offsets[186], object.useMpvConfig);
-  writer.writeBool(offsets[187], object.usePageTapZones);
-  writer.writeBool(offsets[188], object.useYUV420P);
-  writer.writeString(offsets[189], object.userAgent);
-  writer.writeLong(offsets[190], object.volumeBoostCap);
-  writer.writeBool(offsets[191], object.webtoonDisableZoomOut);
-  writer.writeBool(offsets[192], object.webtoonDoubleTapZoomEnabled);
-  writer.writeLong(offsets[193], object.webtoonSidePadding);
-  writer.writeLong(offsets[194], object.zoomStartPosition);
+  writer.writeBool(offsets[185], object.updateProgressAfterReading);
+  writer.writeLong(offsets[186], object.updatedAt);
+  writer.writeBool(offsets[187], object.useLibass);
+  writer.writeBool(offsets[188], object.useMpvConfig);
+  writer.writeBool(offsets[189], object.usePageTapZones);
+  writer.writeBool(offsets[190], object.useYUV420P);
+  writer.writeString(offsets[191], object.userAgent);
+  writer.writeLong(offsets[192], object.volumeBoostCap);
+  writer.writeBool(offsets[193], object.webtoonDisableZoomOut);
+  writer.writeBool(offsets[194], object.webtoonDoubleTapZoomEnabled);
+  writer.writeLong(offsets[195], object.webtoonSidePadding);
+  writer.writeLong(offsets[196], object.zoomStartPosition);
 }
 
 Settings _settingsDeserialize(
@@ -1919,350 +1931,352 @@ Settings _settingsDeserialize(
       AlgorithmWeightsSchema.deserialize,
       allOffsets,
     ),
-    androidProxyServer: reader.readStringOrNull(offsets[1]),
-    aniSkipTimeoutLength: reader.readLongOrNull(offsets[2]),
-    animatePageTransitions: reader.readBoolOrNull(offsets[3]),
+    allowConcurrentDownloads: reader.readBoolOrNull(offsets[1]),
+    androidProxyServer: reader.readStringOrNull(offsets[2]),
+    aniSkipTimeoutLength: reader.readLongOrNull(offsets[3]),
+    animatePageTransitions: reader.readBoolOrNull(offsets[4]),
     animeDisplayType:
         _SettingsanimeDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[4],
+          offsets[5],
         )] ??
         DisplayType.compactGrid,
     animeExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[5],
+      offsets[6],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    animeGridSize: reader.readLongOrNull(offsets[6]),
-    animeLibraryDownloadedChapters: reader.readBoolOrNull(offsets[7]),
-    animeLibraryLocalSource: reader.readBoolOrNull(offsets[8]),
-    animeLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[9]),
-    animeLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[10]),
-    animeLibraryShowLanguage: reader.readBoolOrNull(offsets[11]),
-    animeLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[12]),
-    appFontFamily: reader.readStringOrNull(offsets[13]),
-    appLockEnabled: reader.readBoolOrNull(offsets[14]),
+    animeGridSize: reader.readLongOrNull(offsets[7]),
+    animeLibraryDownloadedChapters: reader.readBoolOrNull(offsets[8]),
+    animeLibraryLocalSource: reader.readBoolOrNull(offsets[9]),
+    animeLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[10]),
+    animeLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[11]),
+    animeLibraryShowLanguage: reader.readBoolOrNull(offsets[12]),
+    animeLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[13]),
+    appFontFamily: reader.readStringOrNull(offsets[14]),
+    appLockEnabled: reader.readBoolOrNull(offsets[15]),
     audioChannels:
         _SettingsaudioChannelsValueEnumMap[reader.readByteOrNull(
-          offsets[15],
+          offsets[16],
         )] ??
         AudioChannel.autoSafe,
-    audioPreferredLanguages: reader.readStringOrNull(offsets[16]),
-    autoBackupLocation: reader.readStringOrNull(offsets[17]),
-    autoExtensionsUpdates: reader.readBoolOrNull(offsets[18]),
-    autoPlayNextEpisode: reader.readBoolOrNull(offsets[19]),
-    autoReadDuplicateChapters: reader.readBoolOrNull(offsets[20]),
+    audioPreferredLanguages: reader.readStringOrNull(offsets[17]),
+    autoBackupLocation: reader.readStringOrNull(offsets[18]),
+    autoExtensionsUpdates: reader.readBoolOrNull(offsets[19]),
+    autoPlayNextEpisode: reader.readBoolOrNull(offsets[20]),
+    autoReadDuplicateChapters: reader.readBoolOrNull(offsets[21]),
     autoScrollPages: reader.readObjectList<AutoScrollPages>(
-      offsets[21],
+      offsets[22],
       AutoScrollPagesSchema.deserialize,
       allOffsets,
       AutoScrollPages(),
     ),
-    automaticBackground: reader.readBoolOrNull(offsets[22]),
+    automaticBackground: reader.readBoolOrNull(offsets[23]),
     backgroundColor:
         _SettingsbackgroundColorValueEnumMap[reader.readByteOrNull(
-          offsets[23],
+          offsets[24],
         )] ??
         BackgroundColor.black,
-    backupCompressionLevel: reader.readLongOrNull(offsets[24]),
-    backupFrequency: reader.readLongOrNull(offsets[25]),
-    backupListOptions: reader.readLongList(offsets[26]),
-    btServerAddress: reader.readStringOrNull(offsets[27]),
-    btServerPort: reader.readLongOrNull(offsets[28]),
-    cfProxyUrl: reader.readStringOrNull(offsets[29]),
+    backupCompressionLevel: reader.readLongOrNull(offsets[25]),
+    backupFrequency: reader.readLongOrNull(offsets[26]),
+    backupListOptions: reader.readLongList(offsets[27]),
+    btServerAddress: reader.readStringOrNull(offsets[28]),
+    btServerPort: reader.readLongOrNull(offsets[29]),
+    cfProxyUrl: reader.readStringOrNull(offsets[30]),
     chapterFilterDownloadedList: reader.readObjectList<ChapterFilterDownloaded>(
-      offsets[31],
+      offsets[32],
       ChapterFilterDownloadedSchema.deserialize,
       allOffsets,
       ChapterFilterDownloaded(),
     ),
     chapterPageIndexList: reader.readObjectList<ChapterPageIndex>(
-      offsets[33],
+      offsets[34],
       ChapterPageIndexSchema.deserialize,
       allOffsets,
       ChapterPageIndex(),
     ),
     chapterPageUrlsList: reader.readObjectList<ChapterPageurls>(
-      offsets[34],
+      offsets[35],
       ChapterPageurlsSchema.deserialize,
       allOffsets,
       ChapterPageurls(),
     ),
-    checkForAppUpdates: reader.readBoolOrNull(offsets[35]),
-    checkForExtensionUpdates: reader.readBoolOrNull(offsets[36]),
-    clearChapterCacheOnAppLaunch: reader.readBoolOrNull(offsets[37]),
+    checkForAppUpdates: reader.readBoolOrNull(offsets[36]),
+    checkForExtensionUpdates: reader.readBoolOrNull(offsets[37]),
+    clearChapterCacheOnAppLaunch: reader.readBoolOrNull(offsets[38]),
     colorFilterBlendMode:
         _SettingscolorFilterBlendModeValueEnumMap[reader.readByteOrNull(
-          offsets[38],
+          offsets[39],
         )] ??
         ColorFilterBlendMode.none,
-    concurrentDownloads: reader.readLongOrNull(offsets[39]),
+    concurrentDownloads: reader.readLongOrNull(offsets[40]),
     cookiesList: reader.readObjectList<MCookie>(
-      offsets[40],
+      offsets[41],
       MCookieSchema.deserialize,
       allOffsets,
       MCookie(),
     ),
-    cropBorders: reader.readBoolOrNull(offsets[41]),
+    cropBorders: reader.readBoolOrNull(offsets[42]),
     customColorFilter: reader.readObjectOrNull<CustomColorFilter>(
-      offsets[42],
+      offsets[43],
       CustomColorFilterSchema.deserialize,
       allOffsets,
     ),
-    customDns: reader.readStringOrNull(offsets[43]),
-    customDohUrl: reader.readStringOrNull(offsets[44]),
-    dateFormat: reader.readStringOrNull(offsets[45]),
+    customDns: reader.readStringOrNull(offsets[44]),
+    customDohUrl: reader.readStringOrNull(offsets[45]),
+    dateFormat: reader.readStringOrNull(offsets[46]),
     debandingType:
         _SettingsdebandingTypeValueEnumMap[reader.readByteOrNull(
-          offsets[46],
+          offsets[47],
         )] ??
         DebandingType.none,
-    defaultDoubleTapToSkipLength: reader.readLongOrNull(offsets[47]),
-    defaultPlayBackSpeed: reader.readDoubleOrNull(offsets[48]),
+    defaultDoubleTapToSkipLength: reader.readLongOrNull(offsets[48]),
+    defaultPlayBackSpeed: reader.readDoubleOrNull(offsets[49]),
     defaultReaderMode:
         _SettingsdefaultReaderModeValueEnumMap[reader.readByteOrNull(
-          offsets[49],
+          offsets[50],
         )] ??
         ReaderMode.vertical,
-    defaultSkipIntroLength: reader.readLongOrNull(offsets[50]),
-    deleteDownloadAfterReading: reader.readBoolOrNull(offsets[52]),
+    defaultSkipIntroLength: reader.readLongOrNull(offsets[51]),
+    deleteDownloadAfterReading: reader.readBoolOrNull(offsets[53]),
     disableSectionType:
         _SettingsdisableSectionTypeValueEnumMap[reader.readByteOrNull(
-          offsets[53],
+          offsets[54],
         )] ??
         SectionType.all,
     displayType:
-        _SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offsets[54])] ??
+        _SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offsets[55])] ??
         DisplayType.compactGrid,
-    doHEnabled: reader.readBoolOrNull(offsets[55]),
-    doHProviderId: reader.readLongOrNull(offsets[56]),
-    doubleTapAnimationSpeed: reader.readLongOrNull(offsets[57]),
-    downloadLocation: reader.readStringOrNull(offsets[58]),
-    downloadOnlyOnWifi: reader.readBoolOrNull(offsets[59]),
-    downloadedOnlyMode: reader.readBoolOrNull(offsets[60]),
-    dualPageInvert: reader.readBoolOrNull(offsets[61]),
-    dualPageRotateToFit: reader.readBoolOrNull(offsets[62]),
-    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[63]),
-    enableAniSkip: reader.readBoolOrNull(offsets[64]),
-    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[65]),
-    enableAutoSkip: reader.readBoolOrNull(offsets[66]),
-    enableCustomColorFilter: reader.readBoolOrNull(offsets[67]),
-    enableDiscordRpc: reader.readBoolOrNull(offsets[68]),
-    enableGpuNext: reader.readBoolOrNull(offsets[69]),
-    enableHardwareAcceleration: reader.readBoolOrNull(offsets[70]),
-    enableLogs: reader.readBoolOrNull(offsets[71]),
-    extensionServerPath: reader.readStringOrNull(offsets[72]),
-    flashColor: reader.readLongOrNull(offsets[74]),
-    flashDuration: reader.readLongOrNull(offsets[75]),
-    flashInterval: reader.readLongOrNull(offsets[76]),
-    flashOnPageChange: reader.readBoolOrNull(offsets[77]),
-    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[78]),
-    flexSchemeColorIndex: reader.readLongOrNull(offsets[79]),
-    followSystemTheme: reader.readBoolOrNull(offsets[80]),
-    forceLandscapePlayer: reader.readBoolOrNull(offsets[81]),
-    fullScreenPlayer: reader.readBoolOrNull(offsets[82]),
-    fullScreenReader: reader.readBoolOrNull(offsets[83]),
-    grayscale: reader.readBoolOrNull(offsets[84]),
-    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[85]),
-    hideItems: reader.readStringList(offsets[86]),
-    hwdecMode: reader.readStringOrNull(offsets[87]),
+    doHEnabled: reader.readBoolOrNull(offsets[56]),
+    doHProviderId: reader.readLongOrNull(offsets[57]),
+    doubleTapAnimationSpeed: reader.readLongOrNull(offsets[58]),
+    downloadDelaySeconds: reader.readLongOrNull(offsets[59]),
+    downloadLocation: reader.readStringOrNull(offsets[60]),
+    downloadOnlyOnWifi: reader.readBoolOrNull(offsets[61]),
+    downloadedOnlyMode: reader.readBoolOrNull(offsets[62]),
+    dualPageInvert: reader.readBoolOrNull(offsets[63]),
+    dualPageRotateToFit: reader.readBoolOrNull(offsets[64]),
+    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[65]),
+    enableAniSkip: reader.readBoolOrNull(offsets[66]),
+    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[67]),
+    enableAutoSkip: reader.readBoolOrNull(offsets[68]),
+    enableCustomColorFilter: reader.readBoolOrNull(offsets[69]),
+    enableDiscordRpc: reader.readBoolOrNull(offsets[70]),
+    enableGpuNext: reader.readBoolOrNull(offsets[71]),
+    enableHardwareAcceleration: reader.readBoolOrNull(offsets[72]),
+    enableLogs: reader.readBoolOrNull(offsets[73]),
+    extensionServerPath: reader.readStringOrNull(offsets[74]),
+    flashColor: reader.readLongOrNull(offsets[76]),
+    flashDuration: reader.readLongOrNull(offsets[77]),
+    flashInterval: reader.readLongOrNull(offsets[78]),
+    flashOnPageChange: reader.readBoolOrNull(offsets[79]),
+    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[80]),
+    flexSchemeColorIndex: reader.readLongOrNull(offsets[81]),
+    followSystemTheme: reader.readBoolOrNull(offsets[82]),
+    forceLandscapePlayer: reader.readBoolOrNull(offsets[83]),
+    fullScreenPlayer: reader.readBoolOrNull(offsets[84]),
+    fullScreenReader: reader.readBoolOrNull(offsets[85]),
+    grayscale: reader.readBoolOrNull(offsets[86]),
+    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[87]),
+    hideItems: reader.readStringList(offsets[88]),
+    hwdecMode: reader.readStringOrNull(offsets[89]),
     id: id,
-    incognitoMode: reader.readBoolOrNull(offsets[88]),
-    invertColors: reader.readBoolOrNull(offsets[89]),
-    jrePath: reader.readStringOrNull(offsets[90]),
-    keepScreenOnReader: reader.readBoolOrNull(offsets[91]),
-    landscapeZoom: reader.readBoolOrNull(offsets[92]),
-    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[93]),
-    libraryDownloadedChapters: reader.readBoolOrNull(offsets[94]),
-    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[95]),
-    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[96]),
-    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[97]),
-    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[98]),
-    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[99]),
-    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[100]),
-    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[101]),
-    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[102]),
-    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[103]),
-    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[104]),
-    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[105]),
-    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[106]),
-    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[107]),
-    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[108]),
-    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[109]),
-    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[110]),
-    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[111]),
-    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[112]),
-    libraryLocalSource: reader.readBoolOrNull(offsets[113]),
-    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[114]),
-    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[115]),
-    libraryShowLanguage: reader.readBoolOrNull(offsets[116]),
-    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[117]),
-    localFolders: reader.readStringList(offsets[118]),
+    incognitoMode: reader.readBoolOrNull(offsets[90]),
+    invertColors: reader.readBoolOrNull(offsets[91]),
+    jrePath: reader.readStringOrNull(offsets[92]),
+    keepScreenOnReader: reader.readBoolOrNull(offsets[93]),
+    landscapeZoom: reader.readBoolOrNull(offsets[94]),
+    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[95]),
+    libraryDownloadedChapters: reader.readBoolOrNull(offsets[96]),
+    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[97]),
+    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[98]),
+    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[99]),
+    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[100]),
+    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[101]),
+    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[102]),
+    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[103]),
+    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[104]),
+    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[105]),
+    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[106]),
+    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[107]),
+    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[108]),
+    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[109]),
+    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[110]),
+    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[111]),
+    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[112]),
+    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[113]),
+    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[114]),
+    libraryLocalSource: reader.readBoolOrNull(offsets[115]),
+    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[116]),
+    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[117]),
+    libraryShowLanguage: reader.readBoolOrNull(offsets[118]),
+    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[119]),
+    localFolders: reader.readStringList(offsets[120]),
     mangaExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[120],
+      offsets[122],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    mangaGridSize: reader.readLongOrNull(offsets[121]),
+    mangaGridSize: reader.readLongOrNull(offsets[123]),
     mangaHomeDisplayType:
         _SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[122],
+          offsets[124],
         )] ??
         DisplayType.comfortableGrid,
-    markEpisodeAsSeenType: reader.readLongOrNull(offsets[123]),
-    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[124]),
-    navigateToPan: reader.readBoolOrNull(offsets[125]),
-    navigationOrder: reader.readStringList(offsets[126]),
+    markEpisodeAsSeenType: reader.readLongOrNull(offsets[125]),
+    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[126]),
+    navigateToPan: reader.readBoolOrNull(offsets[127]),
+    navigationOrder: reader.readStringList(offsets[128]),
     novelDisplayType:
         _SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[127],
+          offsets[129],
         )] ??
         DisplayType.comfortableGrid,
     novelExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[128],
+      offsets[130],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    novelFontSize: reader.readLongOrNull(offsets[129]),
-    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[131]),
-    novelLibraryLocalSource: reader.readBoolOrNull(offsets[132]),
-    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[133]),
-    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[134]),
-    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[135]),
-    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[136]),
-    novelReaderLineHeight: reader.readDoubleOrNull(offsets[137]),
-    novelReaderPadding: reader.readLongOrNull(offsets[138]),
-    novelReaderTextColor: reader.readStringOrNull(offsets[139]),
-    novelReaderTheme: reader.readStringOrNull(offsets[140]),
-    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[141]),
-    novelShowScrollPercentage: reader.readBoolOrNull(offsets[142]),
-    novelTapToScroll: reader.readBoolOrNull(offsets[143]),
+    novelFontSize: reader.readLongOrNull(offsets[131]),
+    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[133]),
+    novelLibraryLocalSource: reader.readBoolOrNull(offsets[134]),
+    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[135]),
+    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[136]),
+    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[137]),
+    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[138]),
+    novelReaderLineHeight: reader.readDoubleOrNull(offsets[139]),
+    novelReaderPadding: reader.readLongOrNull(offsets[140]),
+    novelReaderTextColor: reader.readStringOrNull(offsets[141]),
+    novelReaderTheme: reader.readStringOrNull(offsets[142]),
+    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[143]),
+    novelShowScrollPercentage: reader.readBoolOrNull(offsets[144]),
+    novelTapToScroll: reader.readBoolOrNull(offsets[145]),
     novelTextAlign:
         _SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
-          offsets[144],
+          offsets[146],
         )] ??
         NovelTextAlign.left,
-    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[145]),
-    pagePreloadAmount: reader.readLongOrNull(offsets[146]),
+    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[147]),
+    pagePreloadAmount: reader.readLongOrNull(offsets[148]),
     personalPageModeList: reader.readObjectList<PersonalPageMode>(
-      offsets[147],
+      offsets[149],
       PersonalPageModeSchema.deserialize,
       allOffsets,
       PersonalPageMode(),
     ),
     personalReaderModeList: reader.readObjectList<PersonalReaderMode>(
-      offsets[148],
+      offsets[150],
       PersonalReaderModeSchema.deserialize,
       allOffsets,
       PersonalReaderMode(),
     ),
     playerSubtitleSettings: reader.readObjectOrNull<PlayerSubtitleSettings>(
-      offsets[149],
+      offsets[151],
       PlayerSubtitleSettingsSchema.deserialize,
       allOffsets,
     ),
-    pureBlackDarkMode: reader.readBoolOrNull(offsets[150]),
-    readerBrightness: reader.readDoubleOrNull(offsets[151]),
-    readerContrast: reader.readDoubleOrNull(offsets[152]),
-    readerHideThreshold: reader.readLongOrNull(offsets[153]),
-    readerNavigationLayout: reader.readLongOrNull(offsets[154]),
-    readerSaturation: reader.readDoubleOrNull(offsets[155]),
-    relativeTimesTamps: reader.readLongOrNull(offsets[156]),
-    rpcShowCoverImage: reader.readBoolOrNull(offsets[157]),
-    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[158]),
-    rpcShowTitle: reader.readBoolOrNull(offsets[159]),
-    saveAsCBZArchive: reader.readBoolOrNull(offsets[160]),
+    pureBlackDarkMode: reader.readBoolOrNull(offsets[152]),
+    readerBrightness: reader.readDoubleOrNull(offsets[153]),
+    readerContrast: reader.readDoubleOrNull(offsets[154]),
+    readerHideThreshold: reader.readLongOrNull(offsets[155]),
+    readerNavigationLayout: reader.readLongOrNull(offsets[156]),
+    readerSaturation: reader.readDoubleOrNull(offsets[157]),
+    relativeTimesTamps: reader.readLongOrNull(offsets[158]),
+    rpcShowCoverImage: reader.readBoolOrNull(offsets[159]),
+    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[160]),
+    rpcShowTitle: reader.readBoolOrNull(offsets[161]),
+    saveAsCBZArchive: reader.readBoolOrNull(offsets[162]),
     scaleType:
-        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[161])] ??
+        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[163])] ??
         ScaleType.fitScreen,
-    showNSFW: reader.readBoolOrNull(offsets[162]),
-    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[163]),
-    showPageGaps: reader.readBoolOrNull(offsets[164]),
-    showPagesNumber: reader.readBoolOrNull(offsets[165]),
+    showNSFW: reader.readBoolOrNull(offsets[164]),
+    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[165]),
+    showPageGaps: reader.readBoolOrNull(offsets[166]),
+    showPagesNumber: reader.readBoolOrNull(offsets[167]),
     sortChapterList: reader.readObjectList<SortChapter>(
-      offsets[166],
+      offsets[168],
       SortChapterSchema.deserialize,
       allOffsets,
       SortChapter(),
     ),
     sortLibraryAnime: reader.readObjectOrNull<SortLibraryManga>(
-      offsets[167],
-      SortLibraryMangaSchema.deserialize,
-      allOffsets,
-    ),
-    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
-      offsets[168],
-      SortLibraryMangaSchema.deserialize,
-      allOffsets,
-    ),
-    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
       offsets[169],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    splitWidePages: reader.readBoolOrNull(offsets[170]),
-    startDatebackup: reader.readLongOrNull(offsets[171]),
-    tappingInversion: reader.readLongOrNull(offsets[172]),
-    themeIsDark: reader.readBoolOrNull(offsets[173]),
-    ttsLanguage: reader.readStringOrNull(offsets[174]),
-    ttsPitch: reader.readDoubleOrNull(offsets[175]),
-    ttsSpeechRate: reader.readDoubleOrNull(offsets[176]),
-    ttsVoice: reader.readStringOrNull(offsets[177]),
-    tvAnimeOnlyOverride: reader.readBoolOrNull(offsets[178]),
-    tvHomeGenreRows: reader.readBoolOrNull(offsets[179]),
-    tvHomeStyle: reader.readBoolOrNull(offsets[180]),
-    tvPlayerStyle: reader.readBoolOrNull(offsets[181]),
+    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
+      offsets[170],
+      SortLibraryMangaSchema.deserialize,
+      allOffsets,
+    ),
+    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+      offsets[171],
+      SortLibraryMangaSchema.deserialize,
+      allOffsets,
+    ),
+    splitWidePages: reader.readBoolOrNull(offsets[172]),
+    startDatebackup: reader.readLongOrNull(offsets[173]),
+    tappingInversion: reader.readLongOrNull(offsets[174]),
+    themeIsDark: reader.readBoolOrNull(offsets[175]),
+    ttsLanguage: reader.readStringOrNull(offsets[176]),
+    ttsPitch: reader.readDoubleOrNull(offsets[177]),
+    ttsSpeechRate: reader.readDoubleOrNull(offsets[178]),
+    ttsVoice: reader.readStringOrNull(offsets[179]),
+    tvAnimeOnlyOverride: reader.readBoolOrNull(offsets[180]),
+    tvHomeGenreRows: reader.readBoolOrNull(offsets[181]),
+    tvHomeStyle: reader.readBoolOrNull(offsets[182]),
+    tvPlayerStyle: reader.readBoolOrNull(offsets[183]),
     updateErrorsList: reader.readObjectList<UpdateError>(
-      offsets[182],
+      offsets[184],
       UpdateErrorSchema.deserialize,
       allOffsets,
       UpdateError(),
     ),
-    updateProgressAfterReading: reader.readBoolOrNull(offsets[183]),
-    updatedAt: reader.readLongOrNull(offsets[184]),
-    useLibass: reader.readBoolOrNull(offsets[185]),
-    useMpvConfig: reader.readBoolOrNull(offsets[186]),
-    usePageTapZones: reader.readBoolOrNull(offsets[187]),
-    useYUV420P: reader.readBoolOrNull(offsets[188]),
-    userAgent: reader.readStringOrNull(offsets[189]),
-    volumeBoostCap: reader.readLongOrNull(offsets[190]),
-    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[191]),
-    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[192]),
-    webtoonSidePadding: reader.readLongOrNull(offsets[193]),
-    zoomStartPosition: reader.readLongOrNull(offsets[194]),
+    updateProgressAfterReading: reader.readBoolOrNull(offsets[185]),
+    updatedAt: reader.readLongOrNull(offsets[186]),
+    useLibass: reader.readBoolOrNull(offsets[187]),
+    useMpvConfig: reader.readBoolOrNull(offsets[188]),
+    usePageTapZones: reader.readBoolOrNull(offsets[189]),
+    useYUV420P: reader.readBoolOrNull(offsets[190]),
+    userAgent: reader.readStringOrNull(offsets[191]),
+    volumeBoostCap: reader.readLongOrNull(offsets[192]),
+    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[193]),
+    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[194]),
+    webtoonSidePadding: reader.readLongOrNull(offsets[195]),
+    zoomStartPosition: reader.readLongOrNull(offsets[196]),
   );
   object.chapterFilterBookmarkedList = reader
       .readObjectList<ChapterFilterBookmarked>(
-        offsets[30],
+        offsets[31],
         ChapterFilterBookmarkedSchema.deserialize,
         allOffsets,
         ChapterFilterBookmarked(),
       );
   object.chapterFilterUnreadList = reader.readObjectList<ChapterFilterUnread>(
-    offsets[32],
+    offsets[33],
     ChapterFilterUnreadSchema.deserialize,
     allOffsets,
     ChapterFilterUnread(),
   );
   object.defaultSubtitleLang = reader.readObjectOrNull<L10nLocale>(
-    offsets[51],
+    offsets[52],
     L10nLocaleSchema.deserialize,
     allOffsets,
   );
   object.filterScanlatorList = reader.readObjectList<FilterScanlator>(
-    offsets[73],
+    offsets[75],
     FilterScanlatorSchema.deserialize,
     allOffsets,
     FilterScanlator(),
   );
   object.locale = reader.readObjectOrNull<L10nLocale>(
-    offsets[119],
+    offsets[121],
     L10nLocaleSchema.deserialize,
     allOffsets,
   );
-  object.novelGridSize = reader.readLongOrNull(offsets[130]);
+  object.novelGridSize = reader.readLongOrNull(offsets[132]);
   return object;
 }
 
@@ -2281,18 +2295,20 @@ P _settingsDeserializeProp<P>(
           ))
           as P;
     case 1:
-      return (reader.readStringOrNull(offset)) as P;
-    case 2:
-      return (reader.readLongOrNull(offset)) as P;
-    case 3:
       return (reader.readBoolOrNull(offset)) as P;
+    case 2:
+      return (reader.readStringOrNull(offset)) as P;
+    case 3:
+      return (reader.readLongOrNull(offset)) as P;
     case 4:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 5:
       return (_SettingsanimeDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.compactGrid)
           as P;
-    case 5:
+    case 6:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2300,10 +2316,8 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 6:
-      return (reader.readLongOrNull(offset)) as P;
     case 7:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 8:
       return (reader.readBoolOrNull(offset)) as P;
     case 9:
@@ -2315,26 +2329,28 @@ P _settingsDeserializeProp<P>(
     case 12:
       return (reader.readBoolOrNull(offset)) as P;
     case 13:
-      return (reader.readStringOrNull(offset)) as P;
-    case 14:
       return (reader.readBoolOrNull(offset)) as P;
+    case 14:
+      return (reader.readStringOrNull(offset)) as P;
     case 15:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 16:
       return (_SettingsaudioChannelsValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               AudioChannel.autoSafe)
           as P;
-    case 16:
-      return (reader.readStringOrNull(offset)) as P;
     case 17:
       return (reader.readStringOrNull(offset)) as P;
     case 18:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 19:
       return (reader.readBoolOrNull(offset)) as P;
     case 20:
       return (reader.readBoolOrNull(offset)) as P;
     case 21:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 22:
       return (reader.readObjectList<AutoScrollPages>(
             offset,
             AutoScrollPagesSchema.deserialize,
@@ -2342,27 +2358,27 @@ P _settingsDeserializeProp<P>(
             AutoScrollPages(),
           ))
           as P;
-    case 22:
-      return (reader.readBoolOrNull(offset)) as P;
     case 23:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 24:
       return (_SettingsbackgroundColorValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               BackgroundColor.black)
           as P;
-    case 24:
-      return (reader.readLongOrNull(offset)) as P;
     case 25:
       return (reader.readLongOrNull(offset)) as P;
     case 26:
-      return (reader.readLongList(offset)) as P;
-    case 27:
-      return (reader.readStringOrNull(offset)) as P;
-    case 28:
       return (reader.readLongOrNull(offset)) as P;
-    case 29:
+    case 27:
+      return (reader.readLongList(offset)) as P;
+    case 28:
       return (reader.readStringOrNull(offset)) as P;
+    case 29:
+      return (reader.readLongOrNull(offset)) as P;
     case 30:
+      return (reader.readStringOrNull(offset)) as P;
+    case 31:
       return (reader.readObjectList<ChapterFilterBookmarked>(
             offset,
             ChapterFilterBookmarkedSchema.deserialize,
@@ -2370,7 +2386,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterBookmarked(),
           ))
           as P;
-    case 31:
+    case 32:
       return (reader.readObjectList<ChapterFilterDownloaded>(
             offset,
             ChapterFilterDownloadedSchema.deserialize,
@@ -2378,7 +2394,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterDownloaded(),
           ))
           as P;
-    case 32:
+    case 33:
       return (reader.readObjectList<ChapterFilterUnread>(
             offset,
             ChapterFilterUnreadSchema.deserialize,
@@ -2386,7 +2402,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterUnread(),
           ))
           as P;
-    case 33:
+    case 34:
       return (reader.readObjectList<ChapterPageIndex>(
             offset,
             ChapterPageIndexSchema.deserialize,
@@ -2394,7 +2410,7 @@ P _settingsDeserializeProp<P>(
             ChapterPageIndex(),
           ))
           as P;
-    case 34:
+    case 35:
       return (reader.readObjectList<ChapterPageurls>(
             offset,
             ChapterPageurlsSchema.deserialize,
@@ -2402,21 +2418,21 @@ P _settingsDeserializeProp<P>(
             ChapterPageurls(),
           ))
           as P;
-    case 35:
-      return (reader.readBoolOrNull(offset)) as P;
     case 36:
       return (reader.readBoolOrNull(offset)) as P;
     case 37:
       return (reader.readBoolOrNull(offset)) as P;
     case 38:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 39:
       return (_SettingscolorFilterBlendModeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               ColorFilterBlendMode.none)
           as P;
-    case 39:
-      return (reader.readLongOrNull(offset)) as P;
     case 40:
+      return (reader.readLongOrNull(offset)) as P;
+    case 41:
       return (reader.readObjectList<MCookie>(
             offset,
             MCookieSchema.deserialize,
@@ -2424,70 +2440,68 @@ P _settingsDeserializeProp<P>(
             MCookie(),
           ))
           as P;
-    case 41:
-      return (reader.readBoolOrNull(offset)) as P;
     case 42:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 43:
       return (reader.readObjectOrNull<CustomColorFilter>(
             offset,
             CustomColorFilterSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 43:
-      return (reader.readStringOrNull(offset)) as P;
     case 44:
       return (reader.readStringOrNull(offset)) as P;
     case 45:
       return (reader.readStringOrNull(offset)) as P;
     case 46:
+      return (reader.readStringOrNull(offset)) as P;
+    case 47:
       return (_SettingsdebandingTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DebandingType.none)
           as P;
-    case 47:
-      return (reader.readLongOrNull(offset)) as P;
     case 48:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 49:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 50:
       return (_SettingsdefaultReaderModeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               ReaderMode.vertical)
           as P;
-    case 50:
-      return (reader.readLongOrNull(offset)) as P;
     case 51:
+      return (reader.readLongOrNull(offset)) as P;
+    case 52:
       return (reader.readObjectOrNull<L10nLocale>(
             offset,
             L10nLocaleSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 52:
-      return (reader.readBoolOrNull(offset)) as P;
     case 53:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 54:
       return (_SettingsdisableSectionTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               SectionType.all)
           as P;
-    case 54:
+    case 55:
       return (_SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offset)] ??
               DisplayType.compactGrid)
           as P;
-    case 55:
-      return (reader.readBoolOrNull(offset)) as P;
     case 56:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 57:
       return (reader.readLongOrNull(offset)) as P;
     case 58:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 59:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 60:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 61:
       return (reader.readBoolOrNull(offset)) as P;
     case 62:
@@ -2511,8 +2525,12 @@ P _settingsDeserializeProp<P>(
     case 71:
       return (reader.readBoolOrNull(offset)) as P;
     case 72:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 73:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 74:
+      return (reader.readStringOrNull(offset)) as P;
+    case 75:
       return (reader.readObjectList<FilterScanlator>(
             offset,
             FilterScanlatorSchema.deserialize,
@@ -2520,22 +2538,18 @@ P _settingsDeserializeProp<P>(
             FilterScanlator(),
           ))
           as P;
-    case 74:
-      return (reader.readLongOrNull(offset)) as P;
-    case 75:
-      return (reader.readLongOrNull(offset)) as P;
     case 76:
       return (reader.readLongOrNull(offset)) as P;
     case 77:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 78:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 79:
       return (reader.readLongOrNull(offset)) as P;
+    case 78:
+      return (reader.readLongOrNull(offset)) as P;
+    case 79:
+      return (reader.readBoolOrNull(offset)) as P;
     case 80:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 81:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 82:
       return (reader.readBoolOrNull(offset)) as P;
     case 83:
@@ -2545,27 +2559,27 @@ P _settingsDeserializeProp<P>(
     case 85:
       return (reader.readBoolOrNull(offset)) as P;
     case 86:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 87:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 88:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringList(offset)) as P;
     case 89:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 90:
       return (reader.readStringOrNull(offset)) as P;
+    case 90:
+      return (reader.readBoolOrNull(offset)) as P;
     case 91:
       return (reader.readBoolOrNull(offset)) as P;
     case 92:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 93:
       return (reader.readStringOrNull(offset)) as P;
+    case 93:
+      return (reader.readBoolOrNull(offset)) as P;
     case 94:
       return (reader.readBoolOrNull(offset)) as P;
     case 95:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 96:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 97:
       return (reader.readLongOrNull(offset)) as P;
     case 98:
@@ -2599,9 +2613,9 @@ P _settingsDeserializeProp<P>(
     case 112:
       return (reader.readLongOrNull(offset)) as P;
     case 113:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 114:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 115:
       return (reader.readBoolOrNull(offset)) as P;
     case 116:
@@ -2609,15 +2623,19 @@ P _settingsDeserializeProp<P>(
     case 117:
       return (reader.readBoolOrNull(offset)) as P;
     case 118:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 119:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 120:
+      return (reader.readStringList(offset)) as P;
+    case 121:
       return (reader.readObjectOrNull<L10nLocale>(
             offset,
             L10nLocaleSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 120:
+    case 122:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2625,29 +2643,29 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 121:
+    case 123:
       return (reader.readLongOrNull(offset)) as P;
-    case 122:
+    case 124:
       return (_SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 123:
-      return (reader.readLongOrNull(offset)) as P;
-    case 124:
-      return (reader.readBoolOrNull(offset)) as P;
     case 125:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 126:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 127:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 128:
+      return (reader.readStringList(offset)) as P;
+    case 129:
       return (_SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 128:
+    case 130:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2655,14 +2673,10 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 129:
-      return (reader.readLongOrNull(offset)) as P;
-    case 130:
-      return (reader.readLongOrNull(offset)) as P;
     case 131:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 132:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 133:
       return (reader.readBoolOrNull(offset)) as P;
     case 134:
@@ -2672,30 +2686,34 @@ P _settingsDeserializeProp<P>(
     case 136:
       return (reader.readBoolOrNull(offset)) as P;
     case 137:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 138:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 139:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 140:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 141:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 142:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 143:
       return (reader.readBoolOrNull(offset)) as P;
     case 144:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 145:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 146:
       return (_SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               NovelTextAlign.left)
           as P;
-    case 145:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 146:
-      return (reader.readLongOrNull(offset)) as P;
     case 147:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 148:
+      return (reader.readLongOrNull(offset)) as P;
+    case 149:
       return (reader.readObjectList<PersonalPageMode>(
             offset,
             PersonalPageModeSchema.deserialize,
@@ -2703,7 +2721,7 @@ P _settingsDeserializeProp<P>(
             PersonalPageMode(),
           ))
           as P;
-    case 148:
+    case 150:
       return (reader.readObjectList<PersonalReaderMode>(
             offset,
             PersonalReaderModeSchema.deserialize,
@@ -2711,67 +2729,53 @@ P _settingsDeserializeProp<P>(
             PersonalReaderMode(),
           ))
           as P;
-    case 149:
+    case 151:
       return (reader.readObjectOrNull<PlayerSubtitleSettings>(
             offset,
             PlayerSubtitleSettingsSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 150:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 151:
-      return (reader.readDoubleOrNull(offset)) as P;
     case 152:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 153:
-      return (reader.readLongOrNull(offset)) as P;
-    case 154:
-      return (reader.readLongOrNull(offset)) as P;
-    case 155:
       return (reader.readDoubleOrNull(offset)) as P;
+    case 154:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 155:
+      return (reader.readLongOrNull(offset)) as P;
     case 156:
       return (reader.readLongOrNull(offset)) as P;
     case 157:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 158:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 159:
       return (reader.readBoolOrNull(offset)) as P;
     case 160:
       return (reader.readBoolOrNull(offset)) as P;
     case 161:
-      return (_SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offset)] ??
-              ScaleType.fitScreen)
-          as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 162:
       return (reader.readBoolOrNull(offset)) as P;
     case 163:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (_SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offset)] ??
+              ScaleType.fitScreen)
+          as P;
     case 164:
       return (reader.readBoolOrNull(offset)) as P;
     case 165:
       return (reader.readBoolOrNull(offset)) as P;
     case 166:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 167:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 168:
       return (reader.readObjectList<SortChapter>(
             offset,
             SortChapterSchema.deserialize,
             allOffsets,
             SortChapter(),
-          ))
-          as P;
-    case 167:
-      return (reader.readObjectOrNull<SortLibraryManga>(
-            offset,
-            SortLibraryMangaSchema.deserialize,
-            allOffsets,
-          ))
-          as P;
-    case 168:
-      return (reader.readObjectOrNull<SortLibraryManga>(
-            offset,
-            SortLibraryMangaSchema.deserialize,
-            allOffsets,
           ))
           as P;
     case 169:
@@ -2782,30 +2786,44 @@ P _settingsDeserializeProp<P>(
           ))
           as P;
     case 170:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readObjectOrNull<SortLibraryManga>(
+            offset,
+            SortLibraryMangaSchema.deserialize,
+            allOffsets,
+          ))
+          as P;
     case 171:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readObjectOrNull<SortLibraryManga>(
+            offset,
+            SortLibraryMangaSchema.deserialize,
+            allOffsets,
+          ))
+          as P;
     case 172:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 173:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 174:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 175:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 176:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 177:
       return (reader.readStringOrNull(offset)) as P;
+    case 177:
+      return (reader.readDoubleOrNull(offset)) as P;
     case 178:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 179:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 180:
       return (reader.readBoolOrNull(offset)) as P;
     case 181:
       return (reader.readBoolOrNull(offset)) as P;
     case 182:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 183:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 184:
       return (reader.readObjectList<UpdateError>(
             offset,
             UpdateErrorSchema.deserialize,
@@ -2813,29 +2831,29 @@ P _settingsDeserializeProp<P>(
             UpdateError(),
           ))
           as P;
-    case 183:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 184:
-      return (reader.readLongOrNull(offset)) as P;
     case 185:
       return (reader.readBoolOrNull(offset)) as P;
     case 186:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 187:
       return (reader.readBoolOrNull(offset)) as P;
     case 188:
       return (reader.readBoolOrNull(offset)) as P;
     case 189:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 190:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 191:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 192:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 193:
       return (reader.readLongOrNull(offset)) as P;
+    case 193:
+      return (reader.readBoolOrNull(offset)) as P;
     case 194:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 195:
+      return (reader.readLongOrNull(offset)) as P;
+    case 196:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -3116,6 +3134,36 @@ extension SettingsQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(
         const FilterCondition.isNotNull(property: r'algorithmWeights'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  allowConcurrentDownloadsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'allowConcurrentDownloads'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  allowConcurrentDownloadsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'allowConcurrentDownloads'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  allowConcurrentDownloadsEqualTo(bool? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'allowConcurrentDownloads',
+          value: value,
+        ),
       );
     });
   }
@@ -7284,6 +7332,82 @@ extension SettingsQueryFilter
       return query.addFilterCondition(
         FilterCondition.between(
           property: r'doubleTapAnimationSpeed',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'downloadDelaySeconds'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'downloadDelaySeconds'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsEqualTo(int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'downloadDelaySeconds',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsGreaterThan(int? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'downloadDelaySeconds',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsLessThan(int? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'downloadDelaySeconds',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'downloadDelaySeconds',
           lower: lower,
           includeLower: includeLower,
           upper: upper,
@@ -16172,6 +16296,20 @@ extension SettingsQueryLinks
 }
 
 extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  sortByAllowConcurrentDownloads() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'allowConcurrentDownloads', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  sortByAllowConcurrentDownloadsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'allowConcurrentDownloads', Sort.desc);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterSortBy> sortByAndroidProxyServer() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'androidProxyServer', Sort.asc);
@@ -16770,6 +16908,19 @@ extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
   sortByDoubleTapAnimationSpeedDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'doubleTapAnimationSpeed', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByDownloadDelaySeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'downloadDelaySeconds', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  sortByDownloadDelaySecondsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'downloadDelaySeconds', Sort.desc);
     });
   }
 
@@ -18352,6 +18503,20 @@ extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
 
 extension SettingsQuerySortThenBy
     on QueryBuilder<Settings, Settings, QSortThenBy> {
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  thenByAllowConcurrentDownloads() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'allowConcurrentDownloads', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  thenByAllowConcurrentDownloadsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'allowConcurrentDownloads', Sort.desc);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterSortBy> thenByAndroidProxyServer() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'androidProxyServer', Sort.asc);
@@ -18950,6 +19115,19 @@ extension SettingsQuerySortThenBy
   thenByDoubleTapAnimationSpeedDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'doubleTapAnimationSpeed', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByDownloadDelaySeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'downloadDelaySeconds', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  thenByDownloadDelaySecondsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'downloadDelaySeconds', Sort.desc);
     });
   }
 
@@ -20544,6 +20722,13 @@ extension SettingsQuerySortThenBy
 
 extension SettingsQueryWhereDistinct
     on QueryBuilder<Settings, Settings, QDistinct> {
+  QueryBuilder<Settings, Settings, QDistinct>
+  distinctByAllowConcurrentDownloads() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'allowConcurrentDownloads');
+    });
+  }
+
   QueryBuilder<Settings, Settings, QDistinct> distinctByAndroidProxyServer({
     bool caseSensitive = true,
   }) {
@@ -20871,6 +21056,12 @@ extension SettingsQueryWhereDistinct
   distinctByDoubleTapAnimationSpeed() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'doubleTapAnimationSpeed');
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QDistinct> distinctByDownloadDelaySeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'downloadDelaySeconds');
     });
   }
 
@@ -21720,6 +21911,13 @@ extension SettingsQueryProperty
     });
   }
 
+  QueryBuilder<Settings, bool?, QQueryOperations>
+  allowConcurrentDownloadsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'allowConcurrentDownloads');
+    });
+  }
+
   QueryBuilder<Settings, String?, QQueryOperations>
   androidProxyServerProperty() {
     return QueryBuilder.apply(this, (query) {
@@ -22100,6 +22298,13 @@ extension SettingsQueryProperty
   doubleTapAnimationSpeedProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'doubleTapAnimationSpeed');
+    });
+  }
+
+  QueryBuilder<Settings, int?, QQueryOperations>
+  downloadDelaySecondsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'downloadDelaySeconds');
     });
   }
 

--- a/lib/modules/manga/download/download_page_widget.dart
+++ b/lib/modules/manga/download/download_page_widget.dart
@@ -179,10 +179,10 @@ class ChapterPageDownload extends ConsumerWidget {
                           }
                         },
                         itemBuilder: (context) => [
-                          PopupMenuItem(
-                            value: 1,
-                            child: Text(l10n.start_downloading),
-                          ),
+                          // This download already has progress, so the action is
+                          // a restart, not a start — label it Retry (matches the
+                          // stalled/no-progress state below).
+                          PopupMenuItem(value: 1, child: Text(l10n.retry)),
                           PopupMenuItem(value: 0, child: Text(l10n.cancel)),
                         ],
                       ),

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 import 'dart:io';
 import 'dart:ui';
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -446,6 +447,17 @@ Future<void> downloadChapter(
   }
 }
 
+/// Delay before starting the next queued download. With rate limiting off
+/// ([baseSeconds] 0) this is just the small default gap. Otherwise it is the
+/// chosen base plus 25% to 100% random jitter, spacing requests out and varying
+/// them so a source is less likely to IP-block or wear a plugin out. See #621.
+Duration _downloadStartDelay(int baseSeconds) {
+  if (baseSeconds <= 0) return const Duration(milliseconds: 500);
+  final base = baseSeconds * 1000;
+  final jitter = (base * (0.25 + Random().nextDouble() * 0.75)).round();
+  return Duration(milliseconds: base + jitter);
+}
+
 @riverpod
 Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
   final keepAlive = ref.keepAlive();
@@ -456,7 +468,12 @@ Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
         .isDownloadEqualTo(false)
         .isStartDownloadEqualTo(true)
         .findAll();
-    final maxConcurrentDownloads = ref.read(concurrentDownloadsStateProvider);
+    // When concurrent downloads are disabled, run them one at a time.
+    final allowConcurrent = ref.read(allowConcurrentDownloadsStateProvider);
+    final maxConcurrentDownloads = allowConcurrent
+        ? ref.read(concurrentDownloadsStateProvider)
+        : 1;
+    final delaySeconds = ref.read(downloadDelaySecondsStateProvider);
     int index = 0;
     int downloaded = 0;
     int current = 0;
@@ -470,7 +487,7 @@ Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
         final downloadItem = ongoingDownloads[index++];
         final chapter = downloadItem.chapter.value!;
         chapter.cancelDownloads(downloadItem.id);
-        await Future.delayed(const Duration(milliseconds: 500));
+        await Future.delayed(_downloadStartDelay(delaySeconds));
         ref.read(
           downloadChapterProvider(
             chapter: chapter,

--- a/lib/modules/more/settings/downloads/downloads_screen.dart
+++ b/lib/modules/more/settings/downloads/downloads_screen.dart
@@ -25,6 +25,10 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen> {
     );
     final onlyOnWifiState = ref.watch(onlyOnWifiStateProvider);
     final concurrentDownloads = ref.watch(concurrentDownloadsStateProvider);
+    final allowConcurrentDownloads = ref.watch(
+      allowConcurrentDownloadsStateProvider,
+    );
+    final downloadDelaySeconds = ref.watch(downloadDelaySecondsStateProvider);
     final localFolders = ref.watch(localFoldersStateProvider);
     final l10n = l10nLocalizations(context);
     return Scaffold(
@@ -56,14 +60,94 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen> {
                     .set(value);
               },
             ),
+            SwitchListTile(
+              value: allowConcurrentDownloads,
+              title: Text(l10n.allow_concurrent_downloads),
+              subtitle: Text(l10n.allow_concurrent_downloads_subtitle),
+              onChanged: (value) {
+                ref
+                    .read(allowConcurrentDownloadsStateProvider.notifier)
+                    .set(value);
+              },
+            ),
+            if (allowConcurrentDownloads)
+              ListTile(
+                onTap: () {
+                  int currentIntValue = concurrentDownloads;
+                  showDialog(
+                    context: context,
+                    builder: (context) {
+                      return AlertDialog(
+                        title: Text(context.l10n.concurrent_downloads),
+                        content: StatefulBuilder(
+                          builder: (context, setState) => SizedBox(
+                            height: 200,
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                NumberPicker(
+                                  value: currentIntValue,
+                                  minValue: 1,
+                                  maxValue: 255,
+                                  step: 1,
+                                  haptics: true,
+                                  textMapper: (numberText) => numberText,
+                                  onChanged: (value) =>
+                                      setState(() => currentIntValue = value),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                        actions: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: [
+                              TextButton(
+                                onPressed: () async {
+                                  Navigator.pop(context);
+                                },
+                                child: Text(
+                                  context.l10n.cancel,
+                                  style: TextStyle(color: context.primaryColor),
+                                ),
+                              ),
+                              TextButton(
+                                onPressed: () async {
+                                  ref
+                                      .read(
+                                        concurrentDownloadsStateProvider
+                                            .notifier,
+                                      )
+                                      .set(currentIntValue);
+                                  Navigator.pop(context);
+                                },
+                                child: Text(
+                                  context.l10n.ok,
+                                  style: TextStyle(color: context.primaryColor),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
+                title: Text(context.l10n.concurrent_downloads),
+                subtitle: Text(
+                  "$concurrentDownloads",
+                  style: TextStyle(fontSize: 11, color: context.secondaryColor),
+                ),
+              ),
             ListTile(
               onTap: () {
-                int currentIntValue = concurrentDownloads;
+                int currentDelay = downloadDelaySeconds;
                 showDialog(
                   context: context,
                   builder: (context) {
                     return AlertDialog(
-                      title: Text(context.l10n.concurrent_downloads),
+                      title: Text(context.l10n.download_delay),
                       content: StatefulBuilder(
                         builder: (context, setState) => SizedBox(
                           height: 200,
@@ -71,14 +155,14 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               NumberPicker(
-                                value: currentIntValue,
-                                minValue: 1,
-                                maxValue: 255,
+                                value: currentDelay,
+                                minValue: 0,
+                                maxValue: 120,
                                 step: 1,
                                 haptics: true,
                                 textMapper: (numberText) => numberText,
                                 onChanged: (value) =>
-                                    setState(() => currentIntValue = value),
+                                    setState(() => currentDelay = value),
                               ),
                             ],
                           ),
@@ -89,21 +173,20 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen> {
                           mainAxisAlignment: MainAxisAlignment.end,
                           children: [
                             TextButton(
-                              onPressed: () async {
-                                Navigator.pop(context);
-                              },
+                              onPressed: () => Navigator.pop(context),
                               child: Text(
                                 context.l10n.cancel,
                                 style: TextStyle(color: context.primaryColor),
                               ),
                             ),
                             TextButton(
-                              onPressed: () async {
+                              onPressed: () {
                                 ref
                                     .read(
-                                      concurrentDownloadsStateProvider.notifier,
+                                      downloadDelaySecondsStateProvider
+                                          .notifier,
                                     )
-                                    .set(currentIntValue);
+                                    .set(currentDelay);
                                 Navigator.pop(context);
                               },
                               child: Text(
@@ -118,9 +201,11 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen> {
                   },
                 );
               },
-              title: Text(context.l10n.concurrent_downloads),
+              title: Text(context.l10n.download_delay),
               subtitle: Text(
-                "$concurrentDownloads",
+                downloadDelaySeconds == 0
+                    ? l10n.download_delay_subtitle
+                    : "$downloadDelaySeconds s (+ jitter)",
                 style: TextStyle(fontSize: 11, color: context.secondaryColor),
               ),
             ),

--- a/lib/modules/more/settings/downloads/providers/downloads_state_provider.dart
+++ b/lib/modules/more/settings/downloads/providers/downloads_state_provider.dart
@@ -118,3 +118,43 @@ class ConcurrentDownloadsState extends _$ConcurrentDownloadsState {
     );
   }
 }
+
+@riverpod
+class AllowConcurrentDownloadsState extends _$AllowConcurrentDownloadsState {
+  @override
+  bool build() {
+    return isar.settings.getSync(227)!.allowConcurrentDownloads ?? true;
+  }
+
+  void set(bool value) {
+    final settings = isar.settings.getSync(227);
+    state = value;
+    isar.writeTxnSync(
+      () => isar.settings.putSync(
+        settings!
+          ..allowConcurrentDownloads = value
+          ..updatedAt = DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+}
+
+@riverpod
+class DownloadDelaySecondsState extends _$DownloadDelaySecondsState {
+  @override
+  int build() {
+    return isar.settings.getSync(227)!.downloadDelaySeconds ?? 0;
+  }
+
+  void set(int value) {
+    final settings = isar.settings.getSync(227);
+    state = value;
+    isar.writeTxnSync(
+      () => isar.settings.putSync(
+        settings!
+          ..downloadDelaySeconds = value
+          ..updatedAt = DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+}

--- a/lib/modules/more/settings/downloads/providers/downloads_state_provider.g.dart
+++ b/lib/modules/more/settings/downloads/providers/downloads_state_provider.g.dart
@@ -273,3 +273,110 @@ abstract class _$ConcurrentDownloadsState extends $Notifier<int> {
     element.handleCreate(ref, build);
   }
 }
+
+@ProviderFor(AllowConcurrentDownloadsState)
+final allowConcurrentDownloadsStateProvider =
+    AllowConcurrentDownloadsStateProvider._();
+
+final class AllowConcurrentDownloadsStateProvider
+    extends $NotifierProvider<AllowConcurrentDownloadsState, bool> {
+  AllowConcurrentDownloadsStateProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'allowConcurrentDownloadsStateProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$allowConcurrentDownloadsStateHash();
+
+  @$internal
+  @override
+  AllowConcurrentDownloadsState create() => AllowConcurrentDownloadsState();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$allowConcurrentDownloadsStateHash() =>
+    r'2d71d79e343a17be62684c9b5b99539243519754';
+
+abstract class _$AllowConcurrentDownloadsState extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+@ProviderFor(DownloadDelaySecondsState)
+final downloadDelaySecondsStateProvider = DownloadDelaySecondsStateProvider._();
+
+final class DownloadDelaySecondsStateProvider
+    extends $NotifierProvider<DownloadDelaySecondsState, int> {
+  DownloadDelaySecondsStateProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'downloadDelaySecondsStateProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$downloadDelaySecondsStateHash();
+
+  @$internal
+  @override
+  DownloadDelaySecondsState create() => DownloadDelaySecondsState();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(int value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<int>(value),
+    );
+  }
+}
+
+String _$downloadDelaySecondsStateHash() =>
+    r'eb97bd41f669e2e1bd27ca32a98b1a470f3d50c4';
+
+abstract class _$DownloadDelaySecondsState extends $Notifier<int> {
+  int build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<int, int>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<int, int>,
+              int,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}


### PR DESCRIPTION
Adds two download controls under Settings > Downloads.

## Allow concurrent downloads (default on)
Turning it off runs downloads one at a time (concurrency forced to 1). Steadier, and avoids the connection stalls that get worse with many parallel connections. The concurrent-count picker is hidden when off.

## Download delay (default off, closes #621)
An opt-in per-chapter wait before starting the next queued download, with 25 to 100 percent random jitter on top. Spacing and varying requests makes a source less likely to IP-block the user or wear a plugin out (the motivation in #621). Implemented as a user control (0 to 120s) rather than a forced hidden delay, so it never slows anyone who hasn't asked for it.

New settings persist on the Isar Settings collection. No behaviour change unless the user flips them.
