### PR TITLE
Mark chapters as read when reached via scroll-through transition

### DIFF
--- a/lib/modules/manga/reader/providers/reader_controller_provider.dart
+++ b/lib/modules/manga/reader/providers/reader_controller_provider.dart
@@ -183,9 +183,13 @@ class ReaderController extends _$ReaderController
   }
 
   int? _lastSavedIndex;
-  void setPageIndex(int newIndex, bool save) {
+  void setPageIndex(
+    int newIndex,
+    bool save, [
+    List pageUrlsFallback = const [],
+  ]) {
     if (chapter.isRead! || incognitoMode) return;
-    final pageLength = getPageLength([]);
+    final pageLength = getPageLength(pageUrlsFallback);
     if (pageLength == 0 || (!save && newIndex == _lastSavedIndex)) return;
     _lastSavedIndex = newIndex;
     final isContinuousLike = getReaderMode().isVerticalContinuous;

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -201,6 +201,7 @@ class _MangaChapterPageGalleryState
       _readerController.setPageIndex(
         _isDoublePageActiveSync ? index : _geCurrentIndex(index),
         true,
+        _chapterUrlModel.pageUrls,
       );
     }
     for (final controller in _pageControllers.values) {
@@ -228,6 +229,7 @@ class _MangaChapterPageGalleryState
         _readerController.setPageIndex(
           _isDoublePageActive ? index : _geCurrentIndex(index),
           true,
+          _chapterUrlModel.pageUrls,
         );
       }
     } else if (state == AppLifecycleState.resumed) {
@@ -1203,6 +1205,7 @@ class _MangaChapterPageGalleryState
         _readerController.setPageIndex(
           _isDoublePageActive ? idx : _geCurrentIndex(idx),
           false,
+          _chapterUrlModel.pageUrls,
         );
         ref.read(currentIndexProvider(chapter).notifier).setCurrentIndex(idx);
       }
@@ -1458,6 +1461,7 @@ class _MangaChapterPageGalleryState
       _readerController.setPageIndex(
         _isDoublePageActive ? idx : _geCurrentIndex(idx),
         false,
+        _chapterUrlModel.pageUrls,
       );
     }
     if (_readerController.chapter.id != pages[actualIndex].chapter!.id) {


### PR DESCRIPTION
Chapters entered by scrolling past a transition page (instead of being explicitly opened) were never marked as read. `setPageIndex` computed page length via `getPageLength([])`, which silently returns `0` when the chapter's `chapterPageUrlsList` Isar entry hasn't been populated yet — causing every save call for that chapter to no-op. Fixed by passing `_chapterUrlModel.pageUrls` (already available in the gallery state) as a fallback, so page length resolves correctly regardless of Isar entry state.