### PR TITLE
Fix tracker date/status sync bugs

### DIFF
--- a/lib/services/trackers/kitsu.dart
+++ b/lib/services/trackers/kitsu.dart
@@ -1,5 +1,4 @@
 import 'package:http_interceptor/http_interceptor.dart';
-import 'package:intl/intl.dart';
 import 'package:mangayomi/eval/model/m_bridge.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/track.dart';
@@ -404,19 +403,16 @@ class Kitsu extends _$Kitsu implements BaseTracker {
     };
   }
 
-  var formatter = DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "en");
   String? _convertDate(int dateValue) {
     if (dateValue == 0) return null;
-
-    return formatter.format(DateTime.fromMillisecondsSinceEpoch(dateValue));
+    return DateTime.fromMillisecondsSinceEpoch(
+      dateValue,
+    ).toUtc().toIso8601String();
   }
 
   int _parseDate(String? date) {
     if (date == null) return 0;
-
-    var dateValue = formatter.parse(date);
-
-    return dateValue.millisecondsSinceEpoch;
+    return DateTime.parse(date).millisecondsSinceEpoch;
   }
 
   String? _toKitsuScore(int score) {

--- a/lib/services/trackers/myanimelist.dart
+++ b/lib/services/trackers/myanimelist.dart
@@ -423,13 +423,14 @@ class MyAnimeList extends _$MyAnimeList implements BaseTracker {
           (track.status ==
                   (isManga ? TrackStatus.reReading : TrackStatus.reWatching))
               .toString(),
-      'score': track.score.toString(),
+      if (track.score != null && track.score! > 0)
+        'score': track.score.toString(),
       isManga ? 'num_chapters_read' : 'num_watched_episodes': track
           .lastChapterRead
           .toString(),
-      if (track.startedReadingDate != null)
+      if ((track.startedReadingDate ?? 0) > 0)
         'start_date': _convertToIsoDate(track.startedReadingDate),
-      if (track.finishedReadingDate != null)
+      if ((track.finishedReadingDate ?? 0) > 0)
         'finish_date': _convertToIsoDate(track.finishedReadingDate),
     };
     final request = Request(
@@ -442,7 +443,15 @@ class MyAnimeList extends _$MyAnimeList implements BaseTracker {
     request.bodyFields = formBody;
     request.headers.addAll({'Authorization': 'Bearer $accessToken'});
     final response = await Client().send(request);
-    final mJson = jsonDecode(await response.stream.bytesToString());
+    final bodyStr = await response.stream.bytesToString();
+    if (response.statusCode != 200) {
+      AppLogger.log(
+        "MAL update failed (${response.statusCode}): $bodyStr",
+        logLevel: LogLevel.error,
+      );
+      throw Exception("Failed to update MAL entry: ${response.statusCode}");
+    }
+    final mJson = jsonDecode(bodyStr);
     return _parseItem(mJson, track, isManga);
   }
 

--- a/lib/utils/extensions/chapter_extensions.dart
+++ b/lib/utils/extensions/chapter_extensions.dart
@@ -116,6 +116,7 @@ extension ChapterExtension on Chapter {
           .findFirstSync();
       if (!(service == null || chapterNumber <= (track.lastChapterRead ?? 0))) {
         if (track.status != TrackStatus.completed) {
+          final isFirstRead = (track.lastChapterRead ?? 0) == 0;
           track.lastChapterRead = chapterNumber;
           if (track.lastChapterRead == track.totalChapter &&
               (track.totalChapter ?? 0) > 0) {
@@ -125,7 +126,7 @@ extension ChapterExtension on Chapter {
             track.status = manga.itemType == ItemType.manga
                 ? TrackStatus.reading
                 : TrackStatus.watching;
-            if (track.lastChapterRead == 1) {
+            if (isFirstRead) {
               track.startedReadingDate = DateTime.now().millisecondsSinceEpoch;
             }
           }


### PR DESCRIPTION
## What this fixes

- **Kitsu dates were off by a day.** `_convertDate`/`_parseDate` used a
  `DateFormat` with a quoted `'Z'`, so it was treated as a literal char
  instead of a UTC marker — local time got sent/read as if it were UTC.
  Now uses `toUtc().toIso8601String()` / `DateTime.parse()`.

- **MAL wasn't updating status on new tracks.** `track.score` is null for
  a new track, and `null.toString()` sent `score=null`, which MAL rejects.
  The failure was silently swallowed because the response status was
  never checked. Now skips `score` when unset and throws on non-200
  instead of trying to parse an error body as a track.

- **Bulk-marking chapters as read didn't set the start date.** The old
  check only stamped `startedReadingDate` when `chapterNumber == 1`, but
  bulk operations don't guarantee processing order, so chapter 1 could
  get skipped by an earlier guard once a later chapter was already
  recorded. Now checks `lastChapterRead == 0` before it gets overwritten,
  which works regardless of order.

Tested manually against MAL and Kitsu, both single-chapter and
bulk-select flows.