### PR TITLE
fix(player): stop the mobile controls hiding instantly on tap

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -7,6 +7,7 @@ import 'package:bot_toast/bot_toast.dart';
 import 'package:ffi/ffi.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_qjs/quickjs/ffi.dart';
@@ -2750,7 +2751,13 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
         onEnter: (_) => _revealControls.value++,
         onHover: (_) => _revealControls.value++,
         child: Listener(
-          onPointerDown: (_) => _revealControls.value++,
+          // Reveal on a mouse click (desktop), but NOT on touch. On a touch
+          // device the mobile controls handle tap-to-toggle themselves, so
+          // revealing here on finger-down makes the following tap immediately
+          // hide them again (controls flash and vanish in under a second).
+          onPointerDown: (event) {
+            if (event.kind == PointerDeviceKind.mouse) _revealControls.value++;
+          },
           child: Focus(autofocus: true, onKeyEvent: _onPlayerKey, child: child),
         ),
       ),


### PR DESCRIPTION
On a touch device the player controls flash and vanish in under a second when you tap to show them.

The player wraps the video in a `Listener` whose `onPointerDown` bumps a notifier to reveal the auto-hiding controls (intended for a desktop mouse). But `onPointerDown` fires on touch too: finger-down reveals the controls, and then the tap's own `onTap` sees them already visible and toggles them straight back off, so they never stay for the 3s auto-hide.

Fix: only reveal from `onPointerDown` for a mouse pointer (`event.kind == PointerDeviceKind.mouse`). Touch devices already toggle via the controls' own `onTap`, so the auto-hide timer behaves as intended again. Desktop mouse-click reveal is unchanged.
