### PR TITLE
feat(downloads): stall/truncation/resume fixes + concurrency and rate controls (#621)

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -903,7 +903,7 @@
   "reader_hide_threshold_lowest": "Lowest (47 px)",
   "error_no_pages_available": "Error: no pages available",
   "allow_concurrent_downloads": "Allow concurrent downloads",
-  "allow_concurrent_downloads_subtitle": "Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.",
+  "allow_concurrent_downloads_subtitle": "Download from different sources at the same time. A single source still downloads one chapter at a time so it isn't overloaded. Turn off to download one at a time everywhere.",
   "download_delay": "Download delay",
   "download_delay_subtitle": "Off. Add a wait with random jitter between chapters to be gentler on sources."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -901,5 +901,9 @@
   "reader_hide_threshold_high": "High (13 px)",
   "reader_hide_threshold_low": "Low (31 px)",
   "reader_hide_threshold_lowest": "Lowest (47 px)",
-  "error_no_pages_available": "Error: no pages available"
+  "error_no_pages_available": "Error: no pages available",
+  "allow_concurrent_downloads": "Allow concurrent downloads",
+  "allow_concurrent_downloads_subtitle": "Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.",
+  "download_delay": "Download delay",
+  "download_delay_subtitle": "Off. Add a wait with random jitter between chapters to be gentler on sources."
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -4556,7 +4556,7 @@ abstract class AppLocalizations {
   /// No description provided for @allow_concurrent_downloads_subtitle.
   ///
   /// In en, this message translates to:
-  /// **'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.'**
+  /// **'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.'**
   String get allow_concurrent_downloads_subtitle;
 
   /// No description provided for @download_delay.

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -4546,6 +4546,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Error: no pages available'**
   String get error_no_pages_available;
+
+  /// No description provided for @allow_concurrent_downloads.
+  ///
+  /// In en, this message translates to:
+  /// **'Allow concurrent downloads'**
+  String get allow_concurrent_downloads;
+
+  /// No description provided for @allow_concurrent_downloads_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.'**
+  String get allow_concurrent_downloads_subtitle;
+
+  /// No description provided for @download_delay.
+  ///
+  /// In en, this message translates to:
+  /// **'Download delay'**
+  String get download_delay;
+
+  /// No description provided for @download_delay_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Off. Add a wait with random jitter between chapters to be gentler on sources.'**
+  String get download_delay_subtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -2462,7 +2462,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -2456,4 +2456,18 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'خطأ: لا توجد صفحات متاحة';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -2456,4 +2456,18 @@ class AppLocalizationsAs extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Error: no pages available';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -2462,7 +2462,7 @@ class AppLocalizationsAs extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -2471,4 +2471,18 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Fehler: Keine Seiten verfügbar';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -2477,7 +2477,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -2455,7 +2455,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -2449,4 +2449,18 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Error: no pages available';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -2481,6 +2481,20 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Error: no hay páginas disponibles';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -2487,7 +2487,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -2487,7 +2487,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -2481,4 +2481,18 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Erreur : aucune page disponible';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -2454,4 +2454,18 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'त्रुटि: कोई पन्ने उपलब्ध नहीं हैं';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -2460,7 +2460,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -2460,4 +2460,18 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get error_no_pages_available =>
       'Kesalahan: tidak ada halaman tersedia';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -2466,7 +2466,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -2482,4 +2482,18 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Errore: nessuna pagina disponibile';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -2488,7 +2488,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -2418,4 +2418,18 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'エラー：利用可能なページがありません';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -2424,7 +2424,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -2476,6 +2476,20 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Erro: nenhuma página disponível';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -2482,7 +2482,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -2491,4 +2491,18 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Ошибка: нет доступных страниц';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -2497,7 +2497,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -2457,7 +2457,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -2451,4 +2451,18 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get error_no_pages_available =>
       'เกิดข้อผิดพลาด: ไม่มีหน้าที่พร้อมใช้งาน';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -2463,4 +2463,18 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get error_no_pages_available => 'Hata: kullanılabilir sayfa yok';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -2469,7 +2469,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2380,4 +2380,18 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get error_no_pages_available => '错误：无可用页面';
+
+  @override
+  String get allow_concurrent_downloads => 'Allow concurrent downloads';
+
+  @override
+  String get allow_concurrent_downloads_subtitle =>
+      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+
+  @override
+  String get download_delay => 'Download delay';
+
+  @override
+  String get download_delay_subtitle =>
+      'Off. Add a wait with random jitter between chapters to be gentler on sources.';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2386,7 +2386,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get allow_concurrent_downloads_subtitle =>
-      'Download several chapters at once. Turn off to download one at a time, which is steadier and less likely to stall.';
+      'Download from different sources at the same time. A single source still downloads one chapter at a time so it isn\'t overloaded. Turn off to download one at a time everywhere.';
 
   @override
   String get download_delay => 'Download delay';

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -90,6 +90,8 @@ class Settings {
   bool? deleteDownloadAfterReading;
 
   int? concurrentDownloads;
+  bool? allowConcurrentDownloads;
+  int? downloadDelaySeconds;
 
   String? downloadLocation;
 
@@ -434,6 +436,8 @@ class Settings {
     this.saveAsCBZArchive = false,
     this.deleteDownloadAfterReading = false,
     this.concurrentDownloads = 2,
+    this.allowConcurrentDownloads = true,
+    this.downloadDelaySeconds = 0,
     this.downloadLocation = "",
     this.cropBorders = false,
     this.libraryLocalSource,
@@ -652,6 +656,8 @@ class Settings {
     downloadLocation = json['downloadLocation'];
     downloadOnlyOnWifi = json['downloadOnlyOnWifi'];
     concurrentDownloads = json['concurrentDownloads'];
+    allowConcurrentDownloads = json['allowConcurrentDownloads'] ?? true;
+    downloadDelaySeconds = json['downloadDelaySeconds'] ?? 0;
     filterScanlatorList = (json['filterScanlatorList'] as List?)
         ?.map((e) => FilterScanlator.fromJson(e))
         .toList();
@@ -940,6 +946,8 @@ class Settings {
     'downloadLocation': downloadLocation,
     'downloadOnlyOnWifi': downloadOnlyOnWifi,
     'concurrentDownloads': concurrentDownloads,
+    'allowConcurrentDownloads': allowConcurrentDownloads,
+    'downloadDelaySeconds': downloadDelaySeconds,
     'filterScanlatorList': filterScanlatorList,
     'flexColorSchemeBlendLevel': flexColorSchemeBlendLevel,
     'flexSchemeColorIndex': flexSchemeColorIndex,

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -92,6 +92,7 @@ class Settings {
   int? concurrentDownloads;
   bool? allowConcurrentDownloads;
   int? downloadDelaySeconds;
+  List<int>? downloadQueueOrder;
 
   String? downloadLocation;
 
@@ -438,6 +439,7 @@ class Settings {
     this.concurrentDownloads = 2,
     this.allowConcurrentDownloads = true,
     this.downloadDelaySeconds = 0,
+    this.downloadQueueOrder,
     this.downloadLocation = "",
     this.cropBorders = false,
     this.libraryLocalSource,
@@ -658,6 +660,7 @@ class Settings {
     concurrentDownloads = json['concurrentDownloads'];
     allowConcurrentDownloads = json['allowConcurrentDownloads'] ?? true;
     downloadDelaySeconds = json['downloadDelaySeconds'] ?? 0;
+    downloadQueueOrder = json['downloadQueueOrder']?.cast<int>();
     filterScanlatorList = (json['filterScanlatorList'] as List?)
         ?.map((e) => FilterScanlator.fromJson(e))
         .toList();
@@ -948,6 +951,7 @@ class Settings {
     'concurrentDownloads': concurrentDownloads,
     'allowConcurrentDownloads': allowConcurrentDownloads,
     'downloadDelaySeconds': downloadDelaySeconds,
+    'downloadQueueOrder': downloadQueueOrder,
     'filterScanlatorList': filterScanlatorList,
     'flexColorSchemeBlendLevel': flexColorSchemeBlendLevel,
     'flexSchemeColorIndex': flexSchemeColorIndex,

--- a/lib/models/settings.g.dart
+++ b/lib/models/settings.g.dart
@@ -24,1025 +24,1035 @@ const SettingsSchema = CollectionSchema(
 
       target: r'AlgorithmWeights',
     ),
-    r'androidProxyServer': PropertySchema(
+    r'allowConcurrentDownloads': PropertySchema(
       id: 1,
+      name: r'allowConcurrentDownloads',
+      type: IsarType.bool,
+    ),
+    r'androidProxyServer': PropertySchema(
+      id: 2,
       name: r'androidProxyServer',
       type: IsarType.string,
     ),
     r'aniSkipTimeoutLength': PropertySchema(
-      id: 2,
+      id: 3,
       name: r'aniSkipTimeoutLength',
       type: IsarType.long,
     ),
     r'animatePageTransitions': PropertySchema(
-      id: 3,
+      id: 4,
       name: r'animatePageTransitions',
       type: IsarType.bool,
     ),
     r'animeDisplayType': PropertySchema(
-      id: 4,
+      id: 5,
       name: r'animeDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsanimeDisplayTypeEnumValueMap,
     ),
     r'animeExtensionsRepo': PropertySchema(
-      id: 5,
+      id: 6,
       name: r'animeExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'animeGridSize': PropertySchema(
-      id: 6,
+      id: 7,
       name: r'animeGridSize',
       type: IsarType.long,
     ),
     r'animeLibraryDownloadedChapters': PropertySchema(
-      id: 7,
+      id: 8,
       name: r'animeLibraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'animeLibraryLocalSource': PropertySchema(
-      id: 8,
+      id: 9,
       name: r'animeLibraryLocalSource',
       type: IsarType.bool,
     ),
     r'animeLibraryShowCategoryTabs': PropertySchema(
-      id: 9,
+      id: 10,
       name: r'animeLibraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'animeLibraryShowContinueReadingButton': PropertySchema(
-      id: 10,
+      id: 11,
       name: r'animeLibraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'animeLibraryShowLanguage': PropertySchema(
-      id: 11,
+      id: 12,
       name: r'animeLibraryShowLanguage',
       type: IsarType.bool,
     ),
     r'animeLibraryShowNumbersOfItems': PropertySchema(
-      id: 12,
+      id: 13,
       name: r'animeLibraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'appFontFamily': PropertySchema(
-      id: 13,
+      id: 14,
       name: r'appFontFamily',
       type: IsarType.string,
     ),
     r'appLockEnabled': PropertySchema(
-      id: 14,
+      id: 15,
       name: r'appLockEnabled',
       type: IsarType.bool,
     ),
     r'audioChannels': PropertySchema(
-      id: 15,
+      id: 16,
       name: r'audioChannels',
       type: IsarType.byte,
       enumMap: _SettingsaudioChannelsEnumValueMap,
     ),
     r'audioPreferredLanguages': PropertySchema(
-      id: 16,
+      id: 17,
       name: r'audioPreferredLanguages',
       type: IsarType.string,
     ),
     r'autoBackupLocation': PropertySchema(
-      id: 17,
+      id: 18,
       name: r'autoBackupLocation',
       type: IsarType.string,
     ),
     r'autoExtensionsUpdates': PropertySchema(
-      id: 18,
+      id: 19,
       name: r'autoExtensionsUpdates',
       type: IsarType.bool,
     ),
     r'autoPlayNextEpisode': PropertySchema(
-      id: 19,
+      id: 20,
       name: r'autoPlayNextEpisode',
       type: IsarType.bool,
     ),
     r'autoReadDuplicateChapters': PropertySchema(
-      id: 20,
+      id: 21,
       name: r'autoReadDuplicateChapters',
       type: IsarType.bool,
     ),
     r'autoScrollPages': PropertySchema(
-      id: 21,
+      id: 22,
       name: r'autoScrollPages',
       type: IsarType.objectList,
 
       target: r'AutoScrollPages',
     ),
     r'automaticBackground': PropertySchema(
-      id: 22,
+      id: 23,
       name: r'automaticBackground',
       type: IsarType.bool,
     ),
     r'backgroundColor': PropertySchema(
-      id: 23,
+      id: 24,
       name: r'backgroundColor',
       type: IsarType.byte,
       enumMap: _SettingsbackgroundColorEnumValueMap,
     ),
     r'backupCompressionLevel': PropertySchema(
-      id: 24,
+      id: 25,
       name: r'backupCompressionLevel',
       type: IsarType.long,
     ),
     r'backupFrequency': PropertySchema(
-      id: 25,
+      id: 26,
       name: r'backupFrequency',
       type: IsarType.long,
     ),
     r'backupListOptions': PropertySchema(
-      id: 26,
+      id: 27,
       name: r'backupListOptions',
       type: IsarType.longList,
     ),
     r'btServerAddress': PropertySchema(
-      id: 27,
+      id: 28,
       name: r'btServerAddress',
       type: IsarType.string,
     ),
     r'btServerPort': PropertySchema(
-      id: 28,
+      id: 29,
       name: r'btServerPort',
       type: IsarType.long,
     ),
     r'cfProxyUrl': PropertySchema(
-      id: 29,
+      id: 30,
       name: r'cfProxyUrl',
       type: IsarType.string,
     ),
     r'chapterFilterBookmarkedList': PropertySchema(
-      id: 30,
+      id: 31,
       name: r'chapterFilterBookmarkedList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterBookmarked',
     ),
     r'chapterFilterDownloadedList': PropertySchema(
-      id: 31,
+      id: 32,
       name: r'chapterFilterDownloadedList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterDownloaded',
     ),
     r'chapterFilterUnreadList': PropertySchema(
-      id: 32,
+      id: 33,
       name: r'chapterFilterUnreadList',
       type: IsarType.objectList,
 
       target: r'ChapterFilterUnread',
     ),
     r'chapterPageIndexList': PropertySchema(
-      id: 33,
+      id: 34,
       name: r'chapterPageIndexList',
       type: IsarType.objectList,
 
       target: r'ChapterPageIndex',
     ),
     r'chapterPageUrlsList': PropertySchema(
-      id: 34,
+      id: 35,
       name: r'chapterPageUrlsList',
       type: IsarType.objectList,
 
       target: r'ChapterPageurls',
     ),
     r'checkForAppUpdates': PropertySchema(
-      id: 35,
+      id: 36,
       name: r'checkForAppUpdates',
       type: IsarType.bool,
     ),
     r'checkForExtensionUpdates': PropertySchema(
-      id: 36,
+      id: 37,
       name: r'checkForExtensionUpdates',
       type: IsarType.bool,
     ),
     r'clearChapterCacheOnAppLaunch': PropertySchema(
-      id: 37,
+      id: 38,
       name: r'clearChapterCacheOnAppLaunch',
       type: IsarType.bool,
     ),
     r'colorFilterBlendMode': PropertySchema(
-      id: 38,
+      id: 39,
       name: r'colorFilterBlendMode',
       type: IsarType.byte,
       enumMap: _SettingscolorFilterBlendModeEnumValueMap,
     ),
     r'concurrentDownloads': PropertySchema(
-      id: 39,
+      id: 40,
       name: r'concurrentDownloads',
       type: IsarType.long,
     ),
     r'cookiesList': PropertySchema(
-      id: 40,
+      id: 41,
       name: r'cookiesList',
       type: IsarType.objectList,
 
       target: r'MCookie',
     ),
     r'cropBorders': PropertySchema(
-      id: 41,
+      id: 42,
       name: r'cropBorders',
       type: IsarType.bool,
     ),
     r'customColorFilter': PropertySchema(
-      id: 42,
+      id: 43,
       name: r'customColorFilter',
       type: IsarType.object,
 
       target: r'CustomColorFilter',
     ),
     r'customDns': PropertySchema(
-      id: 43,
+      id: 44,
       name: r'customDns',
       type: IsarType.string,
     ),
     r'customDohUrl': PropertySchema(
-      id: 44,
+      id: 45,
       name: r'customDohUrl',
       type: IsarType.string,
     ),
     r'dateFormat': PropertySchema(
-      id: 45,
+      id: 46,
       name: r'dateFormat',
       type: IsarType.string,
     ),
     r'debandingType': PropertySchema(
-      id: 46,
+      id: 47,
       name: r'debandingType',
       type: IsarType.byte,
       enumMap: _SettingsdebandingTypeEnumValueMap,
     ),
     r'defaultDoubleTapToSkipLength': PropertySchema(
-      id: 47,
+      id: 48,
       name: r'defaultDoubleTapToSkipLength',
       type: IsarType.long,
     ),
     r'defaultPlayBackSpeed': PropertySchema(
-      id: 48,
+      id: 49,
       name: r'defaultPlayBackSpeed',
       type: IsarType.double,
     ),
     r'defaultReaderMode': PropertySchema(
-      id: 49,
+      id: 50,
       name: r'defaultReaderMode',
       type: IsarType.byte,
       enumMap: _SettingsdefaultReaderModeEnumValueMap,
     ),
     r'defaultSkipIntroLength': PropertySchema(
-      id: 50,
+      id: 51,
       name: r'defaultSkipIntroLength',
       type: IsarType.long,
     ),
     r'defaultSubtitleLang': PropertySchema(
-      id: 51,
+      id: 52,
       name: r'defaultSubtitleLang',
       type: IsarType.object,
 
       target: r'L10nLocale',
     ),
     r'deleteDownloadAfterReading': PropertySchema(
-      id: 52,
+      id: 53,
       name: r'deleteDownloadAfterReading',
       type: IsarType.bool,
     ),
     r'disableSectionType': PropertySchema(
-      id: 53,
+      id: 54,
       name: r'disableSectionType',
       type: IsarType.byte,
       enumMap: _SettingsdisableSectionTypeEnumValueMap,
     ),
     r'displayType': PropertySchema(
-      id: 54,
+      id: 55,
       name: r'displayType',
       type: IsarType.byte,
       enumMap: _SettingsdisplayTypeEnumValueMap,
     ),
     r'doHEnabled': PropertySchema(
-      id: 55,
+      id: 56,
       name: r'doHEnabled',
       type: IsarType.bool,
     ),
     r'doHProviderId': PropertySchema(
-      id: 56,
+      id: 57,
       name: r'doHProviderId',
       type: IsarType.long,
     ),
     r'doubleTapAnimationSpeed': PropertySchema(
-      id: 57,
+      id: 58,
       name: r'doubleTapAnimationSpeed',
       type: IsarType.long,
     ),
+    r'downloadDelaySeconds': PropertySchema(
+      id: 59,
+      name: r'downloadDelaySeconds',
+      type: IsarType.long,
+    ),
     r'downloadLocation': PropertySchema(
-      id: 58,
+      id: 60,
       name: r'downloadLocation',
       type: IsarType.string,
     ),
     r'downloadOnlyOnWifi': PropertySchema(
-      id: 59,
+      id: 61,
       name: r'downloadOnlyOnWifi',
       type: IsarType.bool,
     ),
     r'downloadedOnlyMode': PropertySchema(
-      id: 60,
+      id: 62,
       name: r'downloadedOnlyMode',
       type: IsarType.bool,
     ),
     r'dualPageInvert': PropertySchema(
-      id: 61,
+      id: 63,
       name: r'dualPageInvert',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFit': PropertySchema(
-      id: 62,
+      id: 64,
       name: r'dualPageRotateToFit',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFitInvert': PropertySchema(
-      id: 63,
+      id: 65,
       name: r'dualPageRotateToFitInvert',
       type: IsarType.bool,
     ),
     r'enableAniSkip': PropertySchema(
-      id: 64,
+      id: 66,
       name: r'enableAniSkip',
       type: IsarType.bool,
     ),
     r'enableAudioPitchCorrection': PropertySchema(
-      id: 65,
+      id: 67,
       name: r'enableAudioPitchCorrection',
       type: IsarType.bool,
     ),
     r'enableAutoSkip': PropertySchema(
-      id: 66,
+      id: 68,
       name: r'enableAutoSkip',
       type: IsarType.bool,
     ),
     r'enableCustomColorFilter': PropertySchema(
-      id: 67,
+      id: 69,
       name: r'enableCustomColorFilter',
       type: IsarType.bool,
     ),
     r'enableDiscordRpc': PropertySchema(
-      id: 68,
+      id: 70,
       name: r'enableDiscordRpc',
       type: IsarType.bool,
     ),
     r'enableGpuNext': PropertySchema(
-      id: 69,
+      id: 71,
       name: r'enableGpuNext',
       type: IsarType.bool,
     ),
     r'enableHardwareAcceleration': PropertySchema(
-      id: 70,
+      id: 72,
       name: r'enableHardwareAcceleration',
       type: IsarType.bool,
     ),
     r'enableLogs': PropertySchema(
-      id: 71,
+      id: 73,
       name: r'enableLogs',
       type: IsarType.bool,
     ),
     r'extensionServerPath': PropertySchema(
-      id: 72,
+      id: 74,
       name: r'extensionServerPath',
       type: IsarType.string,
     ),
     r'filterScanlatorList': PropertySchema(
-      id: 73,
+      id: 75,
       name: r'filterScanlatorList',
       type: IsarType.objectList,
 
       target: r'FilterScanlator',
     ),
     r'flashColor': PropertySchema(
-      id: 74,
+      id: 76,
       name: r'flashColor',
       type: IsarType.long,
     ),
     r'flashDuration': PropertySchema(
-      id: 75,
+      id: 77,
       name: r'flashDuration',
       type: IsarType.long,
     ),
     r'flashInterval': PropertySchema(
-      id: 76,
+      id: 78,
       name: r'flashInterval',
       type: IsarType.long,
     ),
     r'flashOnPageChange': PropertySchema(
-      id: 77,
+      id: 79,
       name: r'flashOnPageChange',
       type: IsarType.bool,
     ),
     r'flexColorSchemeBlendLevel': PropertySchema(
-      id: 78,
+      id: 80,
       name: r'flexColorSchemeBlendLevel',
       type: IsarType.double,
     ),
     r'flexSchemeColorIndex': PropertySchema(
-      id: 79,
+      id: 81,
       name: r'flexSchemeColorIndex',
       type: IsarType.long,
     ),
     r'followSystemTheme': PropertySchema(
-      id: 80,
+      id: 82,
       name: r'followSystemTheme',
       type: IsarType.bool,
     ),
     r'forceLandscapePlayer': PropertySchema(
-      id: 81,
+      id: 83,
       name: r'forceLandscapePlayer',
       type: IsarType.bool,
     ),
     r'fullScreenPlayer': PropertySchema(
-      id: 82,
+      id: 84,
       name: r'fullScreenPlayer',
       type: IsarType.bool,
     ),
     r'fullScreenReader': PropertySchema(
-      id: 83,
+      id: 85,
       name: r'fullScreenReader',
       type: IsarType.bool,
     ),
     r'grayscale': PropertySchema(
-      id: 84,
+      id: 86,
       name: r'grayscale',
       type: IsarType.bool,
     ),
     r'hideDiscordRpcInIncognito': PropertySchema(
-      id: 85,
+      id: 87,
       name: r'hideDiscordRpcInIncognito',
       type: IsarType.bool,
     ),
     r'hideItems': PropertySchema(
-      id: 86,
+      id: 88,
       name: r'hideItems',
       type: IsarType.stringList,
     ),
     r'hwdecMode': PropertySchema(
-      id: 87,
+      id: 89,
       name: r'hwdecMode',
       type: IsarType.string,
     ),
     r'incognitoMode': PropertySchema(
-      id: 88,
+      id: 90,
       name: r'incognitoMode',
       type: IsarType.bool,
     ),
     r'invertColors': PropertySchema(
-      id: 89,
+      id: 91,
       name: r'invertColors',
       type: IsarType.bool,
     ),
-    r'jrePath': PropertySchema(id: 90, name: r'jrePath', type: IsarType.string),
+    r'jrePath': PropertySchema(id: 92, name: r'jrePath', type: IsarType.string),
     r'keepScreenOnReader': PropertySchema(
-      id: 91,
+      id: 93,
       name: r'keepScreenOnReader',
       type: IsarType.bool,
     ),
     r'landscapeZoom': PropertySchema(
-      id: 92,
+      id: 94,
       name: r'landscapeZoom',
       type: IsarType.bool,
     ),
     r'lastTrackerLibraryLocation': PropertySchema(
-      id: 93,
+      id: 95,
       name: r'lastTrackerLibraryLocation',
       type: IsarType.string,
     ),
     r'libraryDownloadedChapters': PropertySchema(
-      id: 94,
+      id: 96,
       name: r'libraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'libraryFilterAnimeBookMarkedType': PropertySchema(
-      id: 95,
+      id: 97,
       name: r'libraryFilterAnimeBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeCompletedType': PropertySchema(
-      id: 96,
+      id: 98,
       name: r'libraryFilterAnimeCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeDownloadType': PropertySchema(
-      id: 97,
+      id: 99,
       name: r'libraryFilterAnimeDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeStartedType': PropertySchema(
-      id: 98,
+      id: 100,
       name: r'libraryFilterAnimeStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeTrackingType': PropertySchema(
-      id: 99,
+      id: 101,
       name: r'libraryFilterAnimeTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeUnreadType': PropertySchema(
-      id: 100,
+      id: 102,
       name: r'libraryFilterAnimeUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasBookMarkedType': PropertySchema(
-      id: 101,
+      id: 103,
       name: r'libraryFilterMangasBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasCompletedType': PropertySchema(
-      id: 102,
+      id: 104,
       name: r'libraryFilterMangasCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasDownloadType': PropertySchema(
-      id: 103,
+      id: 105,
       name: r'libraryFilterMangasDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasStartedType': PropertySchema(
-      id: 104,
+      id: 106,
       name: r'libraryFilterMangasStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasTrackingType': PropertySchema(
-      id: 105,
+      id: 107,
       name: r'libraryFilterMangasTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasUnreadType': PropertySchema(
-      id: 106,
+      id: 108,
       name: r'libraryFilterMangasUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelBookMarkedType': PropertySchema(
-      id: 107,
+      id: 109,
       name: r'libraryFilterNovelBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelCompletedType': PropertySchema(
-      id: 108,
+      id: 110,
       name: r'libraryFilterNovelCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelDownloadType': PropertySchema(
-      id: 109,
+      id: 111,
       name: r'libraryFilterNovelDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelStartedType': PropertySchema(
-      id: 110,
+      id: 112,
       name: r'libraryFilterNovelStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelTrackingType': PropertySchema(
-      id: 111,
+      id: 113,
       name: r'libraryFilterNovelTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelUnreadType': PropertySchema(
-      id: 112,
+      id: 114,
       name: r'libraryFilterNovelUnreadType',
       type: IsarType.long,
     ),
     r'libraryLocalSource': PropertySchema(
-      id: 113,
+      id: 115,
       name: r'libraryLocalSource',
       type: IsarType.bool,
     ),
     r'libraryShowCategoryTabs': PropertySchema(
-      id: 114,
+      id: 116,
       name: r'libraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'libraryShowContinueReadingButton': PropertySchema(
-      id: 115,
+      id: 117,
       name: r'libraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'libraryShowLanguage': PropertySchema(
-      id: 116,
+      id: 118,
       name: r'libraryShowLanguage',
       type: IsarType.bool,
     ),
     r'libraryShowNumbersOfItems': PropertySchema(
-      id: 117,
+      id: 119,
       name: r'libraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'localFolders': PropertySchema(
-      id: 118,
+      id: 120,
       name: r'localFolders',
       type: IsarType.stringList,
     ),
     r'locale': PropertySchema(
-      id: 119,
+      id: 121,
       name: r'locale',
       type: IsarType.object,
 
       target: r'L10nLocale',
     ),
     r'mangaExtensionsRepo': PropertySchema(
-      id: 120,
+      id: 122,
       name: r'mangaExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'mangaGridSize': PropertySchema(
-      id: 121,
+      id: 123,
       name: r'mangaGridSize',
       type: IsarType.long,
     ),
     r'mangaHomeDisplayType': PropertySchema(
-      id: 122,
+      id: 124,
       name: r'mangaHomeDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsmangaHomeDisplayTypeEnumValueMap,
     ),
     r'markEpisodeAsSeenType': PropertySchema(
-      id: 123,
+      id: 125,
       name: r'markEpisodeAsSeenType',
       type: IsarType.long,
     ),
     r'mergeLibraryNavMobile': PropertySchema(
-      id: 124,
+      id: 126,
       name: r'mergeLibraryNavMobile',
       type: IsarType.bool,
     ),
     r'navigateToPan': PropertySchema(
-      id: 125,
+      id: 127,
       name: r'navigateToPan',
       type: IsarType.bool,
     ),
     r'navigationOrder': PropertySchema(
-      id: 126,
+      id: 128,
       name: r'navigationOrder',
       type: IsarType.stringList,
     ),
     r'novelDisplayType': PropertySchema(
-      id: 127,
+      id: 129,
       name: r'novelDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsnovelDisplayTypeEnumValueMap,
     ),
     r'novelExtensionsRepo': PropertySchema(
-      id: 128,
+      id: 130,
       name: r'novelExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'novelFontSize': PropertySchema(
-      id: 129,
+      id: 131,
       name: r'novelFontSize',
       type: IsarType.long,
     ),
     r'novelGridSize': PropertySchema(
-      id: 130,
+      id: 132,
       name: r'novelGridSize',
       type: IsarType.long,
     ),
     r'novelLibraryDownloadedChapters': PropertySchema(
-      id: 131,
+      id: 133,
       name: r'novelLibraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'novelLibraryLocalSource': PropertySchema(
-      id: 132,
+      id: 134,
       name: r'novelLibraryLocalSource',
       type: IsarType.bool,
     ),
     r'novelLibraryShowCategoryTabs': PropertySchema(
-      id: 133,
+      id: 135,
       name: r'novelLibraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'novelLibraryShowContinueReadingButton': PropertySchema(
-      id: 134,
+      id: 136,
       name: r'novelLibraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'novelLibraryShowLanguage': PropertySchema(
-      id: 135,
+      id: 137,
       name: r'novelLibraryShowLanguage',
       type: IsarType.bool,
     ),
     r'novelLibraryShowNumbersOfItems': PropertySchema(
-      id: 136,
+      id: 138,
       name: r'novelLibraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'novelReaderLineHeight': PropertySchema(
-      id: 137,
+      id: 139,
       name: r'novelReaderLineHeight',
       type: IsarType.double,
     ),
     r'novelReaderPadding': PropertySchema(
-      id: 138,
+      id: 140,
       name: r'novelReaderPadding',
       type: IsarType.long,
     ),
     r'novelReaderTextColor': PropertySchema(
-      id: 139,
+      id: 141,
       name: r'novelReaderTextColor',
       type: IsarType.string,
     ),
     r'novelReaderTheme': PropertySchema(
-      id: 140,
+      id: 142,
       name: r'novelReaderTheme',
       type: IsarType.string,
     ),
     r'novelRemoveExtraParagraphSpacing': PropertySchema(
-      id: 141,
+      id: 143,
       name: r'novelRemoveExtraParagraphSpacing',
       type: IsarType.bool,
     ),
     r'novelShowScrollPercentage': PropertySchema(
-      id: 142,
+      id: 144,
       name: r'novelShowScrollPercentage',
       type: IsarType.bool,
     ),
     r'novelTapToScroll': PropertySchema(
-      id: 143,
+      id: 145,
       name: r'novelTapToScroll',
       type: IsarType.bool,
     ),
     r'novelTextAlign': PropertySchema(
-      id: 144,
+      id: 146,
       name: r'novelTextAlign',
       type: IsarType.byte,
       enumMap: _SettingsnovelTextAlignEnumValueMap,
     ),
     r'onlyIncludePinnedSources': PropertySchema(
-      id: 145,
+      id: 147,
       name: r'onlyIncludePinnedSources',
       type: IsarType.bool,
     ),
     r'pagePreloadAmount': PropertySchema(
-      id: 146,
+      id: 148,
       name: r'pagePreloadAmount',
       type: IsarType.long,
     ),
     r'personalPageModeList': PropertySchema(
-      id: 147,
+      id: 149,
       name: r'personalPageModeList',
       type: IsarType.objectList,
 
       target: r'PersonalPageMode',
     ),
     r'personalReaderModeList': PropertySchema(
-      id: 148,
+      id: 150,
       name: r'personalReaderModeList',
       type: IsarType.objectList,
 
       target: r'PersonalReaderMode',
     ),
     r'playerSubtitleSettings': PropertySchema(
-      id: 149,
+      id: 151,
       name: r'playerSubtitleSettings',
       type: IsarType.object,
 
       target: r'PlayerSubtitleSettings',
     ),
     r'pureBlackDarkMode': PropertySchema(
-      id: 150,
+      id: 152,
       name: r'pureBlackDarkMode',
       type: IsarType.bool,
     ),
     r'readerBrightness': PropertySchema(
-      id: 151,
+      id: 153,
       name: r'readerBrightness',
       type: IsarType.double,
     ),
     r'readerContrast': PropertySchema(
-      id: 152,
+      id: 154,
       name: r'readerContrast',
       type: IsarType.double,
     ),
     r'readerHideThreshold': PropertySchema(
-      id: 153,
+      id: 155,
       name: r'readerHideThreshold',
       type: IsarType.long,
     ),
     r'readerNavigationLayout': PropertySchema(
-      id: 154,
+      id: 156,
       name: r'readerNavigationLayout',
       type: IsarType.long,
     ),
     r'readerSaturation': PropertySchema(
-      id: 155,
+      id: 157,
       name: r'readerSaturation',
       type: IsarType.double,
     ),
     r'relativeTimesTamps': PropertySchema(
-      id: 156,
+      id: 158,
       name: r'relativeTimesTamps',
       type: IsarType.long,
     ),
     r'rpcShowCoverImage': PropertySchema(
-      id: 157,
+      id: 159,
       name: r'rpcShowCoverImage',
       type: IsarType.bool,
     ),
     r'rpcShowReadingWatchingProgress': PropertySchema(
-      id: 158,
+      id: 160,
       name: r'rpcShowReadingWatchingProgress',
       type: IsarType.bool,
     ),
     r'rpcShowTitle': PropertySchema(
-      id: 159,
+      id: 161,
       name: r'rpcShowTitle',
       type: IsarType.bool,
     ),
     r'saveAsCBZArchive': PropertySchema(
-      id: 160,
+      id: 162,
       name: r'saveAsCBZArchive',
       type: IsarType.bool,
     ),
     r'scaleType': PropertySchema(
-      id: 161,
+      id: 163,
       name: r'scaleType',
       type: IsarType.byte,
       enumMap: _SettingsscaleTypeEnumValueMap,
     ),
     r'showNSFW': PropertySchema(
-      id: 162,
+      id: 164,
       name: r'showNSFW',
       type: IsarType.bool,
     ),
     r'showNavigationOverlayOnStart': PropertySchema(
-      id: 163,
+      id: 165,
       name: r'showNavigationOverlayOnStart',
       type: IsarType.bool,
     ),
     r'showPageGaps': PropertySchema(
-      id: 164,
+      id: 166,
       name: r'showPageGaps',
       type: IsarType.bool,
     ),
     r'showPagesNumber': PropertySchema(
-      id: 165,
+      id: 167,
       name: r'showPagesNumber',
       type: IsarType.bool,
     ),
     r'sortChapterList': PropertySchema(
-      id: 166,
+      id: 168,
       name: r'sortChapterList',
       type: IsarType.objectList,
 
       target: r'SortChapter',
     ),
     r'sortLibraryAnime': PropertySchema(
-      id: 167,
+      id: 169,
       name: r'sortLibraryAnime',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryManga': PropertySchema(
-      id: 168,
+      id: 170,
       name: r'sortLibraryManga',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryNovel': PropertySchema(
-      id: 169,
+      id: 171,
       name: r'sortLibraryNovel',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'splitWidePages': PropertySchema(
-      id: 170,
+      id: 172,
       name: r'splitWidePages',
       type: IsarType.bool,
     ),
     r'startDatebackup': PropertySchema(
-      id: 171,
+      id: 173,
       name: r'startDatebackup',
       type: IsarType.long,
     ),
     r'tappingInversion': PropertySchema(
-      id: 172,
+      id: 174,
       name: r'tappingInversion',
       type: IsarType.long,
     ),
     r'themeIsDark': PropertySchema(
-      id: 173,
+      id: 175,
       name: r'themeIsDark',
       type: IsarType.bool,
     ),
     r'ttsLanguage': PropertySchema(
-      id: 174,
+      id: 176,
       name: r'ttsLanguage',
       type: IsarType.string,
     ),
     r'ttsPitch': PropertySchema(
-      id: 175,
+      id: 177,
       name: r'ttsPitch',
       type: IsarType.double,
     ),
     r'ttsSpeechRate': PropertySchema(
-      id: 176,
+      id: 178,
       name: r'ttsSpeechRate',
       type: IsarType.double,
     ),
     r'ttsVoice': PropertySchema(
-      id: 177,
+      id: 179,
       name: r'ttsVoice',
       type: IsarType.string,
     ),
     r'tvAnimeOnlyOverride': PropertySchema(
-      id: 178,
+      id: 180,
       name: r'tvAnimeOnlyOverride',
       type: IsarType.bool,
     ),
     r'tvHomeGenreRows': PropertySchema(
-      id: 179,
+      id: 181,
       name: r'tvHomeGenreRows',
       type: IsarType.bool,
     ),
     r'tvHomeStyle': PropertySchema(
-      id: 180,
+      id: 182,
       name: r'tvHomeStyle',
       type: IsarType.bool,
     ),
     r'tvPlayerStyle': PropertySchema(
-      id: 181,
+      id: 183,
       name: r'tvPlayerStyle',
       type: IsarType.bool,
     ),
     r'updateErrorsList': PropertySchema(
-      id: 182,
+      id: 184,
       name: r'updateErrorsList',
       type: IsarType.objectList,
 
       target: r'UpdateError',
     ),
     r'updateProgressAfterReading': PropertySchema(
-      id: 183,
+      id: 185,
       name: r'updateProgressAfterReading',
       type: IsarType.bool,
     ),
     r'updatedAt': PropertySchema(
-      id: 184,
+      id: 186,
       name: r'updatedAt',
       type: IsarType.long,
     ),
     r'useLibass': PropertySchema(
-      id: 185,
+      id: 187,
       name: r'useLibass',
       type: IsarType.bool,
     ),
     r'useMpvConfig': PropertySchema(
-      id: 186,
+      id: 188,
       name: r'useMpvConfig',
       type: IsarType.bool,
     ),
     r'usePageTapZones': PropertySchema(
-      id: 187,
+      id: 189,
       name: r'usePageTapZones',
       type: IsarType.bool,
     ),
     r'useYUV420P': PropertySchema(
-      id: 188,
+      id: 190,
       name: r'useYUV420P',
       type: IsarType.bool,
     ),
     r'userAgent': PropertySchema(
-      id: 189,
+      id: 191,
       name: r'userAgent',
       type: IsarType.string,
     ),
     r'volumeBoostCap': PropertySchema(
-      id: 190,
+      id: 192,
       name: r'volumeBoostCap',
       type: IsarType.long,
     ),
     r'webtoonDisableZoomOut': PropertySchema(
-      id: 191,
+      id: 193,
       name: r'webtoonDisableZoomOut',
       type: IsarType.bool,
     ),
     r'webtoonDoubleTapZoomEnabled': PropertySchema(
-      id: 192,
+      id: 194,
       name: r'webtoonDoubleTapZoomEnabled',
       type: IsarType.bool,
     ),
     r'webtoonSidePadding': PropertySchema(
-      id: 193,
+      id: 195,
       name: r'webtoonSidePadding',
       type: IsarType.long,
     ),
     r'zoomStartPosition': PropertySchema(
-      id: 194,
+      id: 196,
       name: r'zoomStartPosition',
       type: IsarType.long,
     ),
@@ -1601,310 +1611,312 @@ void _settingsSerialize(
     AlgorithmWeightsSchema.serialize,
     object.algorithmWeights,
   );
-  writer.writeString(offsets[1], object.androidProxyServer);
-  writer.writeLong(offsets[2], object.aniSkipTimeoutLength);
-  writer.writeBool(offsets[3], object.animatePageTransitions);
-  writer.writeByte(offsets[4], object.animeDisplayType.index);
+  writer.writeBool(offsets[1], object.allowConcurrentDownloads);
+  writer.writeString(offsets[2], object.androidProxyServer);
+  writer.writeLong(offsets[3], object.aniSkipTimeoutLength);
+  writer.writeBool(offsets[4], object.animatePageTransitions);
+  writer.writeByte(offsets[5], object.animeDisplayType.index);
   writer.writeObjectList<Repo>(
-    offsets[5],
+    offsets[6],
     allOffsets,
     RepoSchema.serialize,
     object.animeExtensionsRepo,
   );
-  writer.writeLong(offsets[6], object.animeGridSize);
-  writer.writeBool(offsets[7], object.animeLibraryDownloadedChapters);
-  writer.writeBool(offsets[8], object.animeLibraryLocalSource);
-  writer.writeBool(offsets[9], object.animeLibraryShowCategoryTabs);
-  writer.writeBool(offsets[10], object.animeLibraryShowContinueReadingButton);
-  writer.writeBool(offsets[11], object.animeLibraryShowLanguage);
-  writer.writeBool(offsets[12], object.animeLibraryShowNumbersOfItems);
-  writer.writeString(offsets[13], object.appFontFamily);
-  writer.writeBool(offsets[14], object.appLockEnabled);
-  writer.writeByte(offsets[15], object.audioChannels.index);
-  writer.writeString(offsets[16], object.audioPreferredLanguages);
-  writer.writeString(offsets[17], object.autoBackupLocation);
-  writer.writeBool(offsets[18], object.autoExtensionsUpdates);
-  writer.writeBool(offsets[19], object.autoPlayNextEpisode);
-  writer.writeBool(offsets[20], object.autoReadDuplicateChapters);
+  writer.writeLong(offsets[7], object.animeGridSize);
+  writer.writeBool(offsets[8], object.animeLibraryDownloadedChapters);
+  writer.writeBool(offsets[9], object.animeLibraryLocalSource);
+  writer.writeBool(offsets[10], object.animeLibraryShowCategoryTabs);
+  writer.writeBool(offsets[11], object.animeLibraryShowContinueReadingButton);
+  writer.writeBool(offsets[12], object.animeLibraryShowLanguage);
+  writer.writeBool(offsets[13], object.animeLibraryShowNumbersOfItems);
+  writer.writeString(offsets[14], object.appFontFamily);
+  writer.writeBool(offsets[15], object.appLockEnabled);
+  writer.writeByte(offsets[16], object.audioChannels.index);
+  writer.writeString(offsets[17], object.audioPreferredLanguages);
+  writer.writeString(offsets[18], object.autoBackupLocation);
+  writer.writeBool(offsets[19], object.autoExtensionsUpdates);
+  writer.writeBool(offsets[20], object.autoPlayNextEpisode);
+  writer.writeBool(offsets[21], object.autoReadDuplicateChapters);
   writer.writeObjectList<AutoScrollPages>(
-    offsets[21],
+    offsets[22],
     allOffsets,
     AutoScrollPagesSchema.serialize,
     object.autoScrollPages,
   );
-  writer.writeBool(offsets[22], object.automaticBackground);
-  writer.writeByte(offsets[23], object.backgroundColor.index);
-  writer.writeLong(offsets[24], object.backupCompressionLevel);
-  writer.writeLong(offsets[25], object.backupFrequency);
-  writer.writeLongList(offsets[26], object.backupListOptions);
-  writer.writeString(offsets[27], object.btServerAddress);
-  writer.writeLong(offsets[28], object.btServerPort);
-  writer.writeString(offsets[29], object.cfProxyUrl);
+  writer.writeBool(offsets[23], object.automaticBackground);
+  writer.writeByte(offsets[24], object.backgroundColor.index);
+  writer.writeLong(offsets[25], object.backupCompressionLevel);
+  writer.writeLong(offsets[26], object.backupFrequency);
+  writer.writeLongList(offsets[27], object.backupListOptions);
+  writer.writeString(offsets[28], object.btServerAddress);
+  writer.writeLong(offsets[29], object.btServerPort);
+  writer.writeString(offsets[30], object.cfProxyUrl);
   writer.writeObjectList<ChapterFilterBookmarked>(
-    offsets[30],
+    offsets[31],
     allOffsets,
     ChapterFilterBookmarkedSchema.serialize,
     object.chapterFilterBookmarkedList,
   );
   writer.writeObjectList<ChapterFilterDownloaded>(
-    offsets[31],
+    offsets[32],
     allOffsets,
     ChapterFilterDownloadedSchema.serialize,
     object.chapterFilterDownloadedList,
   );
   writer.writeObjectList<ChapterFilterUnread>(
-    offsets[32],
+    offsets[33],
     allOffsets,
     ChapterFilterUnreadSchema.serialize,
     object.chapterFilterUnreadList,
   );
   writer.writeObjectList<ChapterPageIndex>(
-    offsets[33],
+    offsets[34],
     allOffsets,
     ChapterPageIndexSchema.serialize,
     object.chapterPageIndexList,
   );
   writer.writeObjectList<ChapterPageurls>(
-    offsets[34],
+    offsets[35],
     allOffsets,
     ChapterPageurlsSchema.serialize,
     object.chapterPageUrlsList,
   );
-  writer.writeBool(offsets[35], object.checkForAppUpdates);
-  writer.writeBool(offsets[36], object.checkForExtensionUpdates);
-  writer.writeBool(offsets[37], object.clearChapterCacheOnAppLaunch);
-  writer.writeByte(offsets[38], object.colorFilterBlendMode.index);
-  writer.writeLong(offsets[39], object.concurrentDownloads);
+  writer.writeBool(offsets[36], object.checkForAppUpdates);
+  writer.writeBool(offsets[37], object.checkForExtensionUpdates);
+  writer.writeBool(offsets[38], object.clearChapterCacheOnAppLaunch);
+  writer.writeByte(offsets[39], object.colorFilterBlendMode.index);
+  writer.writeLong(offsets[40], object.concurrentDownloads);
   writer.writeObjectList<MCookie>(
-    offsets[40],
+    offsets[41],
     allOffsets,
     MCookieSchema.serialize,
     object.cookiesList,
   );
-  writer.writeBool(offsets[41], object.cropBorders);
+  writer.writeBool(offsets[42], object.cropBorders);
   writer.writeObject<CustomColorFilter>(
-    offsets[42],
+    offsets[43],
     allOffsets,
     CustomColorFilterSchema.serialize,
     object.customColorFilter,
   );
-  writer.writeString(offsets[43], object.customDns);
-  writer.writeString(offsets[44], object.customDohUrl);
-  writer.writeString(offsets[45], object.dateFormat);
-  writer.writeByte(offsets[46], object.debandingType.index);
-  writer.writeLong(offsets[47], object.defaultDoubleTapToSkipLength);
-  writer.writeDouble(offsets[48], object.defaultPlayBackSpeed);
-  writer.writeByte(offsets[49], object.defaultReaderMode.index);
-  writer.writeLong(offsets[50], object.defaultSkipIntroLength);
+  writer.writeString(offsets[44], object.customDns);
+  writer.writeString(offsets[45], object.customDohUrl);
+  writer.writeString(offsets[46], object.dateFormat);
+  writer.writeByte(offsets[47], object.debandingType.index);
+  writer.writeLong(offsets[48], object.defaultDoubleTapToSkipLength);
+  writer.writeDouble(offsets[49], object.defaultPlayBackSpeed);
+  writer.writeByte(offsets[50], object.defaultReaderMode.index);
+  writer.writeLong(offsets[51], object.defaultSkipIntroLength);
   writer.writeObject<L10nLocale>(
-    offsets[51],
+    offsets[52],
     allOffsets,
     L10nLocaleSchema.serialize,
     object.defaultSubtitleLang,
   );
-  writer.writeBool(offsets[52], object.deleteDownloadAfterReading);
-  writer.writeByte(offsets[53], object.disableSectionType.index);
-  writer.writeByte(offsets[54], object.displayType.index);
-  writer.writeBool(offsets[55], object.doHEnabled);
-  writer.writeLong(offsets[56], object.doHProviderId);
-  writer.writeLong(offsets[57], object.doubleTapAnimationSpeed);
-  writer.writeString(offsets[58], object.downloadLocation);
-  writer.writeBool(offsets[59], object.downloadOnlyOnWifi);
-  writer.writeBool(offsets[60], object.downloadedOnlyMode);
-  writer.writeBool(offsets[61], object.dualPageInvert);
-  writer.writeBool(offsets[62], object.dualPageRotateToFit);
-  writer.writeBool(offsets[63], object.dualPageRotateToFitInvert);
-  writer.writeBool(offsets[64], object.enableAniSkip);
-  writer.writeBool(offsets[65], object.enableAudioPitchCorrection);
-  writer.writeBool(offsets[66], object.enableAutoSkip);
-  writer.writeBool(offsets[67], object.enableCustomColorFilter);
-  writer.writeBool(offsets[68], object.enableDiscordRpc);
-  writer.writeBool(offsets[69], object.enableGpuNext);
-  writer.writeBool(offsets[70], object.enableHardwareAcceleration);
-  writer.writeBool(offsets[71], object.enableLogs);
-  writer.writeString(offsets[72], object.extensionServerPath);
+  writer.writeBool(offsets[53], object.deleteDownloadAfterReading);
+  writer.writeByte(offsets[54], object.disableSectionType.index);
+  writer.writeByte(offsets[55], object.displayType.index);
+  writer.writeBool(offsets[56], object.doHEnabled);
+  writer.writeLong(offsets[57], object.doHProviderId);
+  writer.writeLong(offsets[58], object.doubleTapAnimationSpeed);
+  writer.writeLong(offsets[59], object.downloadDelaySeconds);
+  writer.writeString(offsets[60], object.downloadLocation);
+  writer.writeBool(offsets[61], object.downloadOnlyOnWifi);
+  writer.writeBool(offsets[62], object.downloadedOnlyMode);
+  writer.writeBool(offsets[63], object.dualPageInvert);
+  writer.writeBool(offsets[64], object.dualPageRotateToFit);
+  writer.writeBool(offsets[65], object.dualPageRotateToFitInvert);
+  writer.writeBool(offsets[66], object.enableAniSkip);
+  writer.writeBool(offsets[67], object.enableAudioPitchCorrection);
+  writer.writeBool(offsets[68], object.enableAutoSkip);
+  writer.writeBool(offsets[69], object.enableCustomColorFilter);
+  writer.writeBool(offsets[70], object.enableDiscordRpc);
+  writer.writeBool(offsets[71], object.enableGpuNext);
+  writer.writeBool(offsets[72], object.enableHardwareAcceleration);
+  writer.writeBool(offsets[73], object.enableLogs);
+  writer.writeString(offsets[74], object.extensionServerPath);
   writer.writeObjectList<FilterScanlator>(
-    offsets[73],
+    offsets[75],
     allOffsets,
     FilterScanlatorSchema.serialize,
     object.filterScanlatorList,
   );
-  writer.writeLong(offsets[74], object.flashColor);
-  writer.writeLong(offsets[75], object.flashDuration);
-  writer.writeLong(offsets[76], object.flashInterval);
-  writer.writeBool(offsets[77], object.flashOnPageChange);
-  writer.writeDouble(offsets[78], object.flexColorSchemeBlendLevel);
-  writer.writeLong(offsets[79], object.flexSchemeColorIndex);
-  writer.writeBool(offsets[80], object.followSystemTheme);
-  writer.writeBool(offsets[81], object.forceLandscapePlayer);
-  writer.writeBool(offsets[82], object.fullScreenPlayer);
-  writer.writeBool(offsets[83], object.fullScreenReader);
-  writer.writeBool(offsets[84], object.grayscale);
-  writer.writeBool(offsets[85], object.hideDiscordRpcInIncognito);
-  writer.writeStringList(offsets[86], object.hideItems);
-  writer.writeString(offsets[87], object.hwdecMode);
-  writer.writeBool(offsets[88], object.incognitoMode);
-  writer.writeBool(offsets[89], object.invertColors);
-  writer.writeString(offsets[90], object.jrePath);
-  writer.writeBool(offsets[91], object.keepScreenOnReader);
-  writer.writeBool(offsets[92], object.landscapeZoom);
-  writer.writeString(offsets[93], object.lastTrackerLibraryLocation);
-  writer.writeBool(offsets[94], object.libraryDownloadedChapters);
-  writer.writeLong(offsets[95], object.libraryFilterAnimeBookMarkedType);
-  writer.writeLong(offsets[96], object.libraryFilterAnimeCompletedType);
-  writer.writeLong(offsets[97], object.libraryFilterAnimeDownloadType);
-  writer.writeLong(offsets[98], object.libraryFilterAnimeStartedType);
-  writer.writeLong(offsets[99], object.libraryFilterAnimeTrackingType);
-  writer.writeLong(offsets[100], object.libraryFilterAnimeUnreadType);
-  writer.writeLong(offsets[101], object.libraryFilterMangasBookMarkedType);
-  writer.writeLong(offsets[102], object.libraryFilterMangasCompletedType);
-  writer.writeLong(offsets[103], object.libraryFilterMangasDownloadType);
-  writer.writeLong(offsets[104], object.libraryFilterMangasStartedType);
-  writer.writeLong(offsets[105], object.libraryFilterMangasTrackingType);
-  writer.writeLong(offsets[106], object.libraryFilterMangasUnreadType);
-  writer.writeLong(offsets[107], object.libraryFilterNovelBookMarkedType);
-  writer.writeLong(offsets[108], object.libraryFilterNovelCompletedType);
-  writer.writeLong(offsets[109], object.libraryFilterNovelDownloadType);
-  writer.writeLong(offsets[110], object.libraryFilterNovelStartedType);
-  writer.writeLong(offsets[111], object.libraryFilterNovelTrackingType);
-  writer.writeLong(offsets[112], object.libraryFilterNovelUnreadType);
-  writer.writeBool(offsets[113], object.libraryLocalSource);
-  writer.writeBool(offsets[114], object.libraryShowCategoryTabs);
-  writer.writeBool(offsets[115], object.libraryShowContinueReadingButton);
-  writer.writeBool(offsets[116], object.libraryShowLanguage);
-  writer.writeBool(offsets[117], object.libraryShowNumbersOfItems);
-  writer.writeStringList(offsets[118], object.localFolders);
+  writer.writeLong(offsets[76], object.flashColor);
+  writer.writeLong(offsets[77], object.flashDuration);
+  writer.writeLong(offsets[78], object.flashInterval);
+  writer.writeBool(offsets[79], object.flashOnPageChange);
+  writer.writeDouble(offsets[80], object.flexColorSchemeBlendLevel);
+  writer.writeLong(offsets[81], object.flexSchemeColorIndex);
+  writer.writeBool(offsets[82], object.followSystemTheme);
+  writer.writeBool(offsets[83], object.forceLandscapePlayer);
+  writer.writeBool(offsets[84], object.fullScreenPlayer);
+  writer.writeBool(offsets[85], object.fullScreenReader);
+  writer.writeBool(offsets[86], object.grayscale);
+  writer.writeBool(offsets[87], object.hideDiscordRpcInIncognito);
+  writer.writeStringList(offsets[88], object.hideItems);
+  writer.writeString(offsets[89], object.hwdecMode);
+  writer.writeBool(offsets[90], object.incognitoMode);
+  writer.writeBool(offsets[91], object.invertColors);
+  writer.writeString(offsets[92], object.jrePath);
+  writer.writeBool(offsets[93], object.keepScreenOnReader);
+  writer.writeBool(offsets[94], object.landscapeZoom);
+  writer.writeString(offsets[95], object.lastTrackerLibraryLocation);
+  writer.writeBool(offsets[96], object.libraryDownloadedChapters);
+  writer.writeLong(offsets[97], object.libraryFilterAnimeBookMarkedType);
+  writer.writeLong(offsets[98], object.libraryFilterAnimeCompletedType);
+  writer.writeLong(offsets[99], object.libraryFilterAnimeDownloadType);
+  writer.writeLong(offsets[100], object.libraryFilterAnimeStartedType);
+  writer.writeLong(offsets[101], object.libraryFilterAnimeTrackingType);
+  writer.writeLong(offsets[102], object.libraryFilterAnimeUnreadType);
+  writer.writeLong(offsets[103], object.libraryFilterMangasBookMarkedType);
+  writer.writeLong(offsets[104], object.libraryFilterMangasCompletedType);
+  writer.writeLong(offsets[105], object.libraryFilterMangasDownloadType);
+  writer.writeLong(offsets[106], object.libraryFilterMangasStartedType);
+  writer.writeLong(offsets[107], object.libraryFilterMangasTrackingType);
+  writer.writeLong(offsets[108], object.libraryFilterMangasUnreadType);
+  writer.writeLong(offsets[109], object.libraryFilterNovelBookMarkedType);
+  writer.writeLong(offsets[110], object.libraryFilterNovelCompletedType);
+  writer.writeLong(offsets[111], object.libraryFilterNovelDownloadType);
+  writer.writeLong(offsets[112], object.libraryFilterNovelStartedType);
+  writer.writeLong(offsets[113], object.libraryFilterNovelTrackingType);
+  writer.writeLong(offsets[114], object.libraryFilterNovelUnreadType);
+  writer.writeBool(offsets[115], object.libraryLocalSource);
+  writer.writeBool(offsets[116], object.libraryShowCategoryTabs);
+  writer.writeBool(offsets[117], object.libraryShowContinueReadingButton);
+  writer.writeBool(offsets[118], object.libraryShowLanguage);
+  writer.writeBool(offsets[119], object.libraryShowNumbersOfItems);
+  writer.writeStringList(offsets[120], object.localFolders);
   writer.writeObject<L10nLocale>(
-    offsets[119],
+    offsets[121],
     allOffsets,
     L10nLocaleSchema.serialize,
     object.locale,
   );
   writer.writeObjectList<Repo>(
-    offsets[120],
+    offsets[122],
     allOffsets,
     RepoSchema.serialize,
     object.mangaExtensionsRepo,
   );
-  writer.writeLong(offsets[121], object.mangaGridSize);
-  writer.writeByte(offsets[122], object.mangaHomeDisplayType.index);
-  writer.writeLong(offsets[123], object.markEpisodeAsSeenType);
-  writer.writeBool(offsets[124], object.mergeLibraryNavMobile);
-  writer.writeBool(offsets[125], object.navigateToPan);
-  writer.writeStringList(offsets[126], object.navigationOrder);
-  writer.writeByte(offsets[127], object.novelDisplayType.index);
+  writer.writeLong(offsets[123], object.mangaGridSize);
+  writer.writeByte(offsets[124], object.mangaHomeDisplayType.index);
+  writer.writeLong(offsets[125], object.markEpisodeAsSeenType);
+  writer.writeBool(offsets[126], object.mergeLibraryNavMobile);
+  writer.writeBool(offsets[127], object.navigateToPan);
+  writer.writeStringList(offsets[128], object.navigationOrder);
+  writer.writeByte(offsets[129], object.novelDisplayType.index);
   writer.writeObjectList<Repo>(
-    offsets[128],
+    offsets[130],
     allOffsets,
     RepoSchema.serialize,
     object.novelExtensionsRepo,
   );
-  writer.writeLong(offsets[129], object.novelFontSize);
-  writer.writeLong(offsets[130], object.novelGridSize);
-  writer.writeBool(offsets[131], object.novelLibraryDownloadedChapters);
-  writer.writeBool(offsets[132], object.novelLibraryLocalSource);
-  writer.writeBool(offsets[133], object.novelLibraryShowCategoryTabs);
-  writer.writeBool(offsets[134], object.novelLibraryShowContinueReadingButton);
-  writer.writeBool(offsets[135], object.novelLibraryShowLanguage);
-  writer.writeBool(offsets[136], object.novelLibraryShowNumbersOfItems);
-  writer.writeDouble(offsets[137], object.novelReaderLineHeight);
-  writer.writeLong(offsets[138], object.novelReaderPadding);
-  writer.writeString(offsets[139], object.novelReaderTextColor);
-  writer.writeString(offsets[140], object.novelReaderTheme);
-  writer.writeBool(offsets[141], object.novelRemoveExtraParagraphSpacing);
-  writer.writeBool(offsets[142], object.novelShowScrollPercentage);
-  writer.writeBool(offsets[143], object.novelTapToScroll);
-  writer.writeByte(offsets[144], object.novelTextAlign.index);
-  writer.writeBool(offsets[145], object.onlyIncludePinnedSources);
-  writer.writeLong(offsets[146], object.pagePreloadAmount);
+  writer.writeLong(offsets[131], object.novelFontSize);
+  writer.writeLong(offsets[132], object.novelGridSize);
+  writer.writeBool(offsets[133], object.novelLibraryDownloadedChapters);
+  writer.writeBool(offsets[134], object.novelLibraryLocalSource);
+  writer.writeBool(offsets[135], object.novelLibraryShowCategoryTabs);
+  writer.writeBool(offsets[136], object.novelLibraryShowContinueReadingButton);
+  writer.writeBool(offsets[137], object.novelLibraryShowLanguage);
+  writer.writeBool(offsets[138], object.novelLibraryShowNumbersOfItems);
+  writer.writeDouble(offsets[139], object.novelReaderLineHeight);
+  writer.writeLong(offsets[140], object.novelReaderPadding);
+  writer.writeString(offsets[141], object.novelReaderTextColor);
+  writer.writeString(offsets[142], object.novelReaderTheme);
+  writer.writeBool(offsets[143], object.novelRemoveExtraParagraphSpacing);
+  writer.writeBool(offsets[144], object.novelShowScrollPercentage);
+  writer.writeBool(offsets[145], object.novelTapToScroll);
+  writer.writeByte(offsets[146], object.novelTextAlign.index);
+  writer.writeBool(offsets[147], object.onlyIncludePinnedSources);
+  writer.writeLong(offsets[148], object.pagePreloadAmount);
   writer.writeObjectList<PersonalPageMode>(
-    offsets[147],
+    offsets[149],
     allOffsets,
     PersonalPageModeSchema.serialize,
     object.personalPageModeList,
   );
   writer.writeObjectList<PersonalReaderMode>(
-    offsets[148],
+    offsets[150],
     allOffsets,
     PersonalReaderModeSchema.serialize,
     object.personalReaderModeList,
   );
   writer.writeObject<PlayerSubtitleSettings>(
-    offsets[149],
+    offsets[151],
     allOffsets,
     PlayerSubtitleSettingsSchema.serialize,
     object.playerSubtitleSettings,
   );
-  writer.writeBool(offsets[150], object.pureBlackDarkMode);
-  writer.writeDouble(offsets[151], object.readerBrightness);
-  writer.writeDouble(offsets[152], object.readerContrast);
-  writer.writeLong(offsets[153], object.readerHideThreshold);
-  writer.writeLong(offsets[154], object.readerNavigationLayout);
-  writer.writeDouble(offsets[155], object.readerSaturation);
-  writer.writeLong(offsets[156], object.relativeTimesTamps);
-  writer.writeBool(offsets[157], object.rpcShowCoverImage);
-  writer.writeBool(offsets[158], object.rpcShowReadingWatchingProgress);
-  writer.writeBool(offsets[159], object.rpcShowTitle);
-  writer.writeBool(offsets[160], object.saveAsCBZArchive);
-  writer.writeByte(offsets[161], object.scaleType.index);
-  writer.writeBool(offsets[162], object.showNSFW);
-  writer.writeBool(offsets[163], object.showNavigationOverlayOnStart);
-  writer.writeBool(offsets[164], object.showPageGaps);
-  writer.writeBool(offsets[165], object.showPagesNumber);
+  writer.writeBool(offsets[152], object.pureBlackDarkMode);
+  writer.writeDouble(offsets[153], object.readerBrightness);
+  writer.writeDouble(offsets[154], object.readerContrast);
+  writer.writeLong(offsets[155], object.readerHideThreshold);
+  writer.writeLong(offsets[156], object.readerNavigationLayout);
+  writer.writeDouble(offsets[157], object.readerSaturation);
+  writer.writeLong(offsets[158], object.relativeTimesTamps);
+  writer.writeBool(offsets[159], object.rpcShowCoverImage);
+  writer.writeBool(offsets[160], object.rpcShowReadingWatchingProgress);
+  writer.writeBool(offsets[161], object.rpcShowTitle);
+  writer.writeBool(offsets[162], object.saveAsCBZArchive);
+  writer.writeByte(offsets[163], object.scaleType.index);
+  writer.writeBool(offsets[164], object.showNSFW);
+  writer.writeBool(offsets[165], object.showNavigationOverlayOnStart);
+  writer.writeBool(offsets[166], object.showPageGaps);
+  writer.writeBool(offsets[167], object.showPagesNumber);
   writer.writeObjectList<SortChapter>(
-    offsets[166],
+    offsets[168],
     allOffsets,
     SortChapterSchema.serialize,
     object.sortChapterList,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[167],
+    offsets[169],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryAnime,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[168],
+    offsets[170],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryManga,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[169],
+    offsets[171],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryNovel,
   );
-  writer.writeBool(offsets[170], object.splitWidePages);
-  writer.writeLong(offsets[171], object.startDatebackup);
-  writer.writeLong(offsets[172], object.tappingInversion);
-  writer.writeBool(offsets[173], object.themeIsDark);
-  writer.writeString(offsets[174], object.ttsLanguage);
-  writer.writeDouble(offsets[175], object.ttsPitch);
-  writer.writeDouble(offsets[176], object.ttsSpeechRate);
-  writer.writeString(offsets[177], object.ttsVoice);
-  writer.writeBool(offsets[178], object.tvAnimeOnlyOverride);
-  writer.writeBool(offsets[179], object.tvHomeGenreRows);
-  writer.writeBool(offsets[180], object.tvHomeStyle);
-  writer.writeBool(offsets[181], object.tvPlayerStyle);
+  writer.writeBool(offsets[172], object.splitWidePages);
+  writer.writeLong(offsets[173], object.startDatebackup);
+  writer.writeLong(offsets[174], object.tappingInversion);
+  writer.writeBool(offsets[175], object.themeIsDark);
+  writer.writeString(offsets[176], object.ttsLanguage);
+  writer.writeDouble(offsets[177], object.ttsPitch);
+  writer.writeDouble(offsets[178], object.ttsSpeechRate);
+  writer.writeString(offsets[179], object.ttsVoice);
+  writer.writeBool(offsets[180], object.tvAnimeOnlyOverride);
+  writer.writeBool(offsets[181], object.tvHomeGenreRows);
+  writer.writeBool(offsets[182], object.tvHomeStyle);
+  writer.writeBool(offsets[183], object.tvPlayerStyle);
   writer.writeObjectList<UpdateError>(
-    offsets[182],
+    offsets[184],
     allOffsets,
     UpdateErrorSchema.serialize,
     object.updateErrorsList,
   );
-  writer.writeBool(offsets[183], object.updateProgressAfterReading);
-  writer.writeLong(offsets[184], object.updatedAt);
-  writer.writeBool(offsets[185], object.useLibass);
-  writer.writeBool(offsets[186], object.useMpvConfig);
-  writer.writeBool(offsets[187], object.usePageTapZones);
-  writer.writeBool(offsets[188], object.useYUV420P);
-  writer.writeString(offsets[189], object.userAgent);
-  writer.writeLong(offsets[190], object.volumeBoostCap);
-  writer.writeBool(offsets[191], object.webtoonDisableZoomOut);
-  writer.writeBool(offsets[192], object.webtoonDoubleTapZoomEnabled);
-  writer.writeLong(offsets[193], object.webtoonSidePadding);
-  writer.writeLong(offsets[194], object.zoomStartPosition);
+  writer.writeBool(offsets[185], object.updateProgressAfterReading);
+  writer.writeLong(offsets[186], object.updatedAt);
+  writer.writeBool(offsets[187], object.useLibass);
+  writer.writeBool(offsets[188], object.useMpvConfig);
+  writer.writeBool(offsets[189], object.usePageTapZones);
+  writer.writeBool(offsets[190], object.useYUV420P);
+  writer.writeString(offsets[191], object.userAgent);
+  writer.writeLong(offsets[192], object.volumeBoostCap);
+  writer.writeBool(offsets[193], object.webtoonDisableZoomOut);
+  writer.writeBool(offsets[194], object.webtoonDoubleTapZoomEnabled);
+  writer.writeLong(offsets[195], object.webtoonSidePadding);
+  writer.writeLong(offsets[196], object.zoomStartPosition);
 }
 
 Settings _settingsDeserialize(
@@ -1919,350 +1931,352 @@ Settings _settingsDeserialize(
       AlgorithmWeightsSchema.deserialize,
       allOffsets,
     ),
-    androidProxyServer: reader.readStringOrNull(offsets[1]),
-    aniSkipTimeoutLength: reader.readLongOrNull(offsets[2]),
-    animatePageTransitions: reader.readBoolOrNull(offsets[3]),
+    allowConcurrentDownloads: reader.readBoolOrNull(offsets[1]),
+    androidProxyServer: reader.readStringOrNull(offsets[2]),
+    aniSkipTimeoutLength: reader.readLongOrNull(offsets[3]),
+    animatePageTransitions: reader.readBoolOrNull(offsets[4]),
     animeDisplayType:
         _SettingsanimeDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[4],
+          offsets[5],
         )] ??
         DisplayType.compactGrid,
     animeExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[5],
+      offsets[6],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    animeGridSize: reader.readLongOrNull(offsets[6]),
-    animeLibraryDownloadedChapters: reader.readBoolOrNull(offsets[7]),
-    animeLibraryLocalSource: reader.readBoolOrNull(offsets[8]),
-    animeLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[9]),
-    animeLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[10]),
-    animeLibraryShowLanguage: reader.readBoolOrNull(offsets[11]),
-    animeLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[12]),
-    appFontFamily: reader.readStringOrNull(offsets[13]),
-    appLockEnabled: reader.readBoolOrNull(offsets[14]),
+    animeGridSize: reader.readLongOrNull(offsets[7]),
+    animeLibraryDownloadedChapters: reader.readBoolOrNull(offsets[8]),
+    animeLibraryLocalSource: reader.readBoolOrNull(offsets[9]),
+    animeLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[10]),
+    animeLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[11]),
+    animeLibraryShowLanguage: reader.readBoolOrNull(offsets[12]),
+    animeLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[13]),
+    appFontFamily: reader.readStringOrNull(offsets[14]),
+    appLockEnabled: reader.readBoolOrNull(offsets[15]),
     audioChannels:
         _SettingsaudioChannelsValueEnumMap[reader.readByteOrNull(
-          offsets[15],
+          offsets[16],
         )] ??
         AudioChannel.autoSafe,
-    audioPreferredLanguages: reader.readStringOrNull(offsets[16]),
-    autoBackupLocation: reader.readStringOrNull(offsets[17]),
-    autoExtensionsUpdates: reader.readBoolOrNull(offsets[18]),
-    autoPlayNextEpisode: reader.readBoolOrNull(offsets[19]),
-    autoReadDuplicateChapters: reader.readBoolOrNull(offsets[20]),
+    audioPreferredLanguages: reader.readStringOrNull(offsets[17]),
+    autoBackupLocation: reader.readStringOrNull(offsets[18]),
+    autoExtensionsUpdates: reader.readBoolOrNull(offsets[19]),
+    autoPlayNextEpisode: reader.readBoolOrNull(offsets[20]),
+    autoReadDuplicateChapters: reader.readBoolOrNull(offsets[21]),
     autoScrollPages: reader.readObjectList<AutoScrollPages>(
-      offsets[21],
+      offsets[22],
       AutoScrollPagesSchema.deserialize,
       allOffsets,
       AutoScrollPages(),
     ),
-    automaticBackground: reader.readBoolOrNull(offsets[22]),
+    automaticBackground: reader.readBoolOrNull(offsets[23]),
     backgroundColor:
         _SettingsbackgroundColorValueEnumMap[reader.readByteOrNull(
-          offsets[23],
+          offsets[24],
         )] ??
         BackgroundColor.black,
-    backupCompressionLevel: reader.readLongOrNull(offsets[24]),
-    backupFrequency: reader.readLongOrNull(offsets[25]),
-    backupListOptions: reader.readLongList(offsets[26]),
-    btServerAddress: reader.readStringOrNull(offsets[27]),
-    btServerPort: reader.readLongOrNull(offsets[28]),
-    cfProxyUrl: reader.readStringOrNull(offsets[29]),
+    backupCompressionLevel: reader.readLongOrNull(offsets[25]),
+    backupFrequency: reader.readLongOrNull(offsets[26]),
+    backupListOptions: reader.readLongList(offsets[27]),
+    btServerAddress: reader.readStringOrNull(offsets[28]),
+    btServerPort: reader.readLongOrNull(offsets[29]),
+    cfProxyUrl: reader.readStringOrNull(offsets[30]),
     chapterFilterDownloadedList: reader.readObjectList<ChapterFilterDownloaded>(
-      offsets[31],
+      offsets[32],
       ChapterFilterDownloadedSchema.deserialize,
       allOffsets,
       ChapterFilterDownloaded(),
     ),
     chapterPageIndexList: reader.readObjectList<ChapterPageIndex>(
-      offsets[33],
+      offsets[34],
       ChapterPageIndexSchema.deserialize,
       allOffsets,
       ChapterPageIndex(),
     ),
     chapterPageUrlsList: reader.readObjectList<ChapterPageurls>(
-      offsets[34],
+      offsets[35],
       ChapterPageurlsSchema.deserialize,
       allOffsets,
       ChapterPageurls(),
     ),
-    checkForAppUpdates: reader.readBoolOrNull(offsets[35]),
-    checkForExtensionUpdates: reader.readBoolOrNull(offsets[36]),
-    clearChapterCacheOnAppLaunch: reader.readBoolOrNull(offsets[37]),
+    checkForAppUpdates: reader.readBoolOrNull(offsets[36]),
+    checkForExtensionUpdates: reader.readBoolOrNull(offsets[37]),
+    clearChapterCacheOnAppLaunch: reader.readBoolOrNull(offsets[38]),
     colorFilterBlendMode:
         _SettingscolorFilterBlendModeValueEnumMap[reader.readByteOrNull(
-          offsets[38],
+          offsets[39],
         )] ??
         ColorFilterBlendMode.none,
-    concurrentDownloads: reader.readLongOrNull(offsets[39]),
+    concurrentDownloads: reader.readLongOrNull(offsets[40]),
     cookiesList: reader.readObjectList<MCookie>(
-      offsets[40],
+      offsets[41],
       MCookieSchema.deserialize,
       allOffsets,
       MCookie(),
     ),
-    cropBorders: reader.readBoolOrNull(offsets[41]),
+    cropBorders: reader.readBoolOrNull(offsets[42]),
     customColorFilter: reader.readObjectOrNull<CustomColorFilter>(
-      offsets[42],
+      offsets[43],
       CustomColorFilterSchema.deserialize,
       allOffsets,
     ),
-    customDns: reader.readStringOrNull(offsets[43]),
-    customDohUrl: reader.readStringOrNull(offsets[44]),
-    dateFormat: reader.readStringOrNull(offsets[45]),
+    customDns: reader.readStringOrNull(offsets[44]),
+    customDohUrl: reader.readStringOrNull(offsets[45]),
+    dateFormat: reader.readStringOrNull(offsets[46]),
     debandingType:
         _SettingsdebandingTypeValueEnumMap[reader.readByteOrNull(
-          offsets[46],
+          offsets[47],
         )] ??
         DebandingType.none,
-    defaultDoubleTapToSkipLength: reader.readLongOrNull(offsets[47]),
-    defaultPlayBackSpeed: reader.readDoubleOrNull(offsets[48]),
+    defaultDoubleTapToSkipLength: reader.readLongOrNull(offsets[48]),
+    defaultPlayBackSpeed: reader.readDoubleOrNull(offsets[49]),
     defaultReaderMode:
         _SettingsdefaultReaderModeValueEnumMap[reader.readByteOrNull(
-          offsets[49],
+          offsets[50],
         )] ??
         ReaderMode.vertical,
-    defaultSkipIntroLength: reader.readLongOrNull(offsets[50]),
-    deleteDownloadAfterReading: reader.readBoolOrNull(offsets[52]),
+    defaultSkipIntroLength: reader.readLongOrNull(offsets[51]),
+    deleteDownloadAfterReading: reader.readBoolOrNull(offsets[53]),
     disableSectionType:
         _SettingsdisableSectionTypeValueEnumMap[reader.readByteOrNull(
-          offsets[53],
+          offsets[54],
         )] ??
         SectionType.all,
     displayType:
-        _SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offsets[54])] ??
+        _SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offsets[55])] ??
         DisplayType.compactGrid,
-    doHEnabled: reader.readBoolOrNull(offsets[55]),
-    doHProviderId: reader.readLongOrNull(offsets[56]),
-    doubleTapAnimationSpeed: reader.readLongOrNull(offsets[57]),
-    downloadLocation: reader.readStringOrNull(offsets[58]),
-    downloadOnlyOnWifi: reader.readBoolOrNull(offsets[59]),
-    downloadedOnlyMode: reader.readBoolOrNull(offsets[60]),
-    dualPageInvert: reader.readBoolOrNull(offsets[61]),
-    dualPageRotateToFit: reader.readBoolOrNull(offsets[62]),
-    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[63]),
-    enableAniSkip: reader.readBoolOrNull(offsets[64]),
-    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[65]),
-    enableAutoSkip: reader.readBoolOrNull(offsets[66]),
-    enableCustomColorFilter: reader.readBoolOrNull(offsets[67]),
-    enableDiscordRpc: reader.readBoolOrNull(offsets[68]),
-    enableGpuNext: reader.readBoolOrNull(offsets[69]),
-    enableHardwareAcceleration: reader.readBoolOrNull(offsets[70]),
-    enableLogs: reader.readBoolOrNull(offsets[71]),
-    extensionServerPath: reader.readStringOrNull(offsets[72]),
-    flashColor: reader.readLongOrNull(offsets[74]),
-    flashDuration: reader.readLongOrNull(offsets[75]),
-    flashInterval: reader.readLongOrNull(offsets[76]),
-    flashOnPageChange: reader.readBoolOrNull(offsets[77]),
-    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[78]),
-    flexSchemeColorIndex: reader.readLongOrNull(offsets[79]),
-    followSystemTheme: reader.readBoolOrNull(offsets[80]),
-    forceLandscapePlayer: reader.readBoolOrNull(offsets[81]),
-    fullScreenPlayer: reader.readBoolOrNull(offsets[82]),
-    fullScreenReader: reader.readBoolOrNull(offsets[83]),
-    grayscale: reader.readBoolOrNull(offsets[84]),
-    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[85]),
-    hideItems: reader.readStringList(offsets[86]),
-    hwdecMode: reader.readStringOrNull(offsets[87]),
+    doHEnabled: reader.readBoolOrNull(offsets[56]),
+    doHProviderId: reader.readLongOrNull(offsets[57]),
+    doubleTapAnimationSpeed: reader.readLongOrNull(offsets[58]),
+    downloadDelaySeconds: reader.readLongOrNull(offsets[59]),
+    downloadLocation: reader.readStringOrNull(offsets[60]),
+    downloadOnlyOnWifi: reader.readBoolOrNull(offsets[61]),
+    downloadedOnlyMode: reader.readBoolOrNull(offsets[62]),
+    dualPageInvert: reader.readBoolOrNull(offsets[63]),
+    dualPageRotateToFit: reader.readBoolOrNull(offsets[64]),
+    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[65]),
+    enableAniSkip: reader.readBoolOrNull(offsets[66]),
+    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[67]),
+    enableAutoSkip: reader.readBoolOrNull(offsets[68]),
+    enableCustomColorFilter: reader.readBoolOrNull(offsets[69]),
+    enableDiscordRpc: reader.readBoolOrNull(offsets[70]),
+    enableGpuNext: reader.readBoolOrNull(offsets[71]),
+    enableHardwareAcceleration: reader.readBoolOrNull(offsets[72]),
+    enableLogs: reader.readBoolOrNull(offsets[73]),
+    extensionServerPath: reader.readStringOrNull(offsets[74]),
+    flashColor: reader.readLongOrNull(offsets[76]),
+    flashDuration: reader.readLongOrNull(offsets[77]),
+    flashInterval: reader.readLongOrNull(offsets[78]),
+    flashOnPageChange: reader.readBoolOrNull(offsets[79]),
+    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[80]),
+    flexSchemeColorIndex: reader.readLongOrNull(offsets[81]),
+    followSystemTheme: reader.readBoolOrNull(offsets[82]),
+    forceLandscapePlayer: reader.readBoolOrNull(offsets[83]),
+    fullScreenPlayer: reader.readBoolOrNull(offsets[84]),
+    fullScreenReader: reader.readBoolOrNull(offsets[85]),
+    grayscale: reader.readBoolOrNull(offsets[86]),
+    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[87]),
+    hideItems: reader.readStringList(offsets[88]),
+    hwdecMode: reader.readStringOrNull(offsets[89]),
     id: id,
-    incognitoMode: reader.readBoolOrNull(offsets[88]),
-    invertColors: reader.readBoolOrNull(offsets[89]),
-    jrePath: reader.readStringOrNull(offsets[90]),
-    keepScreenOnReader: reader.readBoolOrNull(offsets[91]),
-    landscapeZoom: reader.readBoolOrNull(offsets[92]),
-    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[93]),
-    libraryDownloadedChapters: reader.readBoolOrNull(offsets[94]),
-    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[95]),
-    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[96]),
-    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[97]),
-    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[98]),
-    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[99]),
-    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[100]),
-    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[101]),
-    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[102]),
-    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[103]),
-    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[104]),
-    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[105]),
-    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[106]),
-    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[107]),
-    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[108]),
-    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[109]),
-    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[110]),
-    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[111]),
-    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[112]),
-    libraryLocalSource: reader.readBoolOrNull(offsets[113]),
-    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[114]),
-    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[115]),
-    libraryShowLanguage: reader.readBoolOrNull(offsets[116]),
-    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[117]),
-    localFolders: reader.readStringList(offsets[118]),
+    incognitoMode: reader.readBoolOrNull(offsets[90]),
+    invertColors: reader.readBoolOrNull(offsets[91]),
+    jrePath: reader.readStringOrNull(offsets[92]),
+    keepScreenOnReader: reader.readBoolOrNull(offsets[93]),
+    landscapeZoom: reader.readBoolOrNull(offsets[94]),
+    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[95]),
+    libraryDownloadedChapters: reader.readBoolOrNull(offsets[96]),
+    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[97]),
+    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[98]),
+    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[99]),
+    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[100]),
+    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[101]),
+    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[102]),
+    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[103]),
+    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[104]),
+    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[105]),
+    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[106]),
+    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[107]),
+    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[108]),
+    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[109]),
+    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[110]),
+    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[111]),
+    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[112]),
+    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[113]),
+    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[114]),
+    libraryLocalSource: reader.readBoolOrNull(offsets[115]),
+    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[116]),
+    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[117]),
+    libraryShowLanguage: reader.readBoolOrNull(offsets[118]),
+    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[119]),
+    localFolders: reader.readStringList(offsets[120]),
     mangaExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[120],
