### PR TITLE
perf: fix v8.0 Android jank (Skia renderer + cover thumbnail resampling)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -88,5 +88,14 @@
             android:name="flutterEmbedding"
             android:value="2" />
         <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />
+        <!-- Use the Skia renderer on Android. Impeller (the default on the
+             Flutter version the v8.0 native image decoder pulled in) janks
+             app-wide on many Android devices here: reader scrolling and cover
+             grids stutter, and switching between the anime and manga tabs is
+             slow. Skia restores the pre-v8.0 smoothness. iOS is unaffected and
+             keeps Impeller. -->
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableImpeller"
+            android:value="false" />
     </application>
 </manifest>

--- a/lib/modules/calendar/widgets/upcoming_item.dart
+++ b/lib/modules/calendar/widgets/upcoming_item.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/models/manga.dart';
-import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
+import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/constant.dart';
 import 'package:mangayomi/utils/headers.dart';
 
@@ -65,7 +65,7 @@ class UpcomingItem extends ConsumerWidget {
     if (manga.customCoverImage != null) {
       return MemoryImage(manga.customCoverImage as Uint8List);
     }
-    return CustomExtendedNetworkImageProvider(
+    return coverProvider(
       toImgUrl(manga.customCoverFromTracker ?? manga.imageUrl ?? ''),
       headers: ref.watch(
         headersProvider(

--- a/lib/modules/manga/detail/widgets/tracker_search_widget.dart
+++ b/lib/modules/manga/detail/widgets/tracker_search_widget.dart
@@ -5,7 +5,7 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/track.dart';
 import 'package:mangayomi/models/track_search.dart';
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
-import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
+import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/modules/widgets/error_text.dart';
 import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
@@ -128,7 +128,7 @@ class _TrackerWidgetSearchState extends ConsumerState<TrackerWidgetSearch> {
                                             width: 80,
                                             fit: BoxFit.cover,
                                             image:
-                                                CustomExtendedNetworkImageProvider(
+                                                coverProvider(
                                                   tracks![index].coverUrl!,
                                                 ),
                                           ),

--- a/lib/modules/tracker_library/tracker_item_card.dart
+++ b/lib/modules/tracker_library/tracker_item_card.dart
@@ -6,7 +6,6 @@ import 'package:mangayomi/l10n/generated/app_localizations.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/track_search.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/readmore.dart';
-import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/constant.dart';
@@ -246,7 +245,7 @@ class TrackerItemCard extends StatelessWidget {
   }
 
   Widget _coverCard() {
-    final imageProvider = CustomExtendedNetworkImageProvider(
+    final imageProvider = coverProvider(
       toImgUrl(track.coverUrl ?? ""),
     );
     return Padding(

--- a/lib/modules/updates/widgets/update_chapter_list_tile_widget.dart
+++ b/lib/modules/updates/widgets/update_chapter_list_tile_widget.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mangayomi/models/chapter.dart';
-import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
+import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/constant.dart';
 import 'package:mangayomi/modules/manga/download/download_page_widget.dart';
 import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
@@ -34,7 +34,7 @@ class UpdateChapterListTileWidget extends ConsumerWidget {
               image: manga.customCoverImage != null
                   ? MemoryImage(manga.customCoverImage as Uint8List)
                         as ImageProvider
-                  : CustomExtendedNetworkImageProvider(
+                  : coverProvider(
                       toImgUrl(manga.customCoverFromTracker ?? manga.imageUrl!),
                       headers: ref.watch(
                         headersProvider(
@@ -149,7 +149,7 @@ class UpdateChapterListTileWidget extends ConsumerWidget {
                                           manga.customCoverImage as Uint8List,
                                         )
                                         as ImageProvider
-                                  : CustomExtendedNetworkImageProvider(
+                                  : coverProvider(
                                       toImgUrl(
                                         manga.customCoverFromTracker ??
                                             manga.imageUrl!,


### PR DESCRIPTION
Two changes that together fix the app-wide performance regression introduced in v8.0 on Android. Both are low risk and reversible, and neither touches iOS.

## 1. Fall back to the Skia renderer on Android
When the native image decoder landed in v8.0 it bumped the Flutter version, which flipped Android's default renderer to Impeller. On many Android devices that janks app-wide: reader scrolling and cover grids stutter, and switching between the anime and manga tabs is noticeably slow. Setting `io.flutter.embedding.android.EnableImpeller=false` restores the pre-v8.0 smoothness. iOS keeps Impeller (it was always smooth there). One meta-data line in AndroidManifest.xml, trivially reversible if Impeller improves on Android later.

## 2. Resample cover thumbnails
Cover thumbnails were decoding at full source resolution and blowing up the image cache. Covers in the updates feed, calendar and tracker now decode through a resizing provider sized to their display box. Hero covers and reader pages are left at full resolution.

## Testing
Tested on an Android TV device: with the Skia fallback, tab navigation and cover grids are smooth again. TV does not exercise the reader scroll path, so the reader side is a best guess for now: the same renderer change should also fix the reader and tab jank reported on phones, but that still needs verification on an actual Android phone build. Phone testers welcome. iOS and desktop are untouched.