+      offsets[122],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    mangaGridSize: reader.readLongOrNull(offsets[121]),
+    mangaGridSize: reader.readLongOrNull(offsets[123]),
     mangaHomeDisplayType:
         _SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[122],
+          offsets[124],
         )] ??
         DisplayType.comfortableGrid,
-    markEpisodeAsSeenType: reader.readLongOrNull(offsets[123]),
-    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[124]),
-    navigateToPan: reader.readBoolOrNull(offsets[125]),
-    navigationOrder: reader.readStringList(offsets[126]),
+    markEpisodeAsSeenType: reader.readLongOrNull(offsets[125]),
+    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[126]),
+    navigateToPan: reader.readBoolOrNull(offsets[127]),
+    navigationOrder: reader.readStringList(offsets[128]),
     novelDisplayType:
         _SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[127],
+          offsets[129],
         )] ??
         DisplayType.comfortableGrid,
     novelExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[128],
+      offsets[130],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    novelFontSize: reader.readLongOrNull(offsets[129]),
-    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[131]),
-    novelLibraryLocalSource: reader.readBoolOrNull(offsets[132]),
-    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[133]),
-    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[134]),
-    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[135]),
-    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[136]),
-    novelReaderLineHeight: reader.readDoubleOrNull(offsets[137]),
-    novelReaderPadding: reader.readLongOrNull(offsets[138]),
-    novelReaderTextColor: reader.readStringOrNull(offsets[139]),
-    novelReaderTheme: reader.readStringOrNull(offsets[140]),
-    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[141]),
-    novelShowScrollPercentage: reader.readBoolOrNull(offsets[142]),
-    novelTapToScroll: reader.readBoolOrNull(offsets[143]),
+    novelFontSize: reader.readLongOrNull(offsets[131]),
+    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[133]),
+    novelLibraryLocalSource: reader.readBoolOrNull(offsets[134]),
+    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[135]),
+    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[136]),
+    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[137]),
+    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[138]),
+    novelReaderLineHeight: reader.readDoubleOrNull(offsets[139]),
+    novelReaderPadding: reader.readLongOrNull(offsets[140]),
+    novelReaderTextColor: reader.readStringOrNull(offsets[141]),
+    novelReaderTheme: reader.readStringOrNull(offsets[142]),
+    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[143]),
+    novelShowScrollPercentage: reader.readBoolOrNull(offsets[144]),
+    novelTapToScroll: reader.readBoolOrNull(offsets[145]),
     novelTextAlign:
         _SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
-          offsets[144],
+          offsets[146],
         )] ??
         NovelTextAlign.left,
-    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[145]),
-    pagePreloadAmount: reader.readLongOrNull(offsets[146]),
+    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[147]),
+    pagePreloadAmount: reader.readLongOrNull(offsets[148]),
     personalPageModeList: reader.readObjectList<PersonalPageMode>(
-      offsets[147],
+      offsets[149],
       PersonalPageModeSchema.deserialize,
       allOffsets,
       PersonalPageMode(),
     ),
     personalReaderModeList: reader.readObjectList<PersonalReaderMode>(
-      offsets[148],
+      offsets[150],
       PersonalReaderModeSchema.deserialize,
       allOffsets,
       PersonalReaderMode(),
     ),
     playerSubtitleSettings: reader.readObjectOrNull<PlayerSubtitleSettings>(
-      offsets[149],
+      offsets[151],
       PlayerSubtitleSettingsSchema.deserialize,
       allOffsets,
     ),
-    pureBlackDarkMode: reader.readBoolOrNull(offsets[150]),
-    readerBrightness: reader.readDoubleOrNull(offsets[151]),
-    readerContrast: reader.readDoubleOrNull(offsets[152]),
-    readerHideThreshold: reader.readLongOrNull(offsets[153]),
-    readerNavigationLayout: reader.readLongOrNull(offsets[154]),
-    readerSaturation: reader.readDoubleOrNull(offsets[155]),
-    relativeTimesTamps: reader.readLongOrNull(offsets[156]),
-    rpcShowCoverImage: reader.readBoolOrNull(offsets[157]),
-    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[158]),
-    rpcShowTitle: reader.readBoolOrNull(offsets[159]),
-    saveAsCBZArchive: reader.readBoolOrNull(offsets[160]),
+    pureBlackDarkMode: reader.readBoolOrNull(offsets[152]),
+    readerBrightness: reader.readDoubleOrNull(offsets[153]),
+    readerContrast: reader.readDoubleOrNull(offsets[154]),
+    readerHideThreshold: reader.readLongOrNull(offsets[155]),
+    readerNavigationLayout: reader.readLongOrNull(offsets[156]),
+    readerSaturation: reader.readDoubleOrNull(offsets[157]),
+    relativeTimesTamps: reader.readLongOrNull(offsets[158]),
+    rpcShowCoverImage: reader.readBoolOrNull(offsets[159]),
+    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[160]),
+    rpcShowTitle: reader.readBoolOrNull(offsets[161]),
+    saveAsCBZArchive: reader.readBoolOrNull(offsets[162]),
     scaleType:
-        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[161])] ??
+        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[163])] ??
         ScaleType.fitScreen,
-    showNSFW: reader.readBoolOrNull(offsets[162]),
-    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[163]),
-    showPageGaps: reader.readBoolOrNull(offsets[164]),
-    showPagesNumber: reader.readBoolOrNull(offsets[165]),
+    showNSFW: reader.readBoolOrNull(offsets[164]),
+    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[165]),
+    showPageGaps: reader.readBoolOrNull(offsets[166]),
+    showPagesNumber: reader.readBoolOrNull(offsets[167]),
     sortChapterList: reader.readObjectList<SortChapter>(
-      offsets[166],
+      offsets[168],
       SortChapterSchema.deserialize,
       allOffsets,
       SortChapter(),
     ),
     sortLibraryAnime: reader.readObjectOrNull<SortLibraryManga>(
-      offsets[167],
-      SortLibraryMangaSchema.deserialize,
-      allOffsets,
-    ),
-    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
-      offsets[168],
-      SortLibraryMangaSchema.deserialize,
-      allOffsets,
-    ),
-    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
       offsets[169],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    splitWidePages: reader.readBoolOrNull(offsets[170]),
-    startDatebackup: reader.readLongOrNull(offsets[171]),
-    tappingInversion: reader.readLongOrNull(offsets[172]),
-    themeIsDark: reader.readBoolOrNull(offsets[173]),
-    ttsLanguage: reader.readStringOrNull(offsets[174]),
-    ttsPitch: reader.readDoubleOrNull(offsets[175]),
-    ttsSpeechRate: reader.readDoubleOrNull(offsets[176]),
-    ttsVoice: reader.readStringOrNull(offsets[177]),
-    tvAnimeOnlyOverride: reader.readBoolOrNull(offsets[178]),
-    tvHomeGenreRows: reader.readBoolOrNull(offsets[179]),
-    tvHomeStyle: reader.readBoolOrNull(offsets[180]),
-    tvPlayerStyle: reader.readBoolOrNull(offsets[181]),
+    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
+      offsets[170],
+      SortLibraryMangaSchema.deserialize,
+      allOffsets,
+    ),
+    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+      offsets[171],
+      SortLibraryMangaSchema.deserialize,
+      allOffsets,
+    ),
+    splitWidePages: reader.readBoolOrNull(offsets[172]),
+    startDatebackup: reader.readLongOrNull(offsets[173]),
+    tappingInversion: reader.readLongOrNull(offsets[174]),
+    themeIsDark: reader.readBoolOrNull(offsets[175]),
+    ttsLanguage: reader.readStringOrNull(offsets[176]),
+    ttsPitch: reader.readDoubleOrNull(offsets[177]),
+    ttsSpeechRate: reader.readDoubleOrNull(offsets[178]),
+    ttsVoice: reader.readStringOrNull(offsets[179]),
+    tvAnimeOnlyOverride: reader.readBoolOrNull(offsets[180]),
+    tvHomeGenreRows: reader.readBoolOrNull(offsets[181]),
+    tvHomeStyle: reader.readBoolOrNull(offsets[182]),
+    tvPlayerStyle: reader.readBoolOrNull(offsets[183]),
     updateErrorsList: reader.readObjectList<UpdateError>(
-      offsets[182],
+      offsets[184],
       UpdateErrorSchema.deserialize,
       allOffsets,
       UpdateError(),
     ),
-    updateProgressAfterReading: reader.readBoolOrNull(offsets[183]),
-    updatedAt: reader.readLongOrNull(offsets[184]),
-    useLibass: reader.readBoolOrNull(offsets[185]),
-    useMpvConfig: reader.readBoolOrNull(offsets[186]),
-    usePageTapZones: reader.readBoolOrNull(offsets[187]),
-    useYUV420P: reader.readBoolOrNull(offsets[188]),
-    userAgent: reader.readStringOrNull(offsets[189]),
-    volumeBoostCap: reader.readLongOrNull(offsets[190]),
-    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[191]),
-    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[192]),
-    webtoonSidePadding: reader.readLongOrNull(offsets[193]),
-    zoomStartPosition: reader.readLongOrNull(offsets[194]),
+    updateProgressAfterReading: reader.readBoolOrNull(offsets[185]),
+    updatedAt: reader.readLongOrNull(offsets[186]),
+    useLibass: reader.readBoolOrNull(offsets[187]),
+    useMpvConfig: reader.readBoolOrNull(offsets[188]),
+    usePageTapZones: reader.readBoolOrNull(offsets[189]),
+    useYUV420P: reader.readBoolOrNull(offsets[190]),
+    userAgent: reader.readStringOrNull(offsets[191]),
+    volumeBoostCap: reader.readLongOrNull(offsets[192]),
+    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[193]),
+    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[194]),
+    webtoonSidePadding: reader.readLongOrNull(offsets[195]),
+    zoomStartPosition: reader.readLongOrNull(offsets[196]),
   );
   object.chapterFilterBookmarkedList = reader
       .readObjectList<ChapterFilterBookmarked>(
-        offsets[30],
+        offsets[31],
         ChapterFilterBookmarkedSchema.deserialize,
         allOffsets,
         ChapterFilterBookmarked(),
       );
   object.chapterFilterUnreadList = reader.readObjectList<ChapterFilterUnread>(
-    offsets[32],
+    offsets[33],
     ChapterFilterUnreadSchema.deserialize,
     allOffsets,
     ChapterFilterUnread(),
   );
   object.defaultSubtitleLang = reader.readObjectOrNull<L10nLocale>(
-    offsets[51],
+    offsets[52],
     L10nLocaleSchema.deserialize,
     allOffsets,
   );
   object.filterScanlatorList = reader.readObjectList<FilterScanlator>(
-    offsets[73],
+    offsets[75],
     FilterScanlatorSchema.deserialize,
     allOffsets,
     FilterScanlator(),
   );
   object.locale = reader.readObjectOrNull<L10nLocale>(
-    offsets[119],
+    offsets[121],
     L10nLocaleSchema.deserialize,
     allOffsets,
   );
-  object.novelGridSize = reader.readLongOrNull(offsets[130]);
+  object.novelGridSize = reader.readLongOrNull(offsets[132]);
   return object;
 }
 
@@ -2281,18 +2295,20 @@ P _settingsDeserializeProp<P>(
           ))
           as P;
     case 1:
-      return (reader.readStringOrNull(offset)) as P;
-    case 2:
-      return (reader.readLongOrNull(offset)) as P;
-    case 3:
       return (reader.readBoolOrNull(offset)) as P;
+    case 2:
+      return (reader.readStringOrNull(offset)) as P;
+    case 3:
+      return (reader.readLongOrNull(offset)) as P;
     case 4:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 5:
       return (_SettingsanimeDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.compactGrid)
           as P;
-    case 5:
+    case 6:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2300,10 +2316,8 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 6:
-      return (reader.readLongOrNull(offset)) as P;
     case 7:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 8:
       return (reader.readBoolOrNull(offset)) as P;
     case 9:
@@ -2315,26 +2329,28 @@ P _settingsDeserializeProp<P>(
     case 12:
       return (reader.readBoolOrNull(offset)) as P;
     case 13:
-      return (reader.readStringOrNull(offset)) as P;
-    case 14:
       return (reader.readBoolOrNull(offset)) as P;
+    case 14:
+      return (reader.readStringOrNull(offset)) as P;
     case 15:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 16:
       return (_SettingsaudioChannelsValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               AudioChannel.autoSafe)
           as P;
-    case 16:
-      return (reader.readStringOrNull(offset)) as P;
     case 17:
       return (reader.readStringOrNull(offset)) as P;
     case 18:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 19:
       return (reader.readBoolOrNull(offset)) as P;
     case 20:
       return (reader.readBoolOrNull(offset)) as P;
     case 21:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 22:
       return (reader.readObjectList<AutoScrollPages>(
             offset,
             AutoScrollPagesSchema.deserialize,
@@ -2342,27 +2358,27 @@ P _settingsDeserializeProp<P>(
             AutoScrollPages(),
           ))
           as P;
-    case 22:
-      return (reader.readBoolOrNull(offset)) as P;
     case 23:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 24:
       return (_SettingsbackgroundColorValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               BackgroundColor.black)
           as P;
-    case 24:
-      return (reader.readLongOrNull(offset)) as P;
     case 25:
       return (reader.readLongOrNull(offset)) as P;
     case 26:
-      return (reader.readLongList(offset)) as P;
-    case 27:
-      return (reader.readStringOrNull(offset)) as P;
-    case 28:
       return (reader.readLongOrNull(offset)) as P;
-    case 29:
+    case 27:
+      return (reader.readLongList(offset)) as P;
+    case 28:
       return (reader.readStringOrNull(offset)) as P;
+    case 29:
+      return (reader.readLongOrNull(offset)) as P;
     case 30:
+      return (reader.readStringOrNull(offset)) as P;
+    case 31:
       return (reader.readObjectList<ChapterFilterBookmarked>(
             offset,
             ChapterFilterBookmarkedSchema.deserialize,
@@ -2370,7 +2386,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterBookmarked(),
           ))
           as P;
-    case 31:
+    case 32:
       return (reader.readObjectList<ChapterFilterDownloaded>(
             offset,
             ChapterFilterDownloadedSchema.deserialize,
@@ -2378,7 +2394,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterDownloaded(),
           ))
           as P;
-    case 32:
+    case 33:
       return (reader.readObjectList<ChapterFilterUnread>(
             offset,
             ChapterFilterUnreadSchema.deserialize,
@@ -2386,7 +2402,7 @@ P _settingsDeserializeProp<P>(
             ChapterFilterUnread(),
           ))
           as P;
-    case 33:
+    case 34:
       return (reader.readObjectList<ChapterPageIndex>(
             offset,
             ChapterPageIndexSchema.deserialize,
@@ -2394,7 +2410,7 @@ P _settingsDeserializeProp<P>(
             ChapterPageIndex(),
           ))
           as P;
-    case 34:
+    case 35:
       return (reader.readObjectList<ChapterPageurls>(
             offset,
             ChapterPageurlsSchema.deserialize,
@@ -2402,21 +2418,21 @@ P _settingsDeserializeProp<P>(
             ChapterPageurls(),
           ))
           as P;
-    case 35:
-      return (reader.readBoolOrNull(offset)) as P;
     case 36:
       return (reader.readBoolOrNull(offset)) as P;
     case 37:
       return (reader.readBoolOrNull(offset)) as P;
     case 38:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 39:
       return (_SettingscolorFilterBlendModeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               ColorFilterBlendMode.none)
           as P;
-    case 39:
-      return (reader.readLongOrNull(offset)) as P;
     case 40:
+      return (reader.readLongOrNull(offset)) as P;
+    case 41:
       return (reader.readObjectList<MCookie>(
             offset,
             MCookieSchema.deserialize,
@@ -2424,70 +2440,68 @@ P _settingsDeserializeProp<P>(
             MCookie(),
           ))
           as P;
-    case 41:
-      return (reader.readBoolOrNull(offset)) as P;
     case 42:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 43:
       return (reader.readObjectOrNull<CustomColorFilter>(
             offset,
             CustomColorFilterSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 43:
-      return (reader.readStringOrNull(offset)) as P;
     case 44:
       return (reader.readStringOrNull(offset)) as P;
     case 45:
       return (reader.readStringOrNull(offset)) as P;
     case 46:
+      return (reader.readStringOrNull(offset)) as P;
+    case 47:
       return (_SettingsdebandingTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DebandingType.none)
           as P;
-    case 47:
-      return (reader.readLongOrNull(offset)) as P;
     case 48:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 49:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 50:
       return (_SettingsdefaultReaderModeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               ReaderMode.vertical)
           as P;
-    case 50:
-      return (reader.readLongOrNull(offset)) as P;
     case 51:
+      return (reader.readLongOrNull(offset)) as P;
+    case 52:
       return (reader.readObjectOrNull<L10nLocale>(
             offset,
             L10nLocaleSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 52:
-      return (reader.readBoolOrNull(offset)) as P;
     case 53:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 54:
       return (_SettingsdisableSectionTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               SectionType.all)
           as P;
-    case 54:
+    case 55:
       return (_SettingsdisplayTypeValueEnumMap[reader.readByteOrNull(offset)] ??
               DisplayType.compactGrid)
           as P;
-    case 55:
-      return (reader.readBoolOrNull(offset)) as P;
     case 56:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 57:
       return (reader.readLongOrNull(offset)) as P;
     case 58:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 59:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 60:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 61:
       return (reader.readBoolOrNull(offset)) as P;
     case 62:
@@ -2511,8 +2525,12 @@ P _settingsDeserializeProp<P>(
     case 71:
       return (reader.readBoolOrNull(offset)) as P;
     case 72:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 73:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 74:
+      return (reader.readStringOrNull(offset)) as P;
+    case 75:
       return (reader.readObjectList<FilterScanlator>(
             offset,
             FilterScanlatorSchema.deserialize,
@@ -2520,22 +2538,18 @@ P _settingsDeserializeProp<P>(
             FilterScanlator(),
           ))
           as P;
-    case 74:
-      return (reader.readLongOrNull(offset)) as P;
-    case 75:
-      return (reader.readLongOrNull(offset)) as P;
     case 76:
       return (reader.readLongOrNull(offset)) as P;
     case 77:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 78:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 79:
       return (reader.readLongOrNull(offset)) as P;
+    case 78:
+      return (reader.readLongOrNull(offset)) as P;
+    case 79:
+      return (reader.readBoolOrNull(offset)) as P;
     case 80:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 81:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 82:
       return (reader.readBoolOrNull(offset)) as P;
     case 83:
@@ -2545,27 +2559,27 @@ P _settingsDeserializeProp<P>(
     case 85:
       return (reader.readBoolOrNull(offset)) as P;
     case 86:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 87:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 88:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringList(offset)) as P;
     case 89:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 90:
       return (reader.readStringOrNull(offset)) as P;
+    case 90:
+      return (reader.readBoolOrNull(offset)) as P;
     case 91:
       return (reader.readBoolOrNull(offset)) as P;
     case 92:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 93:
       return (reader.readStringOrNull(offset)) as P;
+    case 93:
+      return (reader.readBoolOrNull(offset)) as P;
     case 94:
       return (reader.readBoolOrNull(offset)) as P;
     case 95:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 96:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 97:
       return (reader.readLongOrNull(offset)) as P;
     case 98:
@@ -2599,9 +2613,9 @@ P _settingsDeserializeProp<P>(
     case 112:
       return (reader.readLongOrNull(offset)) as P;
     case 113:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 114:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 115:
       return (reader.readBoolOrNull(offset)) as P;
     case 116:
@@ -2609,15 +2623,19 @@ P _settingsDeserializeProp<P>(
     case 117:
       return (reader.readBoolOrNull(offset)) as P;
     case 118:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 119:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 120:
+      return (reader.readStringList(offset)) as P;
+    case 121:
       return (reader.readObjectOrNull<L10nLocale>(
             offset,
             L10nLocaleSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 120:
+    case 122:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2625,29 +2643,29 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 121:
+    case 123:
       return (reader.readLongOrNull(offset)) as P;
-    case 122:
+    case 124:
       return (_SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 123:
-      return (reader.readLongOrNull(offset)) as P;
-    case 124:
-      return (reader.readBoolOrNull(offset)) as P;
     case 125:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 126:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 127:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 128:
+      return (reader.readStringList(offset)) as P;
+    case 129:
       return (_SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 128:
+    case 130:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2655,14 +2673,10 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 129:
-      return (reader.readLongOrNull(offset)) as P;
-    case 130:
-      return (reader.readLongOrNull(offset)) as P;
     case 131:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 132:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 133:
       return (reader.readBoolOrNull(offset)) as P;
     case 134:
@@ -2672,30 +2686,34 @@ P _settingsDeserializeProp<P>(
     case 136:
       return (reader.readBoolOrNull(offset)) as P;
     case 137:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 138:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 139:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 140:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 141:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 142:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 143:
       return (reader.readBoolOrNull(offset)) as P;
     case 144:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 145:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 146:
       return (_SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               NovelTextAlign.left)
           as P;
-    case 145:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 146:
-      return (reader.readLongOrNull(offset)) as P;
     case 147:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 148:
+      return (reader.readLongOrNull(offset)) as P;
+    case 149:
       return (reader.readObjectList<PersonalPageMode>(
             offset,
             PersonalPageModeSchema.deserialize,
@@ -2703,7 +2721,7 @@ P _settingsDeserializeProp<P>(
             PersonalPageMode(),
           ))
           as P;
-    case 148:
+    case 150:
       return (reader.readObjectList<PersonalReaderMode>(
             offset,
             PersonalReaderModeSchema.deserialize,
@@ -2711,67 +2729,53 @@ P _settingsDeserializeProp<P>(
             PersonalReaderMode(),
           ))
           as P;
-    case 149:
+    case 151:
       return (reader.readObjectOrNull<PlayerSubtitleSettings>(
             offset,
             PlayerSubtitleSettingsSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 150:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 151:
-      return (reader.readDoubleOrNull(offset)) as P;
     case 152:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 153:
-      return (reader.readLongOrNull(offset)) as P;
-    case 154:
-      return (reader.readLongOrNull(offset)) as P;
-    case 155:
       return (reader.readDoubleOrNull(offset)) as P;
+    case 154:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 155:
+      return (reader.readLongOrNull(offset)) as P;
     case 156:
       return (reader.readLongOrNull(offset)) as P;
     case 157:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 158:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 159:
       return (reader.readBoolOrNull(offset)) as P;
     case 160:
       return (reader.readBoolOrNull(offset)) as P;
     case 161:
-      return (_SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offset)] ??
-              ScaleType.fitScreen)
-          as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 162:
       return (reader.readBoolOrNull(offset)) as P;
     case 163:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (_SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offset)] ??
+              ScaleType.fitScreen)
+          as P;
     case 164:
       return (reader.readBoolOrNull(offset)) as P;
     case 165:
       return (reader.readBoolOrNull(offset)) as P;
     case 166:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 167:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 168:
       return (reader.readObjectList<SortChapter>(
             offset,
             SortChapterSchema.deserialize,
             allOffsets,
             SortChapter(),
-          ))
-          as P;
-    case 167:
-      return (reader.readObjectOrNull<SortLibraryManga>(
-            offset,
-            SortLibraryMangaSchema.deserialize,
-            allOffsets,
-          ))
-          as P;
-    case 168:
-      return (reader.readObjectOrNull<SortLibraryManga>(
-            offset,
-            SortLibraryMangaSchema.deserialize,
-            allOffsets,
           ))
           as P;
     case 169:
@@ -2782,30 +2786,44 @@ P _settingsDeserializeProp<P>(
           ))
           as P;
     case 170:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readObjectOrNull<SortLibraryManga>(
+            offset,
+            SortLibraryMangaSchema.deserialize,
+            allOffsets,
+          ))
+          as P;
     case 171:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readObjectOrNull<SortLibraryManga>(
+            offset,
+            SortLibraryMangaSchema.deserialize,
+            allOffsets,
+          ))
+          as P;
     case 172:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 173:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 174:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 175:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 176:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 177:
       return (reader.readStringOrNull(offset)) as P;
+    case 177:
+      return (reader.readDoubleOrNull(offset)) as P;
     case 178:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 179:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 180:
       return (reader.readBoolOrNull(offset)) as P;
     case 181:
       return (reader.readBoolOrNull(offset)) as P;
     case 182:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 183:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 184:
       return (reader.readObjectList<UpdateError>(
             offset,
             UpdateErrorSchema.deserialize,
@@ -2813,29 +2831,29 @@ P _settingsDeserializeProp<P>(
             UpdateError(),
           ))
           as P;
-    case 183:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 184:
-      return (reader.readLongOrNull(offset)) as P;
     case 185:
       return (reader.readBoolOrNull(offset)) as P;
     case 186:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 187:
       return (reader.readBoolOrNull(offset)) as P;
     case 188:
       return (reader.readBoolOrNull(offset)) as P;
     case 189:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 190:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 191:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 192:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 193:
       return (reader.readLongOrNull(offset)) as P;
+    case 193:
+      return (reader.readBoolOrNull(offset)) as P;
     case 194:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 195:
+      return (reader.readLongOrNull(offset)) as P;
+    case 196:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -3116,6 +3134,36 @@ extension SettingsQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(
         const FilterCondition.isNotNull(property: r'algorithmWeights'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  allowConcurrentDownloadsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'allowConcurrentDownloads'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  allowConcurrentDownloadsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'allowConcurrentDownloads'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  allowConcurrentDownloadsEqualTo(bool? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'allowConcurrentDownloads',
+          value: value,
+        ),
       );
     });
   }
@@ -7284,6 +7332,82 @@ extension SettingsQueryFilter
       return query.addFilterCondition(
         FilterCondition.between(
           property: r'doubleTapAnimationSpeed',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'downloadDelaySeconds'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'downloadDelaySeconds'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsEqualTo(int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'downloadDelaySeconds',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsGreaterThan(int? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'downloadDelaySeconds',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsLessThan(int? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'downloadDelaySeconds',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadDelaySecondsBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'downloadDelaySeconds',
           lower: lower,
           includeLower: includeLower,
           upper: upper,
@@ -16172,6 +16296,20 @@ extension SettingsQueryLinks
 }
 
 extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  sortByAllowConcurrentDownloads() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'allowConcurrentDownloads', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  sortByAllowConcurrentDownloadsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'allowConcurrentDownloads', Sort.desc);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterSortBy> sortByAndroidProxyServer() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'androidProxyServer', Sort.asc);
@@ -16770,6 +16908,19 @@ extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
   sortByDoubleTapAnimationSpeedDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'doubleTapAnimationSpeed', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> sortByDownloadDelaySeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'downloadDelaySeconds', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  sortByDownloadDelaySecondsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'downloadDelaySeconds', Sort.desc);
     });
   }
 
@@ -18352,6 +18503,20 @@ extension SettingsQuerySortBy on QueryBuilder<Settings, Settings, QSortBy> {
 
 extension SettingsQuerySortThenBy
     on QueryBuilder<Settings, Settings, QSortThenBy> {
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  thenByAllowConcurrentDownloads() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'allowConcurrentDownloads', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  thenByAllowConcurrentDownloadsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'allowConcurrentDownloads', Sort.desc);
+    });
+  }
+
   QueryBuilder<Settings, Settings, QAfterSortBy> thenByAndroidProxyServer() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'androidProxyServer', Sort.asc);
@@ -18950,6 +19115,19 @@ extension SettingsQuerySortThenBy
   thenByDoubleTapAnimationSpeedDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'doubleTapAnimationSpeed', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy> thenByDownloadDelaySeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'downloadDelaySeconds', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterSortBy>
+  thenByDownloadDelaySecondsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'downloadDelaySeconds', Sort.desc);
     });
   }
 
@@ -20544,6 +20722,13 @@ extension SettingsQuerySortThenBy
 
 extension SettingsQueryWhereDistinct
     on QueryBuilder<Settings, Settings, QDistinct> {
+  QueryBuilder<Settings, Settings, QDistinct>
+  distinctByAllowConcurrentDownloads() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'allowConcurrentDownloads');
+    });
+  }
+
   QueryBuilder<Settings, Settings, QDistinct> distinctByAndroidProxyServer({
     bool caseSensitive = true,
   }) {
@@ -20871,6 +21056,12 @@ extension SettingsQueryWhereDistinct
   distinctByDoubleTapAnimationSpeed() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'doubleTapAnimationSpeed');
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QDistinct> distinctByDownloadDelaySeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'downloadDelaySeconds');
     });
   }
 
@@ -21720,6 +21911,13 @@ extension SettingsQueryProperty
     });
   }
 
+  QueryBuilder<Settings, bool?, QQueryOperations>
+  allowConcurrentDownloadsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'allowConcurrentDownloads');
+    });
+  }
+
   QueryBuilder<Settings, String?, QQueryOperations>
   androidProxyServerProperty() {
     return QueryBuilder.apply(this, (query) {
@@ -22100,6 +22298,13 @@ extension SettingsQueryProperty
   doubleTapAnimationSpeedProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'doubleTapAnimationSpeed');
+    });
+  }
+
+  QueryBuilder<Settings, int?, QQueryOperations>
+  downloadDelaySecondsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'downloadDelaySeconds');
     });
   }
 

--- a/lib/models/settings.g.dart
+++ b/lib/models/settings.g.dart
@@ -357,702 +357,707 @@ const SettingsSchema = CollectionSchema(
       name: r'downloadOnlyOnWifi',
       type: IsarType.bool,
     ),
-    r'downloadedOnlyMode': PropertySchema(
+    r'downloadQueueOrder': PropertySchema(
       id: 62,
+      name: r'downloadQueueOrder',
+      type: IsarType.longList,
+    ),
+    r'downloadedOnlyMode': PropertySchema(
+      id: 63,
       name: r'downloadedOnlyMode',
       type: IsarType.bool,
     ),
     r'dualPageInvert': PropertySchema(
-      id: 63,
+      id: 64,
       name: r'dualPageInvert',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFit': PropertySchema(
-      id: 64,
+      id: 65,
       name: r'dualPageRotateToFit',
       type: IsarType.bool,
     ),
     r'dualPageRotateToFitInvert': PropertySchema(
-      id: 65,
+      id: 66,
       name: r'dualPageRotateToFitInvert',
       type: IsarType.bool,
     ),
     r'enableAniSkip': PropertySchema(
-      id: 66,
+      id: 67,
       name: r'enableAniSkip',
       type: IsarType.bool,
     ),
     r'enableAudioPitchCorrection': PropertySchema(
-      id: 67,
+      id: 68,
       name: r'enableAudioPitchCorrection',
       type: IsarType.bool,
     ),
     r'enableAutoSkip': PropertySchema(
-      id: 68,
+      id: 69,
       name: r'enableAutoSkip',
       type: IsarType.bool,
     ),
     r'enableCustomColorFilter': PropertySchema(
-      id: 69,
+      id: 70,
       name: r'enableCustomColorFilter',
       type: IsarType.bool,
     ),
     r'enableDiscordRpc': PropertySchema(
-      id: 70,
+      id: 71,
       name: r'enableDiscordRpc',
       type: IsarType.bool,
     ),
     r'enableGpuNext': PropertySchema(
-      id: 71,
+      id: 72,
       name: r'enableGpuNext',
       type: IsarType.bool,
     ),
     r'enableHardwareAcceleration': PropertySchema(
-      id: 72,
+      id: 73,
       name: r'enableHardwareAcceleration',
       type: IsarType.bool,
     ),
     r'enableLogs': PropertySchema(
-      id: 73,
+      id: 74,
       name: r'enableLogs',
       type: IsarType.bool,
     ),
     r'extensionServerPath': PropertySchema(
-      id: 74,
+      id: 75,
       name: r'extensionServerPath',
       type: IsarType.string,
     ),
     r'filterScanlatorList': PropertySchema(
-      id: 75,
+      id: 76,
       name: r'filterScanlatorList',
       type: IsarType.objectList,
 
       target: r'FilterScanlator',
     ),
     r'flashColor': PropertySchema(
-      id: 76,
+      id: 77,
       name: r'flashColor',
       type: IsarType.long,
     ),
     r'flashDuration': PropertySchema(
-      id: 77,
+      id: 78,
       name: r'flashDuration',
       type: IsarType.long,
     ),
     r'flashInterval': PropertySchema(
-      id: 78,
+      id: 79,
       name: r'flashInterval',
       type: IsarType.long,
     ),
     r'flashOnPageChange': PropertySchema(
-      id: 79,
+      id: 80,
       name: r'flashOnPageChange',
       type: IsarType.bool,
     ),
     r'flexColorSchemeBlendLevel': PropertySchema(
-      id: 80,
+      id: 81,
       name: r'flexColorSchemeBlendLevel',
       type: IsarType.double,
     ),
     r'flexSchemeColorIndex': PropertySchema(
-      id: 81,
+      id: 82,
       name: r'flexSchemeColorIndex',
       type: IsarType.long,
     ),
     r'followSystemTheme': PropertySchema(
-      id: 82,
+      id: 83,
       name: r'followSystemTheme',
       type: IsarType.bool,
     ),
     r'forceLandscapePlayer': PropertySchema(
-      id: 83,
+      id: 84,
       name: r'forceLandscapePlayer',
       type: IsarType.bool,
     ),
     r'fullScreenPlayer': PropertySchema(
-      id: 84,
+      id: 85,
       name: r'fullScreenPlayer',
       type: IsarType.bool,
     ),
     r'fullScreenReader': PropertySchema(
-      id: 85,
+      id: 86,
       name: r'fullScreenReader',
       type: IsarType.bool,
     ),
     r'grayscale': PropertySchema(
-      id: 86,
+      id: 87,
       name: r'grayscale',
       type: IsarType.bool,
     ),
     r'hideDiscordRpcInIncognito': PropertySchema(
-      id: 87,
+      id: 88,
       name: r'hideDiscordRpcInIncognito',
       type: IsarType.bool,
     ),
     r'hideItems': PropertySchema(
-      id: 88,
+      id: 89,
       name: r'hideItems',
       type: IsarType.stringList,
     ),
     r'hwdecMode': PropertySchema(
-      id: 89,
+      id: 90,
       name: r'hwdecMode',
       type: IsarType.string,
     ),
     r'incognitoMode': PropertySchema(
-      id: 90,
+      id: 91,
       name: r'incognitoMode',
       type: IsarType.bool,
     ),
     r'invertColors': PropertySchema(
-      id: 91,
+      id: 92,
       name: r'invertColors',
       type: IsarType.bool,
     ),
-    r'jrePath': PropertySchema(id: 92, name: r'jrePath', type: IsarType.string),
+    r'jrePath': PropertySchema(id: 93, name: r'jrePath', type: IsarType.string),
     r'keepScreenOnReader': PropertySchema(
-      id: 93,
+      id: 94,
       name: r'keepScreenOnReader',
       type: IsarType.bool,
     ),
     r'landscapeZoom': PropertySchema(
-      id: 94,
+      id: 95,
       name: r'landscapeZoom',
       type: IsarType.bool,
     ),
     r'lastTrackerLibraryLocation': PropertySchema(
-      id: 95,
+      id: 96,
       name: r'lastTrackerLibraryLocation',
       type: IsarType.string,
     ),
     r'libraryDownloadedChapters': PropertySchema(
-      id: 96,
+      id: 97,
       name: r'libraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'libraryFilterAnimeBookMarkedType': PropertySchema(
-      id: 97,
+      id: 98,
       name: r'libraryFilterAnimeBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeCompletedType': PropertySchema(
-      id: 98,
+      id: 99,
       name: r'libraryFilterAnimeCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeDownloadType': PropertySchema(
-      id: 99,
+      id: 100,
       name: r'libraryFilterAnimeDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeStartedType': PropertySchema(
-      id: 100,
+      id: 101,
       name: r'libraryFilterAnimeStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeTrackingType': PropertySchema(
-      id: 101,
+      id: 102,
       name: r'libraryFilterAnimeTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterAnimeUnreadType': PropertySchema(
-      id: 102,
+      id: 103,
       name: r'libraryFilterAnimeUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasBookMarkedType': PropertySchema(
-      id: 103,
+      id: 104,
       name: r'libraryFilterMangasBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasCompletedType': PropertySchema(
-      id: 104,
+      id: 105,
       name: r'libraryFilterMangasCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasDownloadType': PropertySchema(
-      id: 105,
+      id: 106,
       name: r'libraryFilterMangasDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasStartedType': PropertySchema(
-      id: 106,
+      id: 107,
       name: r'libraryFilterMangasStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasTrackingType': PropertySchema(
-      id: 107,
+      id: 108,
       name: r'libraryFilterMangasTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterMangasUnreadType': PropertySchema(
-      id: 108,
+      id: 109,
       name: r'libraryFilterMangasUnreadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelBookMarkedType': PropertySchema(
-      id: 109,
+      id: 110,
       name: r'libraryFilterNovelBookMarkedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelCompletedType': PropertySchema(
-      id: 110,
+      id: 111,
       name: r'libraryFilterNovelCompletedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelDownloadType': PropertySchema(
-      id: 111,
+      id: 112,
       name: r'libraryFilterNovelDownloadType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelStartedType': PropertySchema(
-      id: 112,
+      id: 113,
       name: r'libraryFilterNovelStartedType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelTrackingType': PropertySchema(
-      id: 113,
+      id: 114,
       name: r'libraryFilterNovelTrackingType',
       type: IsarType.long,
     ),
     r'libraryFilterNovelUnreadType': PropertySchema(
-      id: 114,
+      id: 115,
       name: r'libraryFilterNovelUnreadType',
       type: IsarType.long,
     ),
     r'libraryLocalSource': PropertySchema(
-      id: 115,
+      id: 116,
       name: r'libraryLocalSource',
       type: IsarType.bool,
     ),
     r'libraryShowCategoryTabs': PropertySchema(
-      id: 116,
+      id: 117,
       name: r'libraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'libraryShowContinueReadingButton': PropertySchema(
-      id: 117,
+      id: 118,
       name: r'libraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'libraryShowLanguage': PropertySchema(
-      id: 118,
+      id: 119,
       name: r'libraryShowLanguage',
       type: IsarType.bool,
     ),
     r'libraryShowNumbersOfItems': PropertySchema(
-      id: 119,
+      id: 120,
       name: r'libraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'localFolders': PropertySchema(
-      id: 120,
+      id: 121,
       name: r'localFolders',
       type: IsarType.stringList,
     ),
     r'locale': PropertySchema(
-      id: 121,
+      id: 122,
       name: r'locale',
       type: IsarType.object,
 
       target: r'L10nLocale',
     ),
     r'mangaExtensionsRepo': PropertySchema(
-      id: 122,
+      id: 123,
       name: r'mangaExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'mangaGridSize': PropertySchema(
-      id: 123,
+      id: 124,
       name: r'mangaGridSize',
       type: IsarType.long,
     ),
     r'mangaHomeDisplayType': PropertySchema(
-      id: 124,
+      id: 125,
       name: r'mangaHomeDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsmangaHomeDisplayTypeEnumValueMap,
     ),
     r'markEpisodeAsSeenType': PropertySchema(
-      id: 125,
+      id: 126,
       name: r'markEpisodeAsSeenType',
       type: IsarType.long,
     ),
     r'mergeLibraryNavMobile': PropertySchema(
-      id: 126,
+      id: 127,
       name: r'mergeLibraryNavMobile',
       type: IsarType.bool,
     ),
     r'navigateToPan': PropertySchema(
-      id: 127,
+      id: 128,
       name: r'navigateToPan',
       type: IsarType.bool,
     ),
     r'navigationOrder': PropertySchema(
-      id: 128,
+      id: 129,
       name: r'navigationOrder',
       type: IsarType.stringList,
     ),
     r'novelDisplayType': PropertySchema(
-      id: 129,
+      id: 130,
       name: r'novelDisplayType',
       type: IsarType.byte,
       enumMap: _SettingsnovelDisplayTypeEnumValueMap,
     ),
     r'novelExtensionsRepo': PropertySchema(
-      id: 130,
+      id: 131,
       name: r'novelExtensionsRepo',
       type: IsarType.objectList,
 
       target: r'Repo',
     ),
     r'novelFontSize': PropertySchema(
-      id: 131,
+      id: 132,
       name: r'novelFontSize',
       type: IsarType.long,
     ),
     r'novelGridSize': PropertySchema(
-      id: 132,
+      id: 133,
       name: r'novelGridSize',
       type: IsarType.long,
     ),
     r'novelLibraryDownloadedChapters': PropertySchema(
-      id: 133,
+      id: 134,
       name: r'novelLibraryDownloadedChapters',
       type: IsarType.bool,
     ),
     r'novelLibraryLocalSource': PropertySchema(
-      id: 134,
+      id: 135,
       name: r'novelLibraryLocalSource',
       type: IsarType.bool,
     ),
     r'novelLibraryShowCategoryTabs': PropertySchema(
-      id: 135,
+      id: 136,
       name: r'novelLibraryShowCategoryTabs',
       type: IsarType.bool,
     ),
     r'novelLibraryShowContinueReadingButton': PropertySchema(
-      id: 136,
+      id: 137,
       name: r'novelLibraryShowContinueReadingButton',
       type: IsarType.bool,
     ),
     r'novelLibraryShowLanguage': PropertySchema(
-      id: 137,
+      id: 138,
       name: r'novelLibraryShowLanguage',
       type: IsarType.bool,
     ),
     r'novelLibraryShowNumbersOfItems': PropertySchema(
-      id: 138,
+      id: 139,
       name: r'novelLibraryShowNumbersOfItems',
       type: IsarType.bool,
     ),
     r'novelReaderLineHeight': PropertySchema(
-      id: 139,
+      id: 140,
       name: r'novelReaderLineHeight',
       type: IsarType.double,
     ),
     r'novelReaderPadding': PropertySchema(
-      id: 140,
+      id: 141,
       name: r'novelReaderPadding',
       type: IsarType.long,
     ),
     r'novelReaderTextColor': PropertySchema(
-      id: 141,
+      id: 142,
       name: r'novelReaderTextColor',
       type: IsarType.string,
     ),
     r'novelReaderTheme': PropertySchema(
-      id: 142,
+      id: 143,
       name: r'novelReaderTheme',
       type: IsarType.string,
     ),
     r'novelRemoveExtraParagraphSpacing': PropertySchema(
-      id: 143,
+      id: 144,
       name: r'novelRemoveExtraParagraphSpacing',
       type: IsarType.bool,
     ),
     r'novelShowScrollPercentage': PropertySchema(
-      id: 144,
+      id: 145,
       name: r'novelShowScrollPercentage',
       type: IsarType.bool,
     ),
     r'novelTapToScroll': PropertySchema(
-      id: 145,
+      id: 146,
       name: r'novelTapToScroll',
       type: IsarType.bool,
     ),
     r'novelTextAlign': PropertySchema(
-      id: 146,
+      id: 147,
       name: r'novelTextAlign',
       type: IsarType.byte,
       enumMap: _SettingsnovelTextAlignEnumValueMap,
     ),
     r'onlyIncludePinnedSources': PropertySchema(
-      id: 147,
+      id: 148,
       name: r'onlyIncludePinnedSources',
       type: IsarType.bool,
     ),
     r'pagePreloadAmount': PropertySchema(
-      id: 148,
+      id: 149,
       name: r'pagePreloadAmount',
       type: IsarType.long,
     ),
     r'personalPageModeList': PropertySchema(
-      id: 149,
+      id: 150,
       name: r'personalPageModeList',
       type: IsarType.objectList,
 
       target: r'PersonalPageMode',
     ),
     r'personalReaderModeList': PropertySchema(
-      id: 150,
+      id: 151,
       name: r'personalReaderModeList',
       type: IsarType.objectList,
 
       target: r'PersonalReaderMode',
     ),
     r'playerSubtitleSettings': PropertySchema(
-      id: 151,
+      id: 152,
       name: r'playerSubtitleSettings',
       type: IsarType.object,
 
       target: r'PlayerSubtitleSettings',
     ),
     r'pureBlackDarkMode': PropertySchema(
-      id: 152,
+      id: 153,
       name: r'pureBlackDarkMode',
       type: IsarType.bool,
     ),
     r'readerBrightness': PropertySchema(
-      id: 153,
+      id: 154,
       name: r'readerBrightness',
       type: IsarType.double,
     ),
     r'readerContrast': PropertySchema(
-      id: 154,
+      id: 155,
       name: r'readerContrast',
       type: IsarType.double,
     ),
     r'readerHideThreshold': PropertySchema(
-      id: 155,
+      id: 156,
       name: r'readerHideThreshold',
       type: IsarType.long,
     ),
     r'readerNavigationLayout': PropertySchema(
-      id: 156,
+      id: 157,
       name: r'readerNavigationLayout',
       type: IsarType.long,
     ),
     r'readerSaturation': PropertySchema(
-      id: 157,
+      id: 158,
       name: r'readerSaturation',
       type: IsarType.double,
     ),
     r'relativeTimesTamps': PropertySchema(
-      id: 158,
+      id: 159,
       name: r'relativeTimesTamps',
       type: IsarType.long,
     ),
     r'rpcShowCoverImage': PropertySchema(
-      id: 159,
+      id: 160,
       name: r'rpcShowCoverImage',
       type: IsarType.bool,
     ),
     r'rpcShowReadingWatchingProgress': PropertySchema(
-      id: 160,
+      id: 161,
       name: r'rpcShowReadingWatchingProgress',
       type: IsarType.bool,
     ),
     r'rpcShowTitle': PropertySchema(
-      id: 161,
+      id: 162,
       name: r'rpcShowTitle',
       type: IsarType.bool,
     ),
     r'saveAsCBZArchive': PropertySchema(
-      id: 162,
+      id: 163,
       name: r'saveAsCBZArchive',
       type: IsarType.bool,
     ),
     r'scaleType': PropertySchema(
-      id: 163,
+      id: 164,
       name: r'scaleType',
       type: IsarType.byte,
       enumMap: _SettingsscaleTypeEnumValueMap,
     ),
     r'showNSFW': PropertySchema(
-      id: 164,
+      id: 165,
       name: r'showNSFW',
       type: IsarType.bool,
     ),
     r'showNavigationOverlayOnStart': PropertySchema(
-      id: 165,
+      id: 166,
       name: r'showNavigationOverlayOnStart',
       type: IsarType.bool,
     ),
     r'showPageGaps': PropertySchema(
-      id: 166,
+      id: 167,
       name: r'showPageGaps',
       type: IsarType.bool,
     ),
     r'showPagesNumber': PropertySchema(
-      id: 167,
+      id: 168,
       name: r'showPagesNumber',
       type: IsarType.bool,
     ),
     r'sortChapterList': PropertySchema(
-      id: 168,
+      id: 169,
       name: r'sortChapterList',
       type: IsarType.objectList,
 
       target: r'SortChapter',
     ),
     r'sortLibraryAnime': PropertySchema(
-      id: 169,
+      id: 170,
       name: r'sortLibraryAnime',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryManga': PropertySchema(
-      id: 170,
+      id: 171,
       name: r'sortLibraryManga',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'sortLibraryNovel': PropertySchema(
-      id: 171,
+      id: 172,
       name: r'sortLibraryNovel',
       type: IsarType.object,
 
       target: r'SortLibraryManga',
     ),
     r'splitWidePages': PropertySchema(
-      id: 172,
+      id: 173,
       name: r'splitWidePages',
       type: IsarType.bool,
     ),
     r'startDatebackup': PropertySchema(
-      id: 173,
+      id: 174,
       name: r'startDatebackup',
       type: IsarType.long,
     ),
     r'tappingInversion': PropertySchema(
-      id: 174,
+      id: 175,
       name: r'tappingInversion',
       type: IsarType.long,
     ),
     r'themeIsDark': PropertySchema(
-      id: 175,
+      id: 176,
       name: r'themeIsDark',
       type: IsarType.bool,
     ),
     r'ttsLanguage': PropertySchema(
-      id: 176,
+      id: 177,
       name: r'ttsLanguage',
       type: IsarType.string,
     ),
     r'ttsPitch': PropertySchema(
-      id: 177,
+      id: 178,
       name: r'ttsPitch',
       type: IsarType.double,
     ),
     r'ttsSpeechRate': PropertySchema(
-      id: 178,
+      id: 179,
       name: r'ttsSpeechRate',
       type: IsarType.double,
     ),
     r'ttsVoice': PropertySchema(
-      id: 179,
+      id: 180,
       name: r'ttsVoice',
       type: IsarType.string,
     ),
     r'tvAnimeOnlyOverride': PropertySchema(
-      id: 180,
+      id: 181,
       name: r'tvAnimeOnlyOverride',
       type: IsarType.bool,
     ),
     r'tvHomeGenreRows': PropertySchema(
-      id: 181,
+      id: 182,
       name: r'tvHomeGenreRows',
       type: IsarType.bool,
     ),
     r'tvHomeStyle': PropertySchema(
-      id: 182,
+      id: 183,
       name: r'tvHomeStyle',
       type: IsarType.bool,
     ),
     r'tvPlayerStyle': PropertySchema(
-      id: 183,
+      id: 184,
       name: r'tvPlayerStyle',
       type: IsarType.bool,
     ),
     r'updateErrorsList': PropertySchema(
-      id: 184,
+      id: 185,
       name: r'updateErrorsList',
       type: IsarType.objectList,
 
       target: r'UpdateError',
     ),
     r'updateProgressAfterReading': PropertySchema(
-      id: 185,
+      id: 186,
       name: r'updateProgressAfterReading',
       type: IsarType.bool,
     ),
     r'updatedAt': PropertySchema(
-      id: 186,
+      id: 187,
       name: r'updatedAt',
       type: IsarType.long,
     ),
     r'useLibass': PropertySchema(
-      id: 187,
+      id: 188,
       name: r'useLibass',
       type: IsarType.bool,
     ),
     r'useMpvConfig': PropertySchema(
-      id: 188,
+      id: 189,
       name: r'useMpvConfig',
       type: IsarType.bool,
     ),
     r'usePageTapZones': PropertySchema(
-      id: 189,
+      id: 190,
       name: r'usePageTapZones',
       type: IsarType.bool,
     ),
     r'useYUV420P': PropertySchema(
-      id: 190,
+      id: 191,
       name: r'useYUV420P',
       type: IsarType.bool,
     ),
     r'userAgent': PropertySchema(
-      id: 191,
+      id: 192,
       name: r'userAgent',
       type: IsarType.string,
     ),
     r'volumeBoostCap': PropertySchema(
-      id: 192,
+      id: 193,
       name: r'volumeBoostCap',
       type: IsarType.long,
     ),
     r'webtoonDisableZoomOut': PropertySchema(
-      id: 193,
+      id: 194,
       name: r'webtoonDisableZoomOut',
       type: IsarType.bool,
     ),
     r'webtoonDoubleTapZoomEnabled': PropertySchema(
-      id: 194,
+      id: 195,
       name: r'webtoonDoubleTapZoomEnabled',
       type: IsarType.bool,
     ),
     r'webtoonSidePadding': PropertySchema(
-      id: 195,
+      id: 196,
       name: r'webtoonSidePadding',
       type: IsarType.long,
     ),
     r'zoomStartPosition': PropertySchema(
-      id: 196,
+      id: 197,
       name: r'zoomStartPosition',
       type: IsarType.long,
     ),
@@ -1333,6 +1338,12 @@ int _settingsEstimateSize(
     final value = object.downloadLocation;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.downloadQueueOrder;
+    if (value != null) {
+      bytesCount += 3 + value.length * 8;
     }
   }
   {
@@ -1722,201 +1733,202 @@ void _settingsSerialize(
   writer.writeLong(offsets[59], object.downloadDelaySeconds);
   writer.writeString(offsets[60], object.downloadLocation);
   writer.writeBool(offsets[61], object.downloadOnlyOnWifi);
-  writer.writeBool(offsets[62], object.downloadedOnlyMode);
-  writer.writeBool(offsets[63], object.dualPageInvert);
-  writer.writeBool(offsets[64], object.dualPageRotateToFit);
-  writer.writeBool(offsets[65], object.dualPageRotateToFitInvert);
-  writer.writeBool(offsets[66], object.enableAniSkip);
-  writer.writeBool(offsets[67], object.enableAudioPitchCorrection);
-  writer.writeBool(offsets[68], object.enableAutoSkip);
-  writer.writeBool(offsets[69], object.enableCustomColorFilter);
-  writer.writeBool(offsets[70], object.enableDiscordRpc);
-  writer.writeBool(offsets[71], object.enableGpuNext);
-  writer.writeBool(offsets[72], object.enableHardwareAcceleration);
-  writer.writeBool(offsets[73], object.enableLogs);
-  writer.writeString(offsets[74], object.extensionServerPath);
+  writer.writeLongList(offsets[62], object.downloadQueueOrder);
+  writer.writeBool(offsets[63], object.downloadedOnlyMode);
+  writer.writeBool(offsets[64], object.dualPageInvert);
+  writer.writeBool(offsets[65], object.dualPageRotateToFit);
+  writer.writeBool(offsets[66], object.dualPageRotateToFitInvert);
+  writer.writeBool(offsets[67], object.enableAniSkip);
+  writer.writeBool(offsets[68], object.enableAudioPitchCorrection);
+  writer.writeBool(offsets[69], object.enableAutoSkip);
+  writer.writeBool(offsets[70], object.enableCustomColorFilter);
+  writer.writeBool(offsets[71], object.enableDiscordRpc);
+  writer.writeBool(offsets[72], object.enableGpuNext);
+  writer.writeBool(offsets[73], object.enableHardwareAcceleration);
+  writer.writeBool(offsets[74], object.enableLogs);
+  writer.writeString(offsets[75], object.extensionServerPath);
   writer.writeObjectList<FilterScanlator>(
-    offsets[75],
+    offsets[76],
     allOffsets,
     FilterScanlatorSchema.serialize,
     object.filterScanlatorList,
   );
-  writer.writeLong(offsets[76], object.flashColor);
-  writer.writeLong(offsets[77], object.flashDuration);
-  writer.writeLong(offsets[78], object.flashInterval);
-  writer.writeBool(offsets[79], object.flashOnPageChange);
-  writer.writeDouble(offsets[80], object.flexColorSchemeBlendLevel);
-  writer.writeLong(offsets[81], object.flexSchemeColorIndex);
-  writer.writeBool(offsets[82], object.followSystemTheme);
-  writer.writeBool(offsets[83], object.forceLandscapePlayer);
-  writer.writeBool(offsets[84], object.fullScreenPlayer);
-  writer.writeBool(offsets[85], object.fullScreenReader);
-  writer.writeBool(offsets[86], object.grayscale);
-  writer.writeBool(offsets[87], object.hideDiscordRpcInIncognito);
-  writer.writeStringList(offsets[88], object.hideItems);
-  writer.writeString(offsets[89], object.hwdecMode);
-  writer.writeBool(offsets[90], object.incognitoMode);
-  writer.writeBool(offsets[91], object.invertColors);
-  writer.writeString(offsets[92], object.jrePath);
-  writer.writeBool(offsets[93], object.keepScreenOnReader);
-  writer.writeBool(offsets[94], object.landscapeZoom);
-  writer.writeString(offsets[95], object.lastTrackerLibraryLocation);
-  writer.writeBool(offsets[96], object.libraryDownloadedChapters);
-  writer.writeLong(offsets[97], object.libraryFilterAnimeBookMarkedType);
-  writer.writeLong(offsets[98], object.libraryFilterAnimeCompletedType);
-  writer.writeLong(offsets[99], object.libraryFilterAnimeDownloadType);
-  writer.writeLong(offsets[100], object.libraryFilterAnimeStartedType);
-  writer.writeLong(offsets[101], object.libraryFilterAnimeTrackingType);
-  writer.writeLong(offsets[102], object.libraryFilterAnimeUnreadType);
-  writer.writeLong(offsets[103], object.libraryFilterMangasBookMarkedType);
-  writer.writeLong(offsets[104], object.libraryFilterMangasCompletedType);
-  writer.writeLong(offsets[105], object.libraryFilterMangasDownloadType);
-  writer.writeLong(offsets[106], object.libraryFilterMangasStartedType);
-  writer.writeLong(offsets[107], object.libraryFilterMangasTrackingType);
-  writer.writeLong(offsets[108], object.libraryFilterMangasUnreadType);
-  writer.writeLong(offsets[109], object.libraryFilterNovelBookMarkedType);
-  writer.writeLong(offsets[110], object.libraryFilterNovelCompletedType);
-  writer.writeLong(offsets[111], object.libraryFilterNovelDownloadType);
-  writer.writeLong(offsets[112], object.libraryFilterNovelStartedType);
-  writer.writeLong(offsets[113], object.libraryFilterNovelTrackingType);
-  writer.writeLong(offsets[114], object.libraryFilterNovelUnreadType);
-  writer.writeBool(offsets[115], object.libraryLocalSource);
-  writer.writeBool(offsets[116], object.libraryShowCategoryTabs);
-  writer.writeBool(offsets[117], object.libraryShowContinueReadingButton);
-  writer.writeBool(offsets[118], object.libraryShowLanguage);
-  writer.writeBool(offsets[119], object.libraryShowNumbersOfItems);
-  writer.writeStringList(offsets[120], object.localFolders);
+  writer.writeLong(offsets[77], object.flashColor);
+  writer.writeLong(offsets[78], object.flashDuration);
+  writer.writeLong(offsets[79], object.flashInterval);
+  writer.writeBool(offsets[80], object.flashOnPageChange);
+  writer.writeDouble(offsets[81], object.flexColorSchemeBlendLevel);
+  writer.writeLong(offsets[82], object.flexSchemeColorIndex);
+  writer.writeBool(offsets[83], object.followSystemTheme);
+  writer.writeBool(offsets[84], object.forceLandscapePlayer);
+  writer.writeBool(offsets[85], object.fullScreenPlayer);
+  writer.writeBool(offsets[86], object.fullScreenReader);
+  writer.writeBool(offsets[87], object.grayscale);
+  writer.writeBool(offsets[88], object.hideDiscordRpcInIncognito);
+  writer.writeStringList(offsets[89], object.hideItems);
+  writer.writeString(offsets[90], object.hwdecMode);
+  writer.writeBool(offsets[91], object.incognitoMode);
+  writer.writeBool(offsets[92], object.invertColors);
+  writer.writeString(offsets[93], object.jrePath);
+  writer.writeBool(offsets[94], object.keepScreenOnReader);
+  writer.writeBool(offsets[95], object.landscapeZoom);
+  writer.writeString(offsets[96], object.lastTrackerLibraryLocation);
+  writer.writeBool(offsets[97], object.libraryDownloadedChapters);
+  writer.writeLong(offsets[98], object.libraryFilterAnimeBookMarkedType);
+  writer.writeLong(offsets[99], object.libraryFilterAnimeCompletedType);
+  writer.writeLong(offsets[100], object.libraryFilterAnimeDownloadType);
+  writer.writeLong(offsets[101], object.libraryFilterAnimeStartedType);
+  writer.writeLong(offsets[102], object.libraryFilterAnimeTrackingType);
+  writer.writeLong(offsets[103], object.libraryFilterAnimeUnreadType);
+  writer.writeLong(offsets[104], object.libraryFilterMangasBookMarkedType);
+  writer.writeLong(offsets[105], object.libraryFilterMangasCompletedType);
+  writer.writeLong(offsets[106], object.libraryFilterMangasDownloadType);
+  writer.writeLong(offsets[107], object.libraryFilterMangasStartedType);
+  writer.writeLong(offsets[108], object.libraryFilterMangasTrackingType);
+  writer.writeLong(offsets[109], object.libraryFilterMangasUnreadType);
+  writer.writeLong(offsets[110], object.libraryFilterNovelBookMarkedType);
+  writer.writeLong(offsets[111], object.libraryFilterNovelCompletedType);
+  writer.writeLong(offsets[112], object.libraryFilterNovelDownloadType);
+  writer.writeLong(offsets[113], object.libraryFilterNovelStartedType);
+  writer.writeLong(offsets[114], object.libraryFilterNovelTrackingType);
+  writer.writeLong(offsets[115], object.libraryFilterNovelUnreadType);
+  writer.writeBool(offsets[116], object.libraryLocalSource);
+  writer.writeBool(offsets[117], object.libraryShowCategoryTabs);
+  writer.writeBool(offsets[118], object.libraryShowContinueReadingButton);
+  writer.writeBool(offsets[119], object.libraryShowLanguage);
+  writer.writeBool(offsets[120], object.libraryShowNumbersOfItems);
+  writer.writeStringList(offsets[121], object.localFolders);
   writer.writeObject<L10nLocale>(
-    offsets[121],
+    offsets[122],
     allOffsets,
     L10nLocaleSchema.serialize,
     object.locale,
   );
   writer.writeObjectList<Repo>(
-    offsets[122],
+    offsets[123],
     allOffsets,
     RepoSchema.serialize,
     object.mangaExtensionsRepo,
   );
-  writer.writeLong(offsets[123], object.mangaGridSize);
-  writer.writeByte(offsets[124], object.mangaHomeDisplayType.index);
-  writer.writeLong(offsets[125], object.markEpisodeAsSeenType);
-  writer.writeBool(offsets[126], object.mergeLibraryNavMobile);
-  writer.writeBool(offsets[127], object.navigateToPan);
-  writer.writeStringList(offsets[128], object.navigationOrder);
-  writer.writeByte(offsets[129], object.novelDisplayType.index);
+  writer.writeLong(offsets[124], object.mangaGridSize);
+  writer.writeByte(offsets[125], object.mangaHomeDisplayType.index);
+  writer.writeLong(offsets[126], object.markEpisodeAsSeenType);
+  writer.writeBool(offsets[127], object.mergeLibraryNavMobile);
+  writer.writeBool(offsets[128], object.navigateToPan);
+  writer.writeStringList(offsets[129], object.navigationOrder);
+  writer.writeByte(offsets[130], object.novelDisplayType.index);
   writer.writeObjectList<Repo>(
-    offsets[130],
+    offsets[131],
     allOffsets,
     RepoSchema.serialize,
     object.novelExtensionsRepo,
   );
-  writer.writeLong(offsets[131], object.novelFontSize);
-  writer.writeLong(offsets[132], object.novelGridSize);
-  writer.writeBool(offsets[133], object.novelLibraryDownloadedChapters);
-  writer.writeBool(offsets[134], object.novelLibraryLocalSource);
-  writer.writeBool(offsets[135], object.novelLibraryShowCategoryTabs);
-  writer.writeBool(offsets[136], object.novelLibraryShowContinueReadingButton);
-  writer.writeBool(offsets[137], object.novelLibraryShowLanguage);
-  writer.writeBool(offsets[138], object.novelLibraryShowNumbersOfItems);
-  writer.writeDouble(offsets[139], object.novelReaderLineHeight);
-  writer.writeLong(offsets[140], object.novelReaderPadding);
-  writer.writeString(offsets[141], object.novelReaderTextColor);
-  writer.writeString(offsets[142], object.novelReaderTheme);
-  writer.writeBool(offsets[143], object.novelRemoveExtraParagraphSpacing);
-  writer.writeBool(offsets[144], object.novelShowScrollPercentage);
-  writer.writeBool(offsets[145], object.novelTapToScroll);
-  writer.writeByte(offsets[146], object.novelTextAlign.index);
-  writer.writeBool(offsets[147], object.onlyIncludePinnedSources);
-  writer.writeLong(offsets[148], object.pagePreloadAmount);
+  writer.writeLong(offsets[132], object.novelFontSize);
+  writer.writeLong(offsets[133], object.novelGridSize);
+  writer.writeBool(offsets[134], object.novelLibraryDownloadedChapters);
+  writer.writeBool(offsets[135], object.novelLibraryLocalSource);
+  writer.writeBool(offsets[136], object.novelLibraryShowCategoryTabs);
+  writer.writeBool(offsets[137], object.novelLibraryShowContinueReadingButton);
+  writer.writeBool(offsets[138], object.novelLibraryShowLanguage);
+  writer.writeBool(offsets[139], object.novelLibraryShowNumbersOfItems);
+  writer.writeDouble(offsets[140], object.novelReaderLineHeight);
+  writer.writeLong(offsets[141], object.novelReaderPadding);
+  writer.writeString(offsets[142], object.novelReaderTextColor);
+  writer.writeString(offsets[143], object.novelReaderTheme);
+  writer.writeBool(offsets[144], object.novelRemoveExtraParagraphSpacing);
+  writer.writeBool(offsets[145], object.novelShowScrollPercentage);
+  writer.writeBool(offsets[146], object.novelTapToScroll);
+  writer.writeByte(offsets[147], object.novelTextAlign.index);
+  writer.writeBool(offsets[148], object.onlyIncludePinnedSources);
+  writer.writeLong(offsets[149], object.pagePreloadAmount);
   writer.writeObjectList<PersonalPageMode>(
-    offsets[149],
+    offsets[150],
     allOffsets,
     PersonalPageModeSchema.serialize,
     object.personalPageModeList,
   );
   writer.writeObjectList<PersonalReaderMode>(
-    offsets[150],
+    offsets[151],
     allOffsets,
     PersonalReaderModeSchema.serialize,
     object.personalReaderModeList,
   );
   writer.writeObject<PlayerSubtitleSettings>(
-    offsets[151],
+    offsets[152],
     allOffsets,
     PlayerSubtitleSettingsSchema.serialize,
     object.playerSubtitleSettings,
   );
-  writer.writeBool(offsets[152], object.pureBlackDarkMode);
-  writer.writeDouble(offsets[153], object.readerBrightness);
-  writer.writeDouble(offsets[154], object.readerContrast);
-  writer.writeLong(offsets[155], object.readerHideThreshold);
-  writer.writeLong(offsets[156], object.readerNavigationLayout);
-  writer.writeDouble(offsets[157], object.readerSaturation);
-  writer.writeLong(offsets[158], object.relativeTimesTamps);
-  writer.writeBool(offsets[159], object.rpcShowCoverImage);
-  writer.writeBool(offsets[160], object.rpcShowReadingWatchingProgress);
-  writer.writeBool(offsets[161], object.rpcShowTitle);
-  writer.writeBool(offsets[162], object.saveAsCBZArchive);
-  writer.writeByte(offsets[163], object.scaleType.index);
-  writer.writeBool(offsets[164], object.showNSFW);
-  writer.writeBool(offsets[165], object.showNavigationOverlayOnStart);
-  writer.writeBool(offsets[166], object.showPageGaps);
-  writer.writeBool(offsets[167], object.showPagesNumber);
+  writer.writeBool(offsets[153], object.pureBlackDarkMode);
+  writer.writeDouble(offsets[154], object.readerBrightness);
+  writer.writeDouble(offsets[155], object.readerContrast);
+  writer.writeLong(offsets[156], object.readerHideThreshold);
+  writer.writeLong(offsets[157], object.readerNavigationLayout);
+  writer.writeDouble(offsets[158], object.readerSaturation);
+  writer.writeLong(offsets[159], object.relativeTimesTamps);
+  writer.writeBool(offsets[160], object.rpcShowCoverImage);
+  writer.writeBool(offsets[161], object.rpcShowReadingWatchingProgress);
+  writer.writeBool(offsets[162], object.rpcShowTitle);
+  writer.writeBool(offsets[163], object.saveAsCBZArchive);
+  writer.writeByte(offsets[164], object.scaleType.index);
+  writer.writeBool(offsets[165], object.showNSFW);
+  writer.writeBool(offsets[166], object.showNavigationOverlayOnStart);
+  writer.writeBool(offsets[167], object.showPageGaps);
+  writer.writeBool(offsets[168], object.showPagesNumber);
   writer.writeObjectList<SortChapter>(
-    offsets[168],
+    offsets[169],
     allOffsets,
     SortChapterSchema.serialize,
     object.sortChapterList,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[169],
+    offsets[170],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryAnime,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[170],
+    offsets[171],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryManga,
   );
   writer.writeObject<SortLibraryManga>(
-    offsets[171],
+    offsets[172],
     allOffsets,
     SortLibraryMangaSchema.serialize,
     object.sortLibraryNovel,
   );
-  writer.writeBool(offsets[172], object.splitWidePages);
-  writer.writeLong(offsets[173], object.startDatebackup);
-  writer.writeLong(offsets[174], object.tappingInversion);
-  writer.writeBool(offsets[175], object.themeIsDark);
-  writer.writeString(offsets[176], object.ttsLanguage);
-  writer.writeDouble(offsets[177], object.ttsPitch);
-  writer.writeDouble(offsets[178], object.ttsSpeechRate);
-  writer.writeString(offsets[179], object.ttsVoice);
-  writer.writeBool(offsets[180], object.tvAnimeOnlyOverride);
-  writer.writeBool(offsets[181], object.tvHomeGenreRows);
-  writer.writeBool(offsets[182], object.tvHomeStyle);
-  writer.writeBool(offsets[183], object.tvPlayerStyle);
+  writer.writeBool(offsets[173], object.splitWidePages);
+  writer.writeLong(offsets[174], object.startDatebackup);
+  writer.writeLong(offsets[175], object.tappingInversion);
+  writer.writeBool(offsets[176], object.themeIsDark);
+  writer.writeString(offsets[177], object.ttsLanguage);
+  writer.writeDouble(offsets[178], object.ttsPitch);
+  writer.writeDouble(offsets[179], object.ttsSpeechRate);
+  writer.writeString(offsets[180], object.ttsVoice);
+  writer.writeBool(offsets[181], object.tvAnimeOnlyOverride);
+  writer.writeBool(offsets[182], object.tvHomeGenreRows);
+  writer.writeBool(offsets[183], object.tvHomeStyle);
+  writer.writeBool(offsets[184], object.tvPlayerStyle);
   writer.writeObjectList<UpdateError>(
-    offsets[184],
+    offsets[185],
     allOffsets,
     UpdateErrorSchema.serialize,
     object.updateErrorsList,
   );
-  writer.writeBool(offsets[185], object.updateProgressAfterReading);
-  writer.writeLong(offsets[186], object.updatedAt);
-  writer.writeBool(offsets[187], object.useLibass);
-  writer.writeBool(offsets[188], object.useMpvConfig);
-  writer.writeBool(offsets[189], object.usePageTapZones);
-  writer.writeBool(offsets[190], object.useYUV420P);
-  writer.writeString(offsets[191], object.userAgent);
-  writer.writeLong(offsets[192], object.volumeBoostCap);
-  writer.writeBool(offsets[193], object.webtoonDisableZoomOut);
-  writer.writeBool(offsets[194], object.webtoonDoubleTapZoomEnabled);
-  writer.writeLong(offsets[195], object.webtoonSidePadding);
-  writer.writeLong(offsets[196], object.zoomStartPosition);
+  writer.writeBool(offsets[186], object.updateProgressAfterReading);
+  writer.writeLong(offsets[187], object.updatedAt);
+  writer.writeBool(offsets[188], object.useLibass);
+  writer.writeBool(offsets[189], object.useMpvConfig);
+  writer.writeBool(offsets[190], object.usePageTapZones);
+  writer.writeBool(offsets[191], object.useYUV420P);
+  writer.writeString(offsets[192], object.userAgent);
+  writer.writeLong(offsets[193], object.volumeBoostCap);
+  writer.writeBool(offsets[194], object.webtoonDisableZoomOut);
+  writer.writeBool(offsets[195], object.webtoonDoubleTapZoomEnabled);
+  writer.writeLong(offsets[196], object.webtoonSidePadding);
+  writer.writeLong(offsets[197], object.zoomStartPosition);
 }
 
 Settings _settingsDeserialize(
@@ -2053,199 +2065,200 @@ Settings _settingsDeserialize(
     downloadDelaySeconds: reader.readLongOrNull(offsets[59]),
     downloadLocation: reader.readStringOrNull(offsets[60]),
     downloadOnlyOnWifi: reader.readBoolOrNull(offsets[61]),
-    downloadedOnlyMode: reader.readBoolOrNull(offsets[62]),
-    dualPageInvert: reader.readBoolOrNull(offsets[63]),
-    dualPageRotateToFit: reader.readBoolOrNull(offsets[64]),
-    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[65]),
-    enableAniSkip: reader.readBoolOrNull(offsets[66]),
-    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[67]),
-    enableAutoSkip: reader.readBoolOrNull(offsets[68]),
-    enableCustomColorFilter: reader.readBoolOrNull(offsets[69]),
-    enableDiscordRpc: reader.readBoolOrNull(offsets[70]),
-    enableGpuNext: reader.readBoolOrNull(offsets[71]),
-    enableHardwareAcceleration: reader.readBoolOrNull(offsets[72]),
-    enableLogs: reader.readBoolOrNull(offsets[73]),
-    extensionServerPath: reader.readStringOrNull(offsets[74]),
-    flashColor: reader.readLongOrNull(offsets[76]),
-    flashDuration: reader.readLongOrNull(offsets[77]),
-    flashInterval: reader.readLongOrNull(offsets[78]),
-    flashOnPageChange: reader.readBoolOrNull(offsets[79]),
-    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[80]),
-    flexSchemeColorIndex: reader.readLongOrNull(offsets[81]),
-    followSystemTheme: reader.readBoolOrNull(offsets[82]),
-    forceLandscapePlayer: reader.readBoolOrNull(offsets[83]),
-    fullScreenPlayer: reader.readBoolOrNull(offsets[84]),
-    fullScreenReader: reader.readBoolOrNull(offsets[85]),
-    grayscale: reader.readBoolOrNull(offsets[86]),
-    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[87]),
-    hideItems: reader.readStringList(offsets[88]),
-    hwdecMode: reader.readStringOrNull(offsets[89]),
+    downloadQueueOrder: reader.readLongList(offsets[62]),
+    downloadedOnlyMode: reader.readBoolOrNull(offsets[63]),
+    dualPageInvert: reader.readBoolOrNull(offsets[64]),
+    dualPageRotateToFit: reader.readBoolOrNull(offsets[65]),
+    dualPageRotateToFitInvert: reader.readBoolOrNull(offsets[66]),
+    enableAniSkip: reader.readBoolOrNull(offsets[67]),
+    enableAudioPitchCorrection: reader.readBoolOrNull(offsets[68]),
+    enableAutoSkip: reader.readBoolOrNull(offsets[69]),
+    enableCustomColorFilter: reader.readBoolOrNull(offsets[70]),
+    enableDiscordRpc: reader.readBoolOrNull(offsets[71]),
+    enableGpuNext: reader.readBoolOrNull(offsets[72]),
+    enableHardwareAcceleration: reader.readBoolOrNull(offsets[73]),
+    enableLogs: reader.readBoolOrNull(offsets[74]),
+    extensionServerPath: reader.readStringOrNull(offsets[75]),
+    flashColor: reader.readLongOrNull(offsets[77]),
+    flashDuration: reader.readLongOrNull(offsets[78]),
+    flashInterval: reader.readLongOrNull(offsets[79]),
+    flashOnPageChange: reader.readBoolOrNull(offsets[80]),
+    flexColorSchemeBlendLevel: reader.readDoubleOrNull(offsets[81]),
+    flexSchemeColorIndex: reader.readLongOrNull(offsets[82]),
+    followSystemTheme: reader.readBoolOrNull(offsets[83]),
+    forceLandscapePlayer: reader.readBoolOrNull(offsets[84]),
+    fullScreenPlayer: reader.readBoolOrNull(offsets[85]),
+    fullScreenReader: reader.readBoolOrNull(offsets[86]),
+    grayscale: reader.readBoolOrNull(offsets[87]),
+    hideDiscordRpcInIncognito: reader.readBoolOrNull(offsets[88]),
+    hideItems: reader.readStringList(offsets[89]),
+    hwdecMode: reader.readStringOrNull(offsets[90]),
     id: id,
-    incognitoMode: reader.readBoolOrNull(offsets[90]),
-    invertColors: reader.readBoolOrNull(offsets[91]),
-    jrePath: reader.readStringOrNull(offsets[92]),
-    keepScreenOnReader: reader.readBoolOrNull(offsets[93]),
-    landscapeZoom: reader.readBoolOrNull(offsets[94]),
-    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[95]),
-    libraryDownloadedChapters: reader.readBoolOrNull(offsets[96]),
-    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[97]),
-    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[98]),
-    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[99]),
-    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[100]),
-    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[101]),
-    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[102]),
-    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[103]),
-    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[104]),
-    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[105]),
-    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[106]),
-    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[107]),
-    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[108]),
-    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[109]),
-    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[110]),
-    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[111]),
-    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[112]),
-    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[113]),
-    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[114]),
-    libraryLocalSource: reader.readBoolOrNull(offsets[115]),
-    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[116]),
-    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[117]),
-    libraryShowLanguage: reader.readBoolOrNull(offsets[118]),
-    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[119]),
-    localFolders: reader.readStringList(offsets[120]),
+    incognitoMode: reader.readBoolOrNull(offsets[91]),
+    invertColors: reader.readBoolOrNull(offsets[92]),
+    jrePath: reader.readStringOrNull(offsets[93]),
+    keepScreenOnReader: reader.readBoolOrNull(offsets[94]),
+    landscapeZoom: reader.readBoolOrNull(offsets[95]),
+    lastTrackerLibraryLocation: reader.readStringOrNull(offsets[96]),
+    libraryDownloadedChapters: reader.readBoolOrNull(offsets[97]),
+    libraryFilterAnimeBookMarkedType: reader.readLongOrNull(offsets[98]),
+    libraryFilterAnimeCompletedType: reader.readLongOrNull(offsets[99]),
+    libraryFilterAnimeDownloadType: reader.readLongOrNull(offsets[100]),
+    libraryFilterAnimeStartedType: reader.readLongOrNull(offsets[101]),
+    libraryFilterAnimeTrackingType: reader.readLongOrNull(offsets[102]),
+    libraryFilterAnimeUnreadType: reader.readLongOrNull(offsets[103]),
+    libraryFilterMangasBookMarkedType: reader.readLongOrNull(offsets[104]),
+    libraryFilterMangasCompletedType: reader.readLongOrNull(offsets[105]),
+    libraryFilterMangasDownloadType: reader.readLongOrNull(offsets[106]),
+    libraryFilterMangasStartedType: reader.readLongOrNull(offsets[107]),
+    libraryFilterMangasTrackingType: reader.readLongOrNull(offsets[108]),
+    libraryFilterMangasUnreadType: reader.readLongOrNull(offsets[109]),
+    libraryFilterNovelBookMarkedType: reader.readLongOrNull(offsets[110]),
+    libraryFilterNovelCompletedType: reader.readLongOrNull(offsets[111]),
+    libraryFilterNovelDownloadType: reader.readLongOrNull(offsets[112]),
+    libraryFilterNovelStartedType: reader.readLongOrNull(offsets[113]),
+    libraryFilterNovelTrackingType: reader.readLongOrNull(offsets[114]),
+    libraryFilterNovelUnreadType: reader.readLongOrNull(offsets[115]),
+    libraryLocalSource: reader.readBoolOrNull(offsets[116]),
+    libraryShowCategoryTabs: reader.readBoolOrNull(offsets[117]),
+    libraryShowContinueReadingButton: reader.readBoolOrNull(offsets[118]),
+    libraryShowLanguage: reader.readBoolOrNull(offsets[119]),
+    libraryShowNumbersOfItems: reader.readBoolOrNull(offsets[120]),
+    localFolders: reader.readStringList(offsets[121]),
     mangaExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[122],
+      offsets[123],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    mangaGridSize: reader.readLongOrNull(offsets[123]),
+    mangaGridSize: reader.readLongOrNull(offsets[124]),
     mangaHomeDisplayType:
         _SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[124],
+          offsets[125],
         )] ??
         DisplayType.comfortableGrid,
-    markEpisodeAsSeenType: reader.readLongOrNull(offsets[125]),
-    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[126]),
-    navigateToPan: reader.readBoolOrNull(offsets[127]),
-    navigationOrder: reader.readStringList(offsets[128]),
+    markEpisodeAsSeenType: reader.readLongOrNull(offsets[126]),
+    mergeLibraryNavMobile: reader.readBoolOrNull(offsets[127]),
+    navigateToPan: reader.readBoolOrNull(offsets[128]),
+    navigationOrder: reader.readStringList(offsets[129]),
     novelDisplayType:
         _SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
-          offsets[129],
+          offsets[130],
         )] ??
         DisplayType.comfortableGrid,
     novelExtensionsRepo: reader.readObjectList<Repo>(
-      offsets[130],
+      offsets[131],
       RepoSchema.deserialize,
       allOffsets,
       Repo(),
     ),
-    novelFontSize: reader.readLongOrNull(offsets[131]),
-    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[133]),
-    novelLibraryLocalSource: reader.readBoolOrNull(offsets[134]),
-    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[135]),
-    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[136]),
-    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[137]),
-    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[138]),
-    novelReaderLineHeight: reader.readDoubleOrNull(offsets[139]),
-    novelReaderPadding: reader.readLongOrNull(offsets[140]),
-    novelReaderTextColor: reader.readStringOrNull(offsets[141]),
-    novelReaderTheme: reader.readStringOrNull(offsets[142]),
-    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[143]),
-    novelShowScrollPercentage: reader.readBoolOrNull(offsets[144]),
-    novelTapToScroll: reader.readBoolOrNull(offsets[145]),
+    novelFontSize: reader.readLongOrNull(offsets[132]),
+    novelLibraryDownloadedChapters: reader.readBoolOrNull(offsets[134]),
+    novelLibraryLocalSource: reader.readBoolOrNull(offsets[135]),
+    novelLibraryShowCategoryTabs: reader.readBoolOrNull(offsets[136]),
+    novelLibraryShowContinueReadingButton: reader.readBoolOrNull(offsets[137]),
+    novelLibraryShowLanguage: reader.readBoolOrNull(offsets[138]),
+    novelLibraryShowNumbersOfItems: reader.readBoolOrNull(offsets[139]),
+    novelReaderLineHeight: reader.readDoubleOrNull(offsets[140]),
+    novelReaderPadding: reader.readLongOrNull(offsets[141]),
+    novelReaderTextColor: reader.readStringOrNull(offsets[142]),
+    novelReaderTheme: reader.readStringOrNull(offsets[143]),
+    novelRemoveExtraParagraphSpacing: reader.readBoolOrNull(offsets[144]),
+    novelShowScrollPercentage: reader.readBoolOrNull(offsets[145]),
+    novelTapToScroll: reader.readBoolOrNull(offsets[146]),
     novelTextAlign:
         _SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
-          offsets[146],
+          offsets[147],
         )] ??
         NovelTextAlign.left,
-    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[147]),
-    pagePreloadAmount: reader.readLongOrNull(offsets[148]),
+    onlyIncludePinnedSources: reader.readBoolOrNull(offsets[148]),
+    pagePreloadAmount: reader.readLongOrNull(offsets[149]),
     personalPageModeList: reader.readObjectList<PersonalPageMode>(
-      offsets[149],
+      offsets[150],
       PersonalPageModeSchema.deserialize,
       allOffsets,
       PersonalPageMode(),
     ),
     personalReaderModeList: reader.readObjectList<PersonalReaderMode>(
-      offsets[150],
+      offsets[151],
       PersonalReaderModeSchema.deserialize,
       allOffsets,
       PersonalReaderMode(),
     ),
     playerSubtitleSettings: reader.readObjectOrNull<PlayerSubtitleSettings>(
-      offsets[151],
+      offsets[152],
       PlayerSubtitleSettingsSchema.deserialize,
       allOffsets,
     ),
-    pureBlackDarkMode: reader.readBoolOrNull(offsets[152]),
-    readerBrightness: reader.readDoubleOrNull(offsets[153]),
-    readerContrast: reader.readDoubleOrNull(offsets[154]),
-    readerHideThreshold: reader.readLongOrNull(offsets[155]),
-    readerNavigationLayout: reader.readLongOrNull(offsets[156]),
-    readerSaturation: reader.readDoubleOrNull(offsets[157]),
-    relativeTimesTamps: reader.readLongOrNull(offsets[158]),
-    rpcShowCoverImage: reader.readBoolOrNull(offsets[159]),
-    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[160]),
-    rpcShowTitle: reader.readBoolOrNull(offsets[161]),
-    saveAsCBZArchive: reader.readBoolOrNull(offsets[162]),
+    pureBlackDarkMode: reader.readBoolOrNull(offsets[153]),
+    readerBrightness: reader.readDoubleOrNull(offsets[154]),
+    readerContrast: reader.readDoubleOrNull(offsets[155]),
+    readerHideThreshold: reader.readLongOrNull(offsets[156]),
+    readerNavigationLayout: reader.readLongOrNull(offsets[157]),
+    readerSaturation: reader.readDoubleOrNull(offsets[158]),
+    relativeTimesTamps: reader.readLongOrNull(offsets[159]),
+    rpcShowCoverImage: reader.readBoolOrNull(offsets[160]),
+    rpcShowReadingWatchingProgress: reader.readBoolOrNull(offsets[161]),
+    rpcShowTitle: reader.readBoolOrNull(offsets[162]),
+    saveAsCBZArchive: reader.readBoolOrNull(offsets[163]),
     scaleType:
-        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[163])] ??
+        _SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offsets[164])] ??
         ScaleType.fitScreen,
-    showNSFW: reader.readBoolOrNull(offsets[164]),
-    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[165]),
-    showPageGaps: reader.readBoolOrNull(offsets[166]),
-    showPagesNumber: reader.readBoolOrNull(offsets[167]),
+    showNSFW: reader.readBoolOrNull(offsets[165]),
+    showNavigationOverlayOnStart: reader.readBoolOrNull(offsets[166]),
+    showPageGaps: reader.readBoolOrNull(offsets[167]),
+    showPagesNumber: reader.readBoolOrNull(offsets[168]),
     sortChapterList: reader.readObjectList<SortChapter>(
-      offsets[168],
+      offsets[169],
       SortChapterSchema.deserialize,
       allOffsets,
       SortChapter(),
     ),
     sortLibraryAnime: reader.readObjectOrNull<SortLibraryManga>(
-      offsets[169],
-      SortLibraryMangaSchema.deserialize,
-      allOffsets,
-    ),
-    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
       offsets[170],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+    sortLibraryManga: reader.readObjectOrNull<SortLibraryManga>(
       offsets[171],
       SortLibraryMangaSchema.deserialize,
       allOffsets,
     ),
-    splitWidePages: reader.readBoolOrNull(offsets[172]),
-    startDatebackup: reader.readLongOrNull(offsets[173]),
-    tappingInversion: reader.readLongOrNull(offsets[174]),
-    themeIsDark: reader.readBoolOrNull(offsets[175]),
-    ttsLanguage: reader.readStringOrNull(offsets[176]),
-    ttsPitch: reader.readDoubleOrNull(offsets[177]),
-    ttsSpeechRate: reader.readDoubleOrNull(offsets[178]),
-    ttsVoice: reader.readStringOrNull(offsets[179]),
-    tvAnimeOnlyOverride: reader.readBoolOrNull(offsets[180]),
-    tvHomeGenreRows: reader.readBoolOrNull(offsets[181]),
-    tvHomeStyle: reader.readBoolOrNull(offsets[182]),
-    tvPlayerStyle: reader.readBoolOrNull(offsets[183]),
+    sortLibraryNovel: reader.readObjectOrNull<SortLibraryManga>(
+      offsets[172],
+      SortLibraryMangaSchema.deserialize,
+      allOffsets,
+    ),
+    splitWidePages: reader.readBoolOrNull(offsets[173]),
+    startDatebackup: reader.readLongOrNull(offsets[174]),
+    tappingInversion: reader.readLongOrNull(offsets[175]),
+    themeIsDark: reader.readBoolOrNull(offsets[176]),
+    ttsLanguage: reader.readStringOrNull(offsets[177]),
+    ttsPitch: reader.readDoubleOrNull(offsets[178]),
+    ttsSpeechRate: reader.readDoubleOrNull(offsets[179]),
+    ttsVoice: reader.readStringOrNull(offsets[180]),
+    tvAnimeOnlyOverride: reader.readBoolOrNull(offsets[181]),
+    tvHomeGenreRows: reader.readBoolOrNull(offsets[182]),
+    tvHomeStyle: reader.readBoolOrNull(offsets[183]),
+    tvPlayerStyle: reader.readBoolOrNull(offsets[184]),
     updateErrorsList: reader.readObjectList<UpdateError>(
-      offsets[184],
+      offsets[185],
       UpdateErrorSchema.deserialize,
       allOffsets,
       UpdateError(),
     ),
-    updateProgressAfterReading: reader.readBoolOrNull(offsets[185]),
-    updatedAt: reader.readLongOrNull(offsets[186]),
-    useLibass: reader.readBoolOrNull(offsets[187]),
-    useMpvConfig: reader.readBoolOrNull(offsets[188]),
-    usePageTapZones: reader.readBoolOrNull(offsets[189]),
-    useYUV420P: reader.readBoolOrNull(offsets[190]),
-    userAgent: reader.readStringOrNull(offsets[191]),
-    volumeBoostCap: reader.readLongOrNull(offsets[192]),
-    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[193]),
-    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[194]),
-    webtoonSidePadding: reader.readLongOrNull(offsets[195]),
-    zoomStartPosition: reader.readLongOrNull(offsets[196]),
+    updateProgressAfterReading: reader.readBoolOrNull(offsets[186]),
+    updatedAt: reader.readLongOrNull(offsets[187]),
+    useLibass: reader.readBoolOrNull(offsets[188]),
+    useMpvConfig: reader.readBoolOrNull(offsets[189]),
+    usePageTapZones: reader.readBoolOrNull(offsets[190]),
+    useYUV420P: reader.readBoolOrNull(offsets[191]),
+    userAgent: reader.readStringOrNull(offsets[192]),
+    volumeBoostCap: reader.readLongOrNull(offsets[193]),
+    webtoonDisableZoomOut: reader.readBoolOrNull(offsets[194]),
+    webtoonDoubleTapZoomEnabled: reader.readBoolOrNull(offsets[195]),
+    webtoonSidePadding: reader.readLongOrNull(offsets[196]),
+    zoomStartPosition: reader.readLongOrNull(offsets[197]),
   );
   object.chapterFilterBookmarkedList = reader
       .readObjectList<ChapterFilterBookmarked>(
@@ -2266,17 +2279,17 @@ Settings _settingsDeserialize(
     allOffsets,
   );
   object.filterScanlatorList = reader.readObjectList<FilterScanlator>(
-    offsets[75],
+    offsets[76],
     FilterScanlatorSchema.deserialize,
     allOffsets,
     FilterScanlator(),
   );
   object.locale = reader.readObjectOrNull<L10nLocale>(
-    offsets[121],
+    offsets[122],
     L10nLocaleSchema.deserialize,
     allOffsets,
   );
-  object.novelGridSize = reader.readLongOrNull(offsets[132]);
+  object.novelGridSize = reader.readLongOrNull(offsets[133]);
   return object;
 }
 
@@ -2505,7 +2518,7 @@ P _settingsDeserializeProp<P>(
     case 61:
       return (reader.readBoolOrNull(offset)) as P;
     case 62:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongList(offset)) as P;
     case 63:
       return (reader.readBoolOrNull(offset)) as P;
     case 64:
@@ -2529,8 +2542,10 @@ P _settingsDeserializeProp<P>(
     case 73:
       return (reader.readBoolOrNull(offset)) as P;
     case 74:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 75:
+      return (reader.readStringOrNull(offset)) as P;
+    case 76:
       return (reader.readObjectList<FilterScanlator>(
             offset,
             FilterScanlatorSchema.deserialize,
@@ -2538,20 +2553,18 @@ P _settingsDeserializeProp<P>(
             FilterScanlator(),
           ))
           as P;
-    case 76:
-      return (reader.readLongOrNull(offset)) as P;
     case 77:
       return (reader.readLongOrNull(offset)) as P;
     case 78:
       return (reader.readLongOrNull(offset)) as P;
     case 79:
-      return (reader.readBoolOrNull(offset)) as P;
-    case 80:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 81:
       return (reader.readLongOrNull(offset)) as P;
-    case 82:
+    case 80:
       return (reader.readBoolOrNull(offset)) as P;
+    case 81:
+      return (reader.readDoubleOrNull(offset)) as P;
+    case 82:
+      return (reader.readLongOrNull(offset)) as P;
     case 83:
       return (reader.readBoolOrNull(offset)) as P;
     case 84:
@@ -2563,25 +2576,25 @@ P _settingsDeserializeProp<P>(
     case 87:
       return (reader.readBoolOrNull(offset)) as P;
     case 88:
-      return (reader.readStringList(offset)) as P;
-    case 89:
-      return (reader.readStringOrNull(offset)) as P;
-    case 90:
       return (reader.readBoolOrNull(offset)) as P;
+    case 89:
+      return (reader.readStringList(offset)) as P;
+    case 90:
+      return (reader.readStringOrNull(offset)) as P;
     case 91:
       return (reader.readBoolOrNull(offset)) as P;
     case 92:
-      return (reader.readStringOrNull(offset)) as P;
-    case 93:
       return (reader.readBoolOrNull(offset)) as P;
+    case 93:
+      return (reader.readStringOrNull(offset)) as P;
     case 94:
       return (reader.readBoolOrNull(offset)) as P;
     case 95:
-      return (reader.readStringOrNull(offset)) as P;
-    case 96:
       return (reader.readBoolOrNull(offset)) as P;
+    case 96:
+      return (reader.readStringOrNull(offset)) as P;
     case 97:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 98:
       return (reader.readLongOrNull(offset)) as P;
     case 99:
@@ -2617,7 +2630,7 @@ P _settingsDeserializeProp<P>(
     case 114:
       return (reader.readLongOrNull(offset)) as P;
     case 115:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 116:
       return (reader.readBoolOrNull(offset)) as P;
     case 117:
@@ -2627,15 +2640,17 @@ P _settingsDeserializeProp<P>(
     case 119:
       return (reader.readBoolOrNull(offset)) as P;
     case 120:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 121:
+      return (reader.readStringList(offset)) as P;
+    case 122:
       return (reader.readObjectOrNull<L10nLocale>(
             offset,
             L10nLocaleSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 122:
+    case 123:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2643,29 +2658,29 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 123:
-      return (reader.readLongOrNull(offset)) as P;
     case 124:
+      return (reader.readLongOrNull(offset)) as P;
+    case 125:
       return (_SettingsmangaHomeDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 125:
-      return (reader.readLongOrNull(offset)) as P;
     case 126:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 127:
       return (reader.readBoolOrNull(offset)) as P;
     case 128:
-      return (reader.readStringList(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 129:
+      return (reader.readStringList(offset)) as P;
+    case 130:
       return (_SettingsnovelDisplayTypeValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               DisplayType.comfortableGrid)
           as P;
-    case 130:
+    case 131:
       return (reader.readObjectList<Repo>(
             offset,
             RepoSchema.deserialize,
@@ -2673,12 +2688,10 @@ P _settingsDeserializeProp<P>(
             Repo(),
           ))
           as P;
-    case 131:
-      return (reader.readLongOrNull(offset)) as P;
     case 132:
       return (reader.readLongOrNull(offset)) as P;
     case 133:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 134:
       return (reader.readBoolOrNull(offset)) as P;
     case 135:
@@ -2690,30 +2703,32 @@ P _settingsDeserializeProp<P>(
     case 138:
       return (reader.readBoolOrNull(offset)) as P;
     case 139:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 140:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 141:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 142:
       return (reader.readStringOrNull(offset)) as P;
     case 143:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 144:
       return (reader.readBoolOrNull(offset)) as P;
     case 145:
       return (reader.readBoolOrNull(offset)) as P;
     case 146:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 147:
       return (_SettingsnovelTextAlignValueEnumMap[reader.readByteOrNull(
                 offset,
               )] ??
               NovelTextAlign.left)
           as P;
-    case 147:
-      return (reader.readBoolOrNull(offset)) as P;
     case 148:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 149:
+      return (reader.readLongOrNull(offset)) as P;
+    case 150:
       return (reader.readObjectList<PersonalPageMode>(
             offset,
             PersonalPageModeSchema.deserialize,
@@ -2721,7 +2736,7 @@ P _settingsDeserializeProp<P>(
             PersonalPageMode(),
           ))
           as P;
-    case 150:
+    case 151:
       return (reader.readObjectList<PersonalReaderMode>(
             offset,
             PersonalReaderModeSchema.deserialize,
@@ -2729,29 +2744,27 @@ P _settingsDeserializeProp<P>(
             PersonalReaderMode(),
           ))
           as P;
-    case 151:
+    case 152:
       return (reader.readObjectOrNull<PlayerSubtitleSettings>(
             offset,
             PlayerSubtitleSettingsSchema.deserialize,
             allOffsets,
           ))
           as P;
-    case 152:
-      return (reader.readBoolOrNull(offset)) as P;
     case 153:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 154:
       return (reader.readDoubleOrNull(offset)) as P;
     case 155:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 156:
       return (reader.readLongOrNull(offset)) as P;
     case 157:
-      return (reader.readDoubleOrNull(offset)) as P;
-    case 158:
       return (reader.readLongOrNull(offset)) as P;
+    case 158:
+      return (reader.readDoubleOrNull(offset)) as P;
     case 159:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 160:
       return (reader.readBoolOrNull(offset)) as P;
     case 161:
@@ -2759,11 +2772,11 @@ P _settingsDeserializeProp<P>(
     case 162:
       return (reader.readBoolOrNull(offset)) as P;
     case 163:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 164:
       return (_SettingsscaleTypeValueEnumMap[reader.readByteOrNull(offset)] ??
               ScaleType.fitScreen)
           as P;
-    case 164:
-      return (reader.readBoolOrNull(offset)) as P;
     case 165:
       return (reader.readBoolOrNull(offset)) as P;
     case 166:
@@ -2771,18 +2784,13 @@ P _settingsDeserializeProp<P>(
     case 167:
       return (reader.readBoolOrNull(offset)) as P;
     case 168:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 169:
       return (reader.readObjectList<SortChapter>(
             offset,
             SortChapterSchema.deserialize,
             allOffsets,
             SortChapter(),
-          ))
-          as P;
-    case 169:
-      return (reader.readObjectOrNull<SortLibraryManga>(
-            offset,
-            SortLibraryMangaSchema.deserialize,
-            allOffsets,
           ))
           as P;
     case 170:
@@ -2800,23 +2808,28 @@ P _settingsDeserializeProp<P>(
           ))
           as P;
     case 172:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readObjectOrNull<SortLibraryManga>(
+            offset,
+            SortLibraryMangaSchema.deserialize,
+            allOffsets,
+          ))
+          as P;
     case 173:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 174:
       return (reader.readLongOrNull(offset)) as P;
     case 175:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 176:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 177:
-      return (reader.readDoubleOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 178:
       return (reader.readDoubleOrNull(offset)) as P;
     case 179:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 180:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 181:
       return (reader.readBoolOrNull(offset)) as P;
     case 182:
@@ -2824,6 +2837,8 @@ P _settingsDeserializeProp<P>(
     case 183:
       return (reader.readBoolOrNull(offset)) as P;
     case 184:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 185:
       return (reader.readObjectList<UpdateError>(
             offset,
             UpdateErrorSchema.deserialize,
@@ -2831,12 +2846,10 @@ P _settingsDeserializeProp<P>(
             UpdateError(),
           ))
           as P;
-    case 185:
-      return (reader.readBoolOrNull(offset)) as P;
     case 186:
-      return (reader.readLongOrNull(offset)) as P;
-    case 187:
       return (reader.readBoolOrNull(offset)) as P;
+    case 187:
+      return (reader.readLongOrNull(offset)) as P;
     case 188:
       return (reader.readBoolOrNull(offset)) as P;
     case 189:
@@ -2844,16 +2857,18 @@ P _settingsDeserializeProp<P>(
     case 190:
       return (reader.readBoolOrNull(offset)) as P;
     case 191:
-      return (reader.readStringOrNull(offset)) as P;
-    case 192:
-      return (reader.readLongOrNull(offset)) as P;
-    case 193:
       return (reader.readBoolOrNull(offset)) as P;
+    case 192:
+      return (reader.readStringOrNull(offset)) as P;
+    case 193:
+      return (reader.readLongOrNull(offset)) as P;
     case 194:
       return (reader.readBoolOrNull(offset)) as P;
     case 195:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readBoolOrNull(offset)) as P;
     case 196:
+      return (reader.readLongOrNull(offset)) as P;
+    case 197:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -7599,6 +7614,144 @@ extension SettingsQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(
         FilterCondition.equalTo(property: r'downloadOnlyOnWifi', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'downloadQueueOrder'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'downloadQueueOrder'),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderElementEqualTo(int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'downloadQueueOrder', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderElementGreaterThan(int value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'downloadQueueOrder',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderElementLessThan(int value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'downloadQueueOrder',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderElementBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'downloadQueueOrder',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderLengthEqualTo(int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'downloadQueueOrder',
+        length,
+        true,
+        length,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'downloadQueueOrder', 0, true, 0, true);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'downloadQueueOrder', 0, false, 999999, true);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderLengthLessThan(int length, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(r'downloadQueueOrder', 0, true, length, include);
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderLengthGreaterThan(int length, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'downloadQueueOrder',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Settings, Settings, QAfterFilterCondition>
+  downloadQueueOrderLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'downloadQueueOrder',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
       );
     });
   }
@@ -21082,6 +21235,12 @@ extension SettingsQueryWhereDistinct
     });
   }
 
+  QueryBuilder<Settings, Settings, QDistinct> distinctByDownloadQueueOrder() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'downloadQueueOrder');
+    });
+  }
+
   QueryBuilder<Settings, Settings, QDistinct> distinctByDownloadedOnlyMode() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'downloadedOnlyMode');
@@ -22317,6 +22476,13 @@ extension SettingsQueryProperty
   QueryBuilder<Settings, bool?, QQueryOperations> downloadOnlyOnWifiProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'downloadOnlyOnWifi');
+    });
+  }
+
+  QueryBuilder<Settings, List<int>?, QQueryOperations>
+  downloadQueueOrderProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'downloadQueueOrder');
     });
   }
 

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -919,14 +919,25 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     }
   }
 
-  Future<void> _openMedia(VideoPrefs prefs, [Duration? position]) {
-    return _player.open(
-      Media(
-        prefs.videoTrack!.id,
-        httpHeaders: prefs.headers,
-        start: position ?? _currentPosition.value,
-      ),
+  Future<void> _openMedia(VideoPrefs prefs, [Duration? position]) async {
+    final start = position ?? _currentPosition.value;
+    await _player.open(
+      Media(prefs.videoTrack!.id, httpHeaders: prefs.headers, start: start),
     );
+    if (start > Duration.zero) {
+      // media_kit's Media(start:) is unreliable for some sources — playback can
+      // begin at 0 even though the resume position was passed. Seek explicitly
+      // once the media reports a duration (i.e. it has loaded). Fire-and-forget
+      // so open() isn't delayed; the timeout guards a source that never reports
+      // one, and a redundant seek (when start: did work) is harmless.
+      unawaited(
+        _player.stream.duration
+            .firstWhere((d) => d > Duration.zero)
+            .timeout(const Duration(seconds: 8))
+            .then((_) => _player.seek(start))
+            .catchError((_) {}),
+      );
+    }
   }
 
   Future<void> _loadAndroidFont() async {

--- a/lib/modules/manga/download/download_page_widget.dart
+++ b/lib/modules/manga/download/download_page_widget.dart
@@ -179,10 +179,10 @@ class ChapterPageDownload extends ConsumerWidget {
                           }
                         },
                         itemBuilder: (context) => [
-                          PopupMenuItem(
-                            value: 1,
-                            child: Text(l10n.start_downloading),
-                          ),
+                          // This download already has progress, so the action is
+                          // a restart, not a start — label it Retry (matches the
+                          // stalled/no-progress state below).
+                          PopupMenuItem(value: 1, child: Text(l10n.retry)),
                           PopupMenuItem(value: 0, child: Text(l10n.cancel)),
                         ],
                       ),

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -315,6 +315,24 @@ Future<void> downloadChapter(
     }
 
     if (pageUrls.isNotEmpty) {
+      // A stalled or failed attempt can leave a partial single-file download
+      // (anime .mp4, novel .html) on disk. The existence check below would then
+      // treat it as already downloaded and mark it complete — a truncated but
+      // "finished" file. If this chapter's download record is not actually
+      // complete, delete any such leftover first so it re-downloads fresh.
+      final downloadRecord = isar.downloads.getSync(chapter.id!);
+      if (!(downloadRecord?.isDownload ?? false)) {
+        for (final leftover in [
+          File(p.join(mangaMainDirectory!.path, "$chapterName.mp4")),
+          File(p.join(mangaMainDirectory.path, "$chapterName.html")),
+        ]) {
+          if (leftover.existsSync()) {
+            try {
+              leftover.deleteSync();
+            } catch (_) {}
+          }
+        }
+      }
       bool cbzFileExist =
           await File(
             p.join(mangaMainDirectory!.path, "${chapter.name}.cbz"),

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -476,6 +476,22 @@ Duration _downloadStartDelay(int baseSeconds) {
   return Duration(milliseconds: base + jitter);
 }
 
+/// Key identifying the source a download belongs to, used to serialize
+/// downloads from the same source. Falls back to a per-download unique key when
+/// the source can't be resolved, so an unknown source never over-serializes.
+String _downloadSourceKey(Download d) {
+  final chapter = d.chapter.value;
+  if (chapter == null) return 'download-${d.id}';
+  if (!chapter.manga.isLoaded) {
+    try {
+      chapter.manga.loadSync();
+    } catch (_) {}
+  }
+  final m = chapter.manga.value;
+  if (m?.source == null) return 'download-${d.id}';
+  return '${m!.source}|${m.lang}|${m.sourceId}';
+}
+
 @riverpod
 Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
   final keepAlive = ref.keepAlive();
@@ -492,17 +508,29 @@ Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
         ? ref.read(concurrentDownloadsStateProvider)
         : 1;
     final delaySeconds = ref.read(downloadDelaySecondsStateProvider);
-    int index = 0;
-    int downloaded = 0;
+    // Serialize downloads from the same source: at most one per source runs at
+    // a time even when concurrency is on, so a single plugin/source is never hit
+    // by parallel requests. Different sources still download in parallel. #645.
+    final pending = List.of(ongoingDownloads);
+    final total = ongoingDownloads.length;
+    final activeSources = <String>{};
+    int done = 0;
     int current = 0;
     await Future.doWhile(() async {
       await Future.delayed(const Duration(seconds: 1));
-      if (ongoingDownloads.length == downloaded) {
+      if (done >= total) {
         return false;
       }
-      if (current < maxConcurrentDownloads) {
+      while (current < maxConcurrentDownloads && pending.isNotEmpty) {
+        // Next pending download whose source isn't already downloading.
+        final idx = pending.indexWhere(
+          (d) => !activeSources.contains(_downloadSourceKey(d)),
+        );
+        if (idx < 0) break; // every remaining download shares a busy source
+        final downloadItem = pending.removeAt(idx);
+        final key = _downloadSourceKey(downloadItem);
+        activeSources.add(key);
         current++;
-        final downloadItem = ongoingDownloads[index++];
         final chapter = downloadItem.chapter.value!;
         chapter.cancelDownloads(downloadItem.id);
         await Future.delayed(_downloadStartDelay(delaySeconds));
@@ -511,8 +539,9 @@ Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
             chapter: chapter,
             useWifi: useWifi,
             callback: () {
-              downloaded++;
+              done++;
               current--;
+              activeSources.remove(key);
             },
           ),
         );

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -343,6 +343,7 @@ Future<void> downloadChapter(
 
     if (!isOk) {
       botToast(startFailure ?? "Couldn't start the download");
+      _markDownloadFailed(chapter);
       if (callback != null) callback();
       keepAlive.close();
       return;
@@ -492,7 +493,8 @@ Future<void> downloadChapter(
   } catch (e) {
     // Surface the failure instead of swallowing it — a silent catch here is
     // exactly how "downloads just don't start" stays invisible.
-    botToast("Download failed to start: $e");
+    botToast("Download failed: $e");
+    _markDownloadFailed(chapter);
     if (callback != null) callback();
     keepAlive.close();
   } finally {
@@ -509,6 +511,22 @@ Duration _downloadStartDelay(int baseSeconds) {
   final base = baseSeconds * 1000;
   final jitter = (base * (0.25 + Random().nextDouble() * 0.75)).round();
   return Duration(milliseconds: base + jitter);
+}
+
+/// Reset a failed/aborted download to a plain, tappable "not downloaded" state
+/// so it shows a retry-able icon instead of a progress bar frozen at its last
+/// value. Any partial file is cleaned up on the next attempt.
+void _markDownloadFailed(Chapter chapter) {
+  final record = isar.downloads.getSync(chapter.id!);
+  if (record == null || (record.isDownload ?? false)) return;
+  isar.writeTxnSync(() {
+    isar.downloads.putSync(
+      record
+        ..isStartDownload = false
+        ..succeeded = 0
+        ..failed = 1,
+    );
+  });
 }
 
 /// Key identifying the source a chapter belongs to, used to serialize

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math';
 import 'dart:io';
 import 'dart:ui';
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -446,6 +447,17 @@ Future<void> downloadChapter(
   }
 }
 
+/// Delay before starting the next queued download. With rate limiting off
+/// ([baseSeconds] 0) this is just the small default gap. Otherwise it is the
+/// chosen base plus 25% to 100% random jitter, spacing requests out and varying
+/// them so a source is less likely to IP-block or wear a plugin out. See #621.
+Duration _downloadStartDelay(int baseSeconds) {
+  if (baseSeconds <= 0) return const Duration(milliseconds: 500);
+  final base = baseSeconds * 1000;
+  final jitter = (base * (0.25 + Random().nextDouble() * 0.75)).round();
+  return Duration(milliseconds: base + jitter);
+}
+
 @riverpod
 Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
   final keepAlive = ref.keepAlive();
@@ -456,7 +468,12 @@ Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
         .isDownloadEqualTo(false)
         .isStartDownloadEqualTo(true)
         .findAll();
-    final maxConcurrentDownloads = ref.read(concurrentDownloadsStateProvider);
+    // When concurrent downloads are disabled, run them one at a time.
+    final allowConcurrent = ref.read(allowConcurrentDownloadsStateProvider);
+    final maxConcurrentDownloads = allowConcurrent
+        ? ref.read(concurrentDownloadsStateProvider)
+        : 1;
+    final delaySeconds = ref.read(downloadDelaySecondsStateProvider);
     int index = 0;
     int downloaded = 0;
     int current = 0;
@@ -470,7 +487,7 @@ Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
         final downloadItem = ongoingDownloads[index++];
         final chapter = downloadItem.chapter.value!;
         chapter.cancelDownloads(downloadItem.id);
-        await Future.delayed(const Duration(milliseconds: 500));
+        await Future.delayed(_downloadStartDelay(delaySeconds));
         ref.read(
           downloadChapterProvider(
             chapter: chapter,

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -21,6 +21,7 @@ import 'package:mangayomi/modules/more/settings/downloads/providers/downloads_st
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/router/router.dart';
+import 'package:mangayomi/services/download_manager/download_queue_order.dart';
 import 'package:mangayomi/services/download_manager/m_downloader.dart';
 import 'package:mangayomi/services/get_video_list.dart';
 import 'package:mangayomi/services/get_chapter_pages.dart';
@@ -91,6 +92,7 @@ Future<void> downloadChapter(
       : 1;
   final delaySeconds = ref.read(downloadDelaySecondsStateProvider);
   await _DownloadGate.instance.acquire(
+    id: chapter.id!,
     sourceKey: sourceKey,
     maxConcurrent: maxConcurrent,
     delaySeconds: delaySeconds,
@@ -565,18 +567,21 @@ String _chapterSourceKey(Chapter chapter) {
   return '${m!.source}|${m.lang}|${m.sourceId}';
 }
 
-/// A download waiting for a slot in [_DownloadGate].
+/// A download waiting for a slot in [_DownloadGate]. [id] is the download's id
+/// (== chapter id), used to honor the manual queue order.
 class _GateWaiter {
-  _GateWaiter(this.sourceKey, this.completer);
+  _GateWaiter(this.id, this.sourceKey, this.completer);
+  final int id;
   final String sourceKey;
   final Completer<void> completer;
 }
 
 /// App-wide gate every download passes through before doing network work.
 /// It bounds how many downloads run at once, keeps a single source strictly
-/// serial (#645), and spaces launches apart with a jittered delay (#621) —
-/// all independent of how the download was triggered (per-chapter icon,
-/// "download all", or the queue processor).
+/// serial (#645), spaces launches apart with a jittered delay (#621), and hands
+/// out slots in the user's manual queue order (#514) — all independent of how
+/// the download was triggered (per-chapter icon, "download all", or the queue
+/// processor).
 class _DownloadGate {
   _DownloadGate._();
   static final _DownloadGate instance = _DownloadGate._();
@@ -588,6 +593,7 @@ class _DownloadGate {
   final List<_GateWaiter> _waiters = <_GateWaiter>[];
 
   Future<void> acquire({
+    required int id,
     required String sourceKey,
     required int maxConcurrent,
     required int delaySeconds,
@@ -595,7 +601,7 @@ class _DownloadGate {
     _maxConcurrent = maxConcurrent < 1 ? 1 : maxConcurrent;
     _delaySeconds = delaySeconds;
     final completer = Completer<void>();
-    _waiters.add(_GateWaiter(sourceKey, completer));
+    _waiters.add(_GateWaiter(id, sourceKey, completer));
     _dispatch();
     return completer.future;
   }
@@ -606,7 +612,34 @@ class _DownloadGate {
     _dispatch();
   }
 
+  /// Reorder the waiting list by the user's saved manual order (#514), re-read
+  /// each dispatch so dragging a chapter up takes effect on what's still
+  /// waiting. Ids not in the saved order keep their current relative order,
+  /// after the ranked ones, so a plain queue behaves exactly as before.
+  void _reorderWaiters() {
+    final order = DownloadQueueOrder.order;
+    if (order.isEmpty || _waiters.length < 2) return;
+    final rank = <int, int>{};
+    for (var j = 0; j < order.length; j++) {
+      rank[order[j]] = j;
+    }
+    final decorated = [
+      for (var j = 0; j < _waiters.length; j++) (pos: j, w: _waiters[j]),
+    ];
+    decorated.sort((a, b) {
+      final ra = rank[a.w.id] ?? (order.length + a.pos);
+      final rb = rank[b.w.id] ?? (order.length + b.pos);
+      return ra.compareTo(rb);
+    });
+    _waiters
+      ..clear()
+      ..addAll(decorated.map((e) => e.w));
+  }
+
   void _dispatch() {
+    // Only worth reordering when a slot is actually free to grant; skipping it
+    // when full keeps a big "download all" burst from doing O(n^2) sorting.
+    if (_active < _maxConcurrent) _reorderWaiters();
     var i = 0;
     while (i < _waiters.length && _active < _maxConcurrent) {
       final waiter = _waiters[i];
@@ -631,16 +664,22 @@ class _DownloadGate {
 Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
   final keepAlive = ref.keepAlive();
   try {
-    final ongoingDownloads = await isar.downloads
-        .filter()
-        .idIsNotNull()
-        .isDownloadEqualTo(false)
-        .isStartDownloadEqualTo(true)
-        .findAll();
+    // Fire in the user's manual queue order (#514) so the initial slots go to
+    // the highest-priority chapters; the gate then keeps honoring live reorders
+    // as later slots free.
+    final ongoingDownloads = DownloadQueueOrder.sorted(
+      await isar.downloads
+          .filter()
+          .idIsNotNull()
+          .isDownloadEqualTo(false)
+          .isStartDownloadEqualTo(true)
+          .findAll(),
+    );
     // Kick off every pending download. The shared _DownloadGate enforces the
-    // concurrency limit, per-source serialization (#645) and the start delay
-    // (#621), so they can all be fired at once and will queue themselves
-    // instead of being paced here (which used to block on the main isolate).
+    // concurrency limit, per-source serialization (#645), the start delay
+    // (#621) and the manual order (#514), so they can all be fired at once and
+    // will queue themselves instead of being paced here (which used to block on
+    // the main isolate).
     for (final downloadItem in ongoingDownloads) {
       if (!downloadItem.chapter.isLoaded) {
         try {

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 import 'dart:io';
@@ -62,6 +63,38 @@ Future<void> downloadChapter(
   VoidCallback? callback,
 }) async {
   final keepAlive = ref.keepAlive();
+
+  // Show the chapter as queued straight away, before it waits for a slot, so
+  // the download icon reacts to the tap immediately even while it sits in the
+  // gate behind other downloads.
+  if (isar.downloads.getSync(chapter.id!) == null) {
+    isar.writeTxnSync(() {
+      isar.downloads.putSync(
+        Download(
+          id: chapter.id,
+          succeeded: 0,
+          failed: 0,
+          total: 100,
+          isDownload: false,
+          isStartDownload: true,
+        )..chapter.value = chapter,
+      );
+    });
+  }
+
+  // Every download path funnels through here, so acquiring the shared gate is
+  // what makes the concurrency limit, per-source serialization (#645) and the
+  // start delay/jitter (#621) apply no matter how the download was started.
+  final sourceKey = _chapterSourceKey(chapter);
+  final maxConcurrent = ref.read(allowConcurrentDownloadsStateProvider)
+      ? ref.read(concurrentDownloadsStateProvider)
+      : 1;
+  final delaySeconds = ref.read(downloadDelaySecondsStateProvider);
+  await _DownloadGate.instance.acquire(
+    sourceKey: sourceKey,
+    maxConcurrent: maxConcurrent,
+    delaySeconds: delaySeconds,
+  );
 
   try {
     bool onlyOnWifi = useWifi ?? ref.read(onlyOnWifiStateProvider);
@@ -462,6 +495,8 @@ Future<void> downloadChapter(
     botToast("Download failed to start: $e");
     if (callback != null) callback();
     keepAlive.close();
+  } finally {
+    _DownloadGate.instance.release(sourceKey);
   }
 }
 
@@ -476,20 +511,80 @@ Duration _downloadStartDelay(int baseSeconds) {
   return Duration(milliseconds: base + jitter);
 }
 
-/// Key identifying the source a download belongs to, used to serialize
-/// downloads from the same source. Falls back to a per-download unique key when
+/// Key identifying the source a chapter belongs to, used to serialize
+/// downloads from the same source. Falls back to a per-chapter unique key when
 /// the source can't be resolved, so an unknown source never over-serializes.
-String _downloadSourceKey(Download d) {
-  final chapter = d.chapter.value;
-  if (chapter == null) return 'download-${d.id}';
+String _chapterSourceKey(Chapter chapter) {
   if (!chapter.manga.isLoaded) {
     try {
       chapter.manga.loadSync();
     } catch (_) {}
   }
   final m = chapter.manga.value;
-  if (m?.source == null) return 'download-${d.id}';
+  if (m?.source == null) return 'chapter-${chapter.id}';
   return '${m!.source}|${m.lang}|${m.sourceId}';
+}
+
+/// A download waiting for a slot in [_DownloadGate].
+class _GateWaiter {
+  _GateWaiter(this.sourceKey, this.completer);
+  final String sourceKey;
+  final Completer<void> completer;
+}
+
+/// App-wide gate every download passes through before doing network work.
+/// It bounds how many downloads run at once, keeps a single source strictly
+/// serial (#645), and spaces launches apart with a jittered delay (#621) —
+/// all independent of how the download was triggered (per-chapter icon,
+/// "download all", or the queue processor).
+class _DownloadGate {
+  _DownloadGate._();
+  static final _DownloadGate instance = _DownloadGate._();
+
+  int _active = 0;
+  int _maxConcurrent = 1;
+  int _delaySeconds = 0;
+  final Set<String> _activeSources = <String>{};
+  final List<_GateWaiter> _waiters = <_GateWaiter>[];
+
+  Future<void> acquire({
+    required String sourceKey,
+    required int maxConcurrent,
+    required int delaySeconds,
+  }) {
+    _maxConcurrent = maxConcurrent < 1 ? 1 : maxConcurrent;
+    _delaySeconds = delaySeconds;
+    final completer = Completer<void>();
+    _waiters.add(_GateWaiter(sourceKey, completer));
+    _dispatch();
+    return completer.future;
+  }
+
+  void release(String sourceKey) {
+    if (_active > 0) _active--;
+    _activeSources.remove(sourceKey);
+    _dispatch();
+  }
+
+  void _dispatch() {
+    var i = 0;
+    while (i < _waiters.length && _active < _maxConcurrent) {
+      final waiter = _waiters[i];
+      // Source already downloading — leave this one queued, try the next.
+      if (_activeSources.contains(waiter.sourceKey)) {
+        i++;
+        continue;
+      }
+      _waiters.removeAt(i);
+      _active++;
+      _activeSources.add(waiter.sourceKey);
+      // Reserve the slot now but only release the waiter after the start delay,
+      // so launches stay spaced out instead of bursting.
+      Future.delayed(_downloadStartDelay(_delaySeconds), () {
+        if (!waiter.completer.isCompleted) waiter.completer.complete();
+      });
+    }
+  }
 }
 
 @riverpod
@@ -502,54 +597,23 @@ Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
         .isDownloadEqualTo(false)
         .isStartDownloadEqualTo(true)
         .findAll();
-    // When concurrent downloads are disabled, run them one at a time.
-    final allowConcurrent = ref.read(allowConcurrentDownloadsStateProvider);
-    final maxConcurrentDownloads = allowConcurrent
-        ? ref.read(concurrentDownloadsStateProvider)
-        : 1;
-    final delaySeconds = ref.read(downloadDelaySecondsStateProvider);
-    // Serialize downloads from the same source: at most one per source runs at
-    // a time even when concurrency is on, so a single plugin/source is never hit
-    // by parallel requests. Different sources still download in parallel. #645.
-    final pending = List.of(ongoingDownloads);
-    final total = ongoingDownloads.length;
-    final activeSources = <String>{};
-    int done = 0;
-    int current = 0;
-    await Future.doWhile(() async {
-      await Future.delayed(const Duration(seconds: 1));
-      if (done >= total) {
-        return false;
+    // Kick off every pending download. The shared _DownloadGate enforces the
+    // concurrency limit, per-source serialization (#645) and the start delay
+    // (#621), so they can all be fired at once and will queue themselves
+    // instead of being paced here (which used to block on the main isolate).
+    for (final downloadItem in ongoingDownloads) {
+      if (!downloadItem.chapter.isLoaded) {
+        try {
+          downloadItem.chapter.loadSync();
+        } catch (_) {}
       }
-      while (current < maxConcurrentDownloads && pending.isNotEmpty) {
-        // Next pending download whose source isn't already downloading.
-        final idx = pending.indexWhere(
-          (d) => !activeSources.contains(_downloadSourceKey(d)),
-        );
-        if (idx < 0) break; // every remaining download shares a busy source
-        final downloadItem = pending.removeAt(idx);
-        final key = _downloadSourceKey(downloadItem);
-        activeSources.add(key);
-        current++;
-        final chapter = downloadItem.chapter.value!;
-        chapter.cancelDownloads(downloadItem.id);
-        await Future.delayed(_downloadStartDelay(delaySeconds));
-        ref.read(
-          downloadChapterProvider(
-            chapter: chapter,
-            useWifi: useWifi,
-            callback: () {
-              done++;
-              current--;
-              activeSources.remove(key);
-            },
-          ),
-        );
-      }
-      return true;
-    });
-    keepAlive.close();
+      final chapter = downloadItem.chapter.value;
+      if (chapter == null) continue;
+      chapter.cancelDownloads(downloadItem.id);
+      ref.read(downloadChapterProvider(chapter: chapter, useWifi: useWifi));
+    }
   } catch (_) {
+  } finally {
     keepAlive.close();
   }
 }

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -97,6 +97,12 @@ Future<void> downloadChapter(
   );
 
   try {
+    // Cancelled while it waited for a slot in the gate? Its record was deleted,
+    // so don't resurrect it.
+    if (_downloadCancelled(chapter)) {
+      keepAlive.close();
+      return;
+    }
     bool onlyOnWifi = useWifi ?? ref.read(onlyOnWifiStateProvider);
     final connectivity = await Connectivity().checkConnectivity();
     final isOnWifi =
@@ -349,6 +355,12 @@ Future<void> downloadChapter(
       return;
     }
 
+    // Cancelled during the (up to 45s) prep wait? Bail before writing files.
+    if (_downloadCancelled(chapter)) {
+      keepAlive.close();
+      return;
+    }
+
     if (pageUrls.isNotEmpty) {
       // A stalled or failed attempt can leave a partial single-file download
       // (anime .mp4, novel .html) on disk. The existence check below would then
@@ -502,12 +514,14 @@ Future<void> downloadChapter(
   }
 }
 
-/// Delay before starting the next queued download. With rate limiting off
-/// ([baseSeconds] 0) this is just the small default gap. Otherwise it is the
-/// chosen base plus 25% to 100% random jitter, spacing requests out and varying
-/// them so a source is less likely to IP-block or wear a plugin out. See #621.
+/// Delay before releasing the next queued download from the gate. With rate
+/// limiting off ([baseSeconds] 0) there is no artificial delay — the gate's
+/// concurrency limit and per-source serialization already prevent hammering, so
+/// downloads should start as soon as a slot is free. Otherwise it is the chosen
+/// base plus 25% to 100% random jitter, spacing requests out and varying them so
+/// a source is less likely to IP-block or wear a plugin out. See #621.
 Duration _downloadStartDelay(int baseSeconds) {
-  if (baseSeconds <= 0) return const Duration(milliseconds: 500);
+  if (baseSeconds <= 0) return Duration.zero;
   final base = baseSeconds * 1000;
   final jitter = (base * (0.25 + Random().nextDouble() * 0.75)).round();
   return Duration(milliseconds: base + jitter);
@@ -528,6 +542,14 @@ void _markDownloadFailed(Chapter chapter) {
     );
   });
 }
+
+/// True when a download was cancelled while it was queued. cancelDownloads
+/// deletes the record, so a missing record for a chapter we were about to
+/// download means "cancelled" — bail instead of resurrecting it. This matters
+/// because every download is fired up front and then waits in the gate; a
+/// cancel that lands while it waits must actually stop it.
+bool _downloadCancelled(Chapter chapter) =>
+    isar.downloads.getSync(chapter.id!) == null;
 
 /// Key identifying the source a chapter belongs to, used to serialize
 /// downloads from the same source. Falls back to a per-chapter unique key when

--- a/lib/modules/manga/download/providers/download_provider.g.dart
+++ b/lib/modules/manga/download/providers/download_provider.g.dart
@@ -136,7 +136,7 @@ final class DownloadChapterProvider
   }
 }
 
-String _$downloadChapterHash() => r'c0d7bc9cd975bb5f1abdf29f9aa6d9d8dc8ca441';
+String _$downloadChapterHash() => r'c1907fb4b8bf9e60c54b9f647b71c831e0661ffa';
 
 final class DownloadChapterFamily extends $Family
     with
@@ -215,7 +215,7 @@ final class ProcessDownloadsProvider
   }
 }
 
-String _$processDownloadsHash() => r'36903a1ca0140ef7d55aa68ee34d8c74573e8e71';
+String _$processDownloadsHash() => r'61cfdcfe76480853d4f2102e4435bd3bdc36c939';
 
 final class ProcessDownloadsFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<void>, bool?> {

--- a/lib/modules/more/download_queue/download_queue_screen.dart
+++ b/lib/modules/more/download_queue/download_queue_screen.dart
@@ -1,20 +1,246 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:grouped_list/grouped_list.dart';
 import 'package:isar_community/isar.dart';
+import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/chapter.dart';
 import 'package:mangayomi/models/download.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/custom_floating_action_btn.dart';
 import 'package:mangayomi/modules/manga/download/providers/download_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/services/download_manager/download_queue_order.dart';
 import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
 import 'package:mangayomi/utils/global_style.dart';
 import 'package:mangayomi/modules/widgets/tv_menu.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
 
-class DownloadQueueScreen extends ConsumerWidget {
+class DownloadQueueScreen extends ConsumerStatefulWidget {
   const DownloadQueueScreen({super.key});
+
+  @override
+  ConsumerState<DownloadQueueScreen> createState() =>
+      _DownloadQueueScreenState();
+}
+
+class _DownloadQueueScreenState extends ConsumerState<DownloadQueueScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final l10n = l10nLocalizations(context)!;
+    return StreamBuilder(
+      // No explicit sort: the natural (insertion) id order is the stable base
+      // the manual queue order is applied on top of, so rows don't reshuffle as
+      // download progress ticks.
+      stream: isar.downloads
+          .filter()
+          .idIsNotNull()
+          .isDownloadEqualTo(false)
+          .isStartDownloadEqualTo(true)
+          .watch(fireImmediately: true),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData || snapshot.data!.isEmpty) {
+          return Scaffold(
+            appBar: AppBar(
+              title: Text(l10n.download_queue),
+              leading: isTv
+                  ? IconButton(
+                      autofocus: true,
+                      icon: const BackButtonIcon(),
+                      onPressed: () => Navigator.of(context).pop(),
+                    )
+                  : null,
+            ),
+            body: Center(child: Text(l10n.no_downloads)),
+          );
+        }
+        // Filter out orphaned downloads (chapter or manga deleted) and auto-
+        // clean their records.
+        final orphanIds = <int>[];
+        final valid = <Download>[];
+        for (final d in snapshot.data!) {
+          if (d.chapter.value == null || d.chapter.value?.manga.value == null) {
+            if (d.id != null) orphanIds.add(d.id!);
+          } else {
+            valid.add(d);
+          }
+        }
+        if (orphanIds.isNotEmpty) {
+          isar.writeTxnSync(() {
+            for (final id in orphanIds) {
+              isar.downloads.deleteSync(id);
+            }
+          });
+        }
+        if (valid.isEmpty) {
+          return Scaffold(
+            appBar: AppBar(
+              title: Text(l10n.download_queue),
+              leading: isTv
+                  ? IconButton(
+                      autofocus: true,
+                      icon: const BackButtonIcon(),
+                      onPressed: () => Navigator.of(context).pop(),
+                    )
+                  : null,
+            ),
+            body: Center(child: Text(l10n.no_downloads)),
+          );
+        }
+        final entries = DownloadQueueOrder.sorted(valid);
+        return Scaffold(
+          appBar: AppBar(
+            title: Row(
+              children: [
+                Text(l10n.download_queue),
+                const SizedBox(width: 10),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 3),
+                  child: Badge(
+                    backgroundColor: Theme.of(context).focusColor,
+                    label: Text(
+                      entries.length.toString(),
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Theme.of(context).textTheme.bodySmall!.color,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          body: ReorderableListView.builder(
+            buildDefaultDragHandles: false,
+            itemCount: entries.length,
+            // onReorderItem already accounts for the item being lifted out at
+            // oldIndex, so newIndex arrives adjusted and must not be shifted
+            // again here.
+            onReorderItem: (oldIndex, newIndex) {
+              final ids = entries.map((e) => e.id!).toList();
+              final moved = ids.removeAt(oldIndex);
+              ids.insert(newIndex, moved);
+              DownloadQueueOrder.setOrder(ids);
+              setState(() {});
+            },
+            itemBuilder: (context, index) {
+              final element = entries[index];
+              return _buildRow(context, l10n, entries, element, index);
+            },
+          ),
+          floatingActionButton: CustomFloatingActionBtn(
+            isExtended: false,
+            label: l10n.download_queue,
+            onPressed: () {
+              ref.read(processDownloadsProvider());
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildRow(
+    BuildContext context,
+    AppLocalizations l10n,
+    List<Download> entries,
+    Download element,
+    int index,
+  ) {
+    return SizedBox(
+      key: ValueKey(element.id),
+      height: 60,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          ReorderableDragStartListener(
+            index: index,
+            child: const Padding(
+              padding: EdgeInsets.all(8.0),
+              child: Icon(Icons.drag_handle),
+            ),
+          ),
+          Flexible(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      element.chapter.value?.manga.value?.name ?? "",
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                    Text(
+                      "${element.succeeded}/${element.total}",
+                      style: const TextStyle(fontSize: 10),
+                    ),
+                  ],
+                ),
+                Text(
+                  element.chapter.value?.name ?? "",
+                  style: const TextStyle(fontSize: 13),
+                ),
+                const SizedBox(height: 8),
+                TweenAnimationBuilder<double>(
+                  duration: const Duration(milliseconds: 250),
+                  curve: Curves.easeInOut,
+                  tween: Tween<double>(
+                    begin: 0,
+                    end: element.succeeded! / element.total!,
+                  ),
+                  builder: (context, value, _) =>
+                      LinearProgressIndicator(value: value),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: isTv
+                // An anchored dropdown is a poor remote target, so pop the same
+                // actions in the centre on TV.
+                ? IconButton(
+                    icon: const Icon(Icons.more_vert),
+                    onPressed: () async {
+                      final picked = await showTvMenu(
+                        context,
+                        title: element.chapter.value?.manga.value?.name ?? '',
+                        options: [
+                          TvMenuOption(l10n.cancel),
+                          TvMenuOption(l10n.cancel_all_for_this_series),
+                        ],
+                      );
+                      if (picked != null && context.mounted) {
+                        await _onDownloadAction(
+                          context,
+                          picked == 0 ? 'Cancel' : 'CancelAll',
+                          element,
+                          entries,
+                        );
+                      }
+                    },
+                  )
+                : PopupMenuButton(
+                    popUpAnimationStyle: popupAnimationStyle,
+                    child: const Icon(Icons.more_vert),
+                    onSelected: (value) => _onDownloadAction(
+                      context,
+                      value.toString(),
+                      element,
+                      entries,
+                    ),
+                    itemBuilder: (context) => [
+                      PopupMenuItem(value: 'Cancel', child: Text(l10n.cancel)),
+                      PopupMenuItem(
+                        value: 'CancelAll',
+                        child: Text(l10n.cancel_all_for_this_series),
+                      ),
+                    ],
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
 
   /// The per-download actions, shared by the popup menu off-TV and the centred
   /// TV menu.
@@ -28,7 +254,7 @@ class DownloadQueueScreen extends ConsumerWidget {
       if (element.chapter.value != null) {
         element.chapter.value!.cancelDownloads(element.id!);
       } else {
-        // Orphaned download — just delete the record
+        // Orphaned download: just delete the record.
         isar.writeTxnSync(() {
           isar.downloads.deleteSync(element.id!);
         });
@@ -50,253 +276,5 @@ class DownloadQueueScreen extends ConsumerWidget {
         chapter?.cancelDownloads(downloadId!);
       }
     }
-  }
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = l10nLocalizations(context);
-    return StreamBuilder(
-      stream: isar.downloads
-          .filter()
-          .idIsNotNull()
-          .isDownloadEqualTo(false)
-          .isStartDownloadEqualTo(true)
-          .sortBySucceededDesc()
-          .watch(fireImmediately: true),
-      builder: (context, snapshot) {
-        if (snapshot.hasData && snapshot.data!.isNotEmpty) {
-          // Filter out orphaned downloads (chapter or manga deleted)
-          final allEntries = snapshot.data!;
-          final orphanIds = <int>[];
-          final entries = <Download>[];
-          for (final d in allEntries) {
-            if (d.chapter.value == null ||
-                d.chapter.value?.manga.value == null) {
-              if (d.id != null) orphanIds.add(d.id!);
-            } else {
-              entries.add(d);
-            }
-          }
-          // Auto-clean orphaned download records
-          if (orphanIds.isNotEmpty) {
-            isar.writeTxnSync(() {
-              for (final id in orphanIds) {
-                isar.downloads.deleteSync(id);
-              }
-            });
-          }
-          if (entries.isEmpty) {
-            return Scaffold(
-              appBar: AppBar(
-                title: Text(l10n!.download_queue),
-                leading: isTv
-                    ? IconButton(
-                        autofocus: true,
-                        icon: const BackButtonIcon(),
-                        onPressed: () => Navigator.of(context).pop(),
-                      )
-                    : null,
-              ),
-              body: Center(child: Text(l10n.no_downloads)),
-            );
-          }
-          final allQueueLength = entries.length;
-          return Scaffold(
-            appBar: AppBar(
-              title: Row(
-                children: [
-                  Text(l10n!.download_queue),
-                  const SizedBox(width: 10),
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 3),
-                    child: Badge(
-                      backgroundColor: Theme.of(context).focusColor,
-                      label: Text(
-                        allQueueLength.toString(),
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: Theme.of(context).textTheme.bodySmall!.color,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            body: GroupedListView<Download, String>(
-              elements: entries,
-              groupBy: (element) =>
-                  element.chapter.value?.manga.value?.source ?? "",
-              groupSeparatorBuilder: (String groupByValue) {
-                final sourceQueueLength = entries
-                    .where(
-                      (element) =>
-                          (element.chapter.value?.manga.value?.source ?? "") ==
-                          groupByValue,
-                    )
-                    .toList()
-                    .length;
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 6, left: 12),
-                  child: Text('$groupByValue ($sourceQueueLength)'),
-                );
-              },
-              itemBuilder: (context, Download element) {
-                return SizedBox(
-                  height: 60,
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      const Padding(
-                        padding: EdgeInsets.all(8.0),
-                        child: Icon(Icons.drag_handle),
-                      ),
-                      Flexible(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Text(
-                                  element.chapter.value?.manga.value?.name ??
-                                      "",
-                                  style: const TextStyle(fontSize: 16),
-                                ),
-                                Text(
-                                  "${element.succeeded}/${element.total}",
-                                  style: const TextStyle(fontSize: 10),
-                                ),
-                              ],
-                            ),
-                            Text(
-                              element.chapter.value?.name ?? "",
-                              style: const TextStyle(fontSize: 13),
-                            ),
-                            const SizedBox(height: 8),
-                            TweenAnimationBuilder<double>(
-                              duration: const Duration(milliseconds: 250),
-                              curve: Curves.easeInOut,
-                              tween: Tween<double>(
-                                begin: 0,
-                                end: element.succeeded! / element.total!,
-                              ),
-                              builder: (context, value, _) =>
-                                  LinearProgressIndicator(value: value),
-                            ),
-                          ],
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: isTv
-                            // An anchored dropdown is a poor remote target, so
-                            // pop the same actions in the centre on TV.
-                            ? IconButton(
-                                icon: const Icon(Icons.more_vert),
-                                onPressed: () async {
-                                  final picked = await showTvMenu(
-                                    context,
-                                    title:
-                                        element
-                                            .chapter
-                                            .value
-                                            ?.manga
-                                            .value
-                                            ?.name ??
-                                        '',
-                                    options: [
-                                      TvMenuOption(l10n.cancel),
-                                      TvMenuOption(
-                                        l10n.cancel_all_for_this_series,
-                                      ),
-                                    ],
-                                  );
-                                  // The menu awaited, so the context may be
-                                  // gone by the time it returns.
-                                  if (picked != null && context.mounted) {
-                                    await _onDownloadAction(
-                                      context,
-                                      picked == 0 ? 'Cancel' : 'CancelAll',
-                                      element,
-                                      entries,
-                                    );
-                                  }
-                                },
-                              )
-                            : PopupMenuButton(
-                                popUpAnimationStyle: popupAnimationStyle,
-                                child: const Icon(Icons.more_vert),
-                                onSelected: (value) => _onDownloadAction(
-                                  context,
-                                  value.toString(),
-                                  element,
-                                  entries,
-                                ),
-                                itemBuilder: (context) => [
-                                  PopupMenuItem(
-                                    value: 'Cancel',
-                                    child: Text(l10n.cancel),
-                                  ),
-                                  PopupMenuItem(
-                                    value: 'CancelAll',
-                                    child: Text(
-                                      l10n.cancel_all_for_this_series,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                      ),
-                    ],
-                  ),
-                );
-              },
-              itemComparator: (item1, item2) =>
-                  (item1.chapter.value?.manga.value?.source ?? "").compareTo(
-                    item2.chapter.value?.manga.value?.source ?? "",
-                  ),
-              order: GroupedListOrder.DESC,
-            ),
-            floatingActionButton: CustomFloatingActionBtn(
-              isExtended: false,
-              label: l10n.download_queue,
-              onPressed: () {
-                ref.read(processDownloadsProvider());
-              },
-            ),
-          );
-        }
-        return Scaffold(
-          appBar: AppBar(
-            title: Text(l10n!.download_queue),
-            leading: isTv
-                ? IconButton(
-                    autofocus: true,
-                    icon: const BackButtonIcon(),
-                    onPressed: () => Navigator.of(context).pop(),
-                  )
-                : null,
-          ),
-          body: Center(child: Text(l10n.no_downloads)),
-        );
-      },
-    );
-  }
-
-  Size measureText(String text, TextStyle style) {
-    final TextPainter textPainter = TextPainter(
-      text: TextSpan(text: text, style: style),
-      textDirection: TextDirection.ltr,
-    )..layout();
-    return textPainter.size;
-  }
-
-  double calculateDynamicButtonWidth(
-    String text,
-    TextStyle textStyle,
-    double padding,
-  ) {
-    final textSize = measureText(text, textStyle);
-    return textSize.width + padding;
   }
 }

--- a/lib/modules/more/settings/downloads/downloads_screen.dart
+++ b/lib/modules/more/settings/downloads/downloads_screen.dart
@@ -25,6 +25,10 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen> {
     );
     final onlyOnWifiState = ref.watch(onlyOnWifiStateProvider);
     final concurrentDownloads = ref.watch(concurrentDownloadsStateProvider);
+    final allowConcurrentDownloads = ref.watch(
+      allowConcurrentDownloadsStateProvider,
+    );
+    final downloadDelaySeconds = ref.watch(downloadDelaySecondsStateProvider);
     final localFolders = ref.watch(localFoldersStateProvider);
     final l10n = l10nLocalizations(context);
     return Scaffold(
@@ -56,14 +60,94 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen> {
                     .set(value);
               },
             ),
+            SwitchListTile(
+              value: allowConcurrentDownloads,
+              title: Text(l10n.allow_concurrent_downloads),
+              subtitle: Text(l10n.allow_concurrent_downloads_subtitle),
+              onChanged: (value) {
+                ref
+                    .read(allowConcurrentDownloadsStateProvider.notifier)
+                    .set(value);
+              },
+            ),
+            if (allowConcurrentDownloads)
+              ListTile(
+                onTap: () {
+                  int currentIntValue = concurrentDownloads;
+                  showDialog(
+                    context: context,
+                    builder: (context) {
+                      return AlertDialog(
+                        title: Text(context.l10n.concurrent_downloads),
+                        content: StatefulBuilder(
+                          builder: (context, setState) => SizedBox(
+                            height: 200,
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                NumberPicker(
+                                  value: currentIntValue,
+                                  minValue: 1,
+                                  maxValue: 255,
+                                  step: 1,
+                                  haptics: true,
+                                  textMapper: (numberText) => numberText,
+                                  onChanged: (value) =>
+                                      setState(() => currentIntValue = value),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                        actions: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: [
+                              TextButton(
+                                onPressed: () async {
+                                  Navigator.pop(context);
+                                },
+                                child: Text(
+                                  context.l10n.cancel,
+                                  style: TextStyle(color: context.primaryColor),
+                                ),
+                              ),
+                              TextButton(
+                                onPressed: () async {
+                                  ref
+                                      .read(
+                                        concurrentDownloadsStateProvider
+                                            .notifier,
+                                      )
+                                      .set(currentIntValue);
+                                  Navigator.pop(context);
+                                },
+                                child: Text(
+                                  context.l10n.ok,
+                                  style: TextStyle(color: context.primaryColor),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
+                title: Text(context.l10n.concurrent_downloads),
+                subtitle: Text(
+                  "$concurrentDownloads",
+                  style: TextStyle(fontSize: 11, color: context.secondaryColor),
+                ),
+              ),
             ListTile(
               onTap: () {
-                int currentIntValue = concurrentDownloads;
+                int currentDelay = downloadDelaySeconds;
                 showDialog(
                   context: context,
                   builder: (context) {
                     return AlertDialog(
-                      title: Text(context.l10n.concurrent_downloads),
+                      title: Text(context.l10n.download_delay),
                       content: StatefulBuilder(
                         builder: (context, setState) => SizedBox(
                           height: 200,
@@ -71,14 +155,14 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               NumberPicker(
-                                value: currentIntValue,
-                                minValue: 1,
-                                maxValue: 255,
+                                value: currentDelay,
+                                minValue: 0,
+                                maxValue: 120,
                                 step: 1,
                                 haptics: true,
                                 textMapper: (numberText) => numberText,
                                 onChanged: (value) =>
-                                    setState(() => currentIntValue = value),
+                                    setState(() => currentDelay = value),
                               ),
                             ],
                           ),
@@ -89,21 +173,20 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen> {
                           mainAxisAlignment: MainAxisAlignment.end,
                           children: [
                             TextButton(
-                              onPressed: () async {
-                                Navigator.pop(context);
-                              },
+                              onPressed: () => Navigator.pop(context),
                               child: Text(
                                 context.l10n.cancel,
                                 style: TextStyle(color: context.primaryColor),
                               ),
                             ),
                             TextButton(
-                              onPressed: () async {
+                              onPressed: () {
                                 ref
                                     .read(
-                                      concurrentDownloadsStateProvider.notifier,
+                                      downloadDelaySecondsStateProvider
+                                          .notifier,
                                     )
-                                    .set(currentIntValue);
+                                    .set(currentDelay);
                                 Navigator.pop(context);
                               },
                               child: Text(
@@ -118,9 +201,11 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen> {
                   },
                 );
               },
-              title: Text(context.l10n.concurrent_downloads),
+              title: Text(context.l10n.download_delay),
               subtitle: Text(
-                "$concurrentDownloads",
+                downloadDelaySeconds == 0
+                    ? l10n.download_delay_subtitle
+                    : "$downloadDelaySeconds s (+ jitter)",
                 style: TextStyle(fontSize: 11, color: context.secondaryColor),
               ),
             ),

--- a/lib/modules/more/settings/downloads/providers/downloads_state_provider.dart
+++ b/lib/modules/more/settings/downloads/providers/downloads_state_provider.dart
@@ -118,3 +118,43 @@ class ConcurrentDownloadsState extends _$ConcurrentDownloadsState {
     );
   }
 }
+
+@riverpod
+class AllowConcurrentDownloadsState extends _$AllowConcurrentDownloadsState {
+  @override
+  bool build() {
+    return isar.settings.getSync(227)!.allowConcurrentDownloads ?? true;
+  }
+
+  void set(bool value) {
+    final settings = isar.settings.getSync(227);
+    state = value;
+    isar.writeTxnSync(
+      () => isar.settings.putSync(
+        settings!
+          ..allowConcurrentDownloads = value
+          ..updatedAt = DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+}
+
+@riverpod
+class DownloadDelaySecondsState extends _$DownloadDelaySecondsState {
+  @override
+  int build() {
+    return isar.settings.getSync(227)!.downloadDelaySeconds ?? 0;
+  }
+
+  void set(int value) {
+    final settings = isar.settings.getSync(227);
+    state = value;
+    isar.writeTxnSync(
+      () => isar.settings.putSync(
+        settings!
+          ..downloadDelaySeconds = value
+          ..updatedAt = DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+}

--- a/lib/modules/more/settings/downloads/providers/downloads_state_provider.g.dart
+++ b/lib/modules/more/settings/downloads/providers/downloads_state_provider.g.dart
@@ -273,3 +273,110 @@ abstract class _$ConcurrentDownloadsState extends $Notifier<int> {
     element.handleCreate(ref, build);
   }
 }
+
+@ProviderFor(AllowConcurrentDownloadsState)
+final allowConcurrentDownloadsStateProvider =
+    AllowConcurrentDownloadsStateProvider._();
+
+final class AllowConcurrentDownloadsStateProvider
+    extends $NotifierProvider<AllowConcurrentDownloadsState, bool> {
+  AllowConcurrentDownloadsStateProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'allowConcurrentDownloadsStateProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$allowConcurrentDownloadsStateHash();
+
+  @$internal
+  @override
+  AllowConcurrentDownloadsState create() => AllowConcurrentDownloadsState();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$allowConcurrentDownloadsStateHash() =>
+    r'2d71d79e343a17be62684c9b5b99539243519754';
+
+abstract class _$AllowConcurrentDownloadsState extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+@ProviderFor(DownloadDelaySecondsState)
+final downloadDelaySecondsStateProvider = DownloadDelaySecondsStateProvider._();
+
+final class DownloadDelaySecondsStateProvider
+    extends $NotifierProvider<DownloadDelaySecondsState, int> {
+  DownloadDelaySecondsStateProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'downloadDelaySecondsStateProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$downloadDelaySecondsStateHash();
+
+  @$internal
+  @override
+  DownloadDelaySecondsState create() => DownloadDelaySecondsState();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(int value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<int>(value),
+    );
+  }
+}
+
+String _$downloadDelaySecondsStateHash() =>
+    r'eb97bd41f669e2e1bd27ca32a98b1a470f3d50c4';
+
+abstract class _$DownloadDelaySecondsState extends $Notifier<int> {
+  int build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<int, int>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<int, int>,
+              int,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/services/download_manager/download_isolate_pool.dart
+++ b/lib/services/download_manager/download_isolate_pool.dart
@@ -514,7 +514,15 @@ Future<void> _downloadFile(
         final file = File(pageUrl.fileName!);
         final sink = file.openWrite();
         try {
-          await for (var value in response.stream) {
+          // Idle timeout: if no bytes arrive for 30s the connection has
+          // stalled, so fail (and retry) instead of hanging the whole
+          // download forever with no progress.
+          await for (var value in response.stream.timeout(
+            const Duration(seconds: 30),
+            onTimeout: (sink) => sink.addError(
+              TimeoutException('Download stalled (no data for 30s)'),
+            ),
+          )) {
             sink.add(value);
             received += value.length;
             try {
@@ -621,7 +629,14 @@ Future<void> _downloadSegment(
 
     final sink = file.openWrite();
     try {
-      await for (var chunk in response.stream) {
+      // Idle timeout: a segment whose connection stalls (no bytes for 30s)
+      // fails and retries instead of hanging the whole download forever.
+      await for (var chunk in response.stream.timeout(
+        const Duration(seconds: 30),
+        onTimeout: (sink) => sink.addError(
+          TimeoutException('Segment stalled (no data for 30s)'),
+        ),
+      )) {
         sink.add(chunk);
       }
     } finally {

--- a/lib/services/download_manager/download_isolate_pool.dart
+++ b/lib/services/download_manager/download_isolate_pool.dart
@@ -510,6 +510,13 @@ Future<void> _downloadFile(
         }
         int total = response.contentLength ?? 0;
         int received = 0;
+        // Throttle progress. Emitting on every chunk floods the main isolate
+        // with synchronous DB writes (setProgress) and freezes the whole UI
+        // while a download runs — worst with large single files (anime .mp4).
+        // Send at most once per 1% step (known length) or every 250ms
+        // (unknown length); the final 100% is delivered by onComplete.
+        int lastPercent = -1;
+        final progressWatch = Stopwatch()..start();
 
         final file = File(pageUrl.fileName!);
         final sink = file.openWrite();
@@ -525,16 +532,24 @@ Future<void> _downloadFile(
           )) {
             sink.add(value);
             received += value.length;
-            try {
-              replyPort.send(
-                DownloadProgress(
-                  (received / total * 100).toInt(),
-                  100,
-                  pageUrl: pageUrl,
-                  itemType,
-                ),
-              );
-            } catch (_) {}
+            final percent = total > 0 ? (received / total * 100).toInt() : -1;
+            final shouldSend = percent >= 0
+                ? percent != lastPercent
+                : progressWatch.elapsedMilliseconds >= 250;
+            if (shouldSend) {
+              lastPercent = percent;
+              if (percent < 0) progressWatch.reset();
+              try {
+                replyPort.send(
+                  DownloadProgress(
+                    percent < 0 ? 0 : percent,
+                    100,
+                    pageUrl: pageUrl,
+                    itemType,
+                  ),
+                );
+              } catch (_) {}
+            }
           }
         } finally {
           await sink.flush();

--- a/lib/services/download_manager/download_isolate_pool.dart
+++ b/lib/services/download_manager/download_isolate_pool.dart
@@ -481,7 +481,9 @@ Future<void> _downloadFile(
   try {
     if (itemType != ItemType.anime) {
       final response = await _withRetry(
-        () => client.get(Uri.parse(pageUrl.url), headers: pageUrl.headers),
+        () => client
+            .get(Uri.parse(pageUrl.url), headers: pageUrl.headers)
+            .timeout(const Duration(seconds: 30)),
         3,
       );
       if (response.statusCode != 200) {
@@ -497,7 +499,14 @@ Future<void> _downloadFile(
       await _withRetry(() async {
         var request = Request('GET', Uri.parse(pageUrl.url));
         request.headers.addAll(pageUrl.headers ?? {});
-        StreamedResponse response = await client.send(request);
+        // Connection/response-headers timeout. Without it, a wifi drop after
+        // streaming has begun makes the stream idle-timeout fire, retry, and
+        // then hang forever on this send with no network — the download stalls
+        // with no progress, no retry, and no error. Bail so _withRetry cycles
+        // and, once exhausted, the failure propagates to the UI.
+        StreamedResponse response = await client
+            .send(request)
+            .timeout(const Duration(seconds: 30));
         // Accept any 2xx — including 206 Partial Content, which the server
         // returns when the source extension sends `Range: bytes=0-` on the
         // streaming request (e.g. AnimeGG). Rejecting 206 here caused 3
@@ -632,7 +641,12 @@ Future<void> _downloadSegment(
     if (params.headers != null) {
       request.headers.addAll(params.headers!);
     }
-    StreamedResponse response = await _withRetry(() => client.send(request), 3);
+    // Connection/response-headers timeout so a dropped connection can't hang
+    // the segment forever (see _downloadFile) — retry, then fail loudly.
+    StreamedResponse response = await _withRetry(
+      () => client.send(request).timeout(const Duration(seconds: 30)),
+      3,
+    );
 
     // Accept any 2xx (including 206 Partial Content) — see comment in
     // _downloadFile.

--- a/lib/services/download_manager/download_queue_order.dart
+++ b/lib/services/download_manager/download_queue_order.dart
@@ -1,0 +1,44 @@
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/download.dart';
+import 'package:mangayomi/models/settings.dart';
+
+/// The user's manual ordering of the download queue as a list of Download ids
+/// (which equal their chapter ids), highest priority first.
+///
+/// Stored on the Settings collection (`downloadQueueOrder`), alongside the rest
+/// of the app's preferences. Ids missing from the saved order are treated as
+/// lowest priority (kept in their incoming id order, after the known ones), so
+/// newly queued downloads slot in at the end until the user moves them.
+class DownloadQueueOrder {
+  /// The saved priority order (Download ids), or an empty list if none.
+  static List<int> get order =>
+      isar.settings.getSync(227)?.downloadQueueOrder ?? const [];
+
+  /// Persists [ids] as the new priority order.
+  static void setOrder(List<int> ids) {
+    isar.writeTxnSync(() {
+      final settings = isar.settings.getSync(227);
+      if (settings != null) {
+        isar.settings.putSync(settings..downloadQueueOrder = ids);
+      }
+    });
+  }
+
+  /// Returns [items] arranged by the saved manual order. Items whose id isn't
+  /// in the saved order come last, keeping their incoming id order.
+  static List<Download> sorted(List<Download> items) {
+    final ord = order;
+    if (ord.isEmpty) return items;
+    final rank = <int, int>{};
+    for (var i = 0; i < ord.length; i++) {
+      rank[ord[i]] = i;
+    }
+    final result = [...items];
+    result.sort((a, b) {
+      final ra = rank[a.id] ?? (ord.length + (a.id ?? 0));
+      final rb = rank[b.id] ?? (ord.length + (b.id ?? 0));
+      return ra.compareTo(rb);
+    });
+    return result;
+  }
+}


### PR DESCRIPTION
Consolidates the download work into one PR. Analyze is clean (0 errors, 0 warnings); untestable from CI, so this wants a real download-that-stalls and a resume pass.

## Fixes
- **Stalls hang forever.** The m3u8 segment and direct file/page downloads streamed with no timeout, so a stalled connection (no bytes) hung the whole download indefinitely. Added a 30s idle timeout so a stalled transfer fails and retries. (More parallel connections made this worse.)
- **Restart marks a partial download complete.** The "already downloaded?" check only tested whether the target file exists, so a partial `.mp4`/`.html` left by a stall was treated as finished (truncated but "complete"). Now, before that check, a leftover is deleted when the chapter's download record is not actually complete, so it re-downloads from scratch.
- **Anime resume plays from 0.** The saved position (correct, stored/read in ms) was passed via media_kit's `Media(start:)`, which some sources ignore. Now the player also seeks explicitly once the media reports a duration.

## Controls
- **Allow concurrent downloads** (default on). Off runs downloads one at a time, steadier and less stall-prone.
- **Download delay** (default off, closes #621): opt-in per-chapter wait with 25 to 100 percent random jitter, to space and vary requests so a source is less likely to IP-block the user or wear a plugin out. A user control rather than a forced hidden delay.
- **Retry label.** A download that already has progress showed "Start downloading now" (a restart) in its menu; it now reads Retry, matching the stalled state.

New settings persist on the Isar Settings collection.

Also closes #645 (same-source downloads are now serialized while different sources still run in parallel).

Also closes #514 — the download queue can be reordered by dragging, and the scheduler hands out slots in that manual order.
