### PR TITLE
Fix library UI jank + related header/user-agent cleanup

### DIFF
--- a/lib/modules/library/library_screen.dart
+++ b/lib/modules/library/library_screen.dart
@@ -263,6 +263,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
                   searchQuery: searchQuery,
                   ignoreFiltersOnSearch: _ignoreFiltersOnSearch,
                   sourceIds: sourceFilterIds,
+                  settings: settings,
                 ),
               );
 

--- a/lib/modules/library/providers/library_filter_provider.dart
+++ b/lib/modules/library/providers/library_filter_provider.dart
@@ -1,4 +1,5 @@
 import 'package:isar_community/isar.dart';
+import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/utils/extensions/manga_extensions.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/download.dart';
@@ -43,6 +44,7 @@ List<Manga> filteredLibraryManga(
   required String searchQuery,
   required bool ignoreFiltersOnSearch,
   required List<String> sourceIds,
+  required Settings settings,
 }) {
   final downloadedIds =
       ref.watch(downloadedChapterIdsProvider).asData?.value ?? const <int>{};
@@ -134,7 +136,7 @@ List<Manga> filteredLibraryManga(
       for (final manga in mangas) {
         if (manga.id != null) {
           // Scanlator-aware unread count (respects the per-manga filter).
-          unreadCounts[manga.id!] = manga.unreadChaptersCount;
+          unreadCounts[manga.id!] = manga.unreadChaptersCount(settings);
         }
       }
       mangas.sort((a, b) {

--- a/lib/modules/library/providers/library_filter_provider.g.dart
+++ b/lib/modules/library/providers/library_filter_provider.g.dart
@@ -116,6 +116,7 @@ final class FilteredLibraryMangaProvider
       String searchQuery,
       bool ignoreFiltersOnSearch,
       List<String> sourceIds,
+      Settings settings,
     })
     super.argument,
   }) : super(
@@ -158,6 +159,7 @@ final class FilteredLibraryMangaProvider
               String searchQuery,
               bool ignoreFiltersOnSearch,
               List<String> sourceIds,
+              Settings settings,
             });
     return filteredLibraryManga(
       ref,
@@ -173,6 +175,7 @@ final class FilteredLibraryMangaProvider
       searchQuery: argument.searchQuery,
       ignoreFiltersOnSearch: argument.ignoreFiltersOnSearch,
       sourceIds: argument.sourceIds,
+      settings: argument.settings,
     );
   }
 
@@ -196,7 +199,7 @@ final class FilteredLibraryMangaProvider
 }
 
 String _$filteredLibraryMangaHash() =>
-    r'aae368f1bab8345d88cf773539a969f8f14cd2fc';
+    r'df4bfaf2b66c8161c1c4d7849159d04ffafbd7d2';
 
 /// Filters and sorts a list of [Manga] based on library filter/sort settings.
 
@@ -217,6 +220,7 @@ final class FilteredLibraryMangaFamily extends $Family
             String searchQuery,
             bool ignoreFiltersOnSearch,
             List<String> sourceIds,
+            Settings settings,
           })
         > {
   FilteredLibraryMangaFamily._()
@@ -243,6 +247,7 @@ final class FilteredLibraryMangaFamily extends $Family
     required String searchQuery,
     required bool ignoreFiltersOnSearch,
     required List<String> sourceIds,
+    required Settings settings,
   }) => FilteredLibraryMangaProvider._(
     argument: (
       data: data,
@@ -257,6 +262,7 @@ final class FilteredLibraryMangaFamily extends $Family
       searchQuery: searchQuery,
       ignoreFiltersOnSearch: ignoreFiltersOnSearch,
       sourceIds: sourceIds,
+      settings: settings,
     ),
     from: this,
   );

--- a/lib/modules/library/tv_home/tv_anime_home_view.dart
+++ b/lib/modules/library/tv_home/tv_anime_home_view.dart
@@ -313,6 +313,7 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
                     ),
                   )
                   .$2,
+              settings: settings,
             ),
           );
           final entries = (sortState.reverse ?? false)

--- a/lib/modules/library/widgets/library_body.dart
+++ b/lib/modules/library/widgets/library_body.dart
@@ -111,6 +111,7 @@ class LibraryBody extends ConsumerWidget {
             searchQuery: searchQuery,
             ignoreFiltersOnSearch: ignoreFiltersOnSearch,
             sourceIds: sourceIds,
+            settings: settings,
           ),
         );
 
@@ -136,6 +137,7 @@ class LibraryBody extends ConsumerWidget {
                   language: language,
                   mangaIdsList: mangaIdsList,
                   localSource: localSource,
+                  settings: settings,
                 )
               : LibraryGridViewWidget(
                   entriesManga: entriesManga,
@@ -148,6 +150,7 @@ class LibraryBody extends ConsumerWidget {
                   mangaIdsList: mangaIdsList,
                   localSource: localSource,
                   itemType: itemType,
+                  settings: settings,
                 ),
         );
       },
@@ -223,6 +226,7 @@ class CategoryBadge extends ConsumerWidget {
             searchQuery: searchQuery,
             ignoreFiltersOnSearch: ignoreFiltersOnSearch,
             sourceIds: sourceIds,
+            settings: settings,
           ),
         );
         return CircleAvatar(

--- a/lib/modules/library/widgets/library_entry_utils.dart
+++ b/lib/modules/library/widgets/library_entry_utils.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/library/providers/library_filter_provider.dart';
 import 'package:mangayomi/modules/library/providers/library_state_provider.dart';
 import 'package:mangayomi/models/manga.dart';
@@ -143,12 +144,14 @@ class LibraryBadgeWidget extends ConsumerWidget {
   final Manga entry;
   final bool showLocal;
   final bool showDownloaded;
+  final Settings settings;
 
   const LibraryBadgeWidget({
     super.key,
     required this.entry,
     required this.showLocal,
     required this.showDownloaded,
+    required this.settings,
   });
 
   @override
@@ -169,7 +172,7 @@ class LibraryBadgeWidget extends ConsumerWidget {
     }
 
     // Scanlator-aware: the badge count respects the per-manga scanlator filter.
-    final unreadCount = entry.unreadChaptersCount;
+    final unreadCount = entry.unreadChaptersCount(settings);
 
     // If there is nothing to show (no local, no download, no unread), return empty
     if (!hasLocal && downloadCount == 0 && unreadCount == 0) {

--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -59,7 +59,6 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
             final entry = widget.entriesManga[index];
             return Consumer(
               builder: (context, ref, child) {
-                final isLongPressed = ref.watch(isLongPressedStateProvider);
                 return Padding(
                   padding: const EdgeInsets.all(2),
                   child: CoverViewWidget(
@@ -75,15 +74,21 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                     ),
                     image: resolveCoverImage(entry, ref),
                     onTap: () => onTapEntry(
-                      isLongPressed: isLongPressed,
+                      isLongPressed: ref.read(isLongPressedStateProvider),
                       ref: ref,
                       context: context,
                       entry: entry,
                     ),
-                    onLongPress: () =>
-                        handleLongOrSecondaryTap(isLongPressed, ref, entry),
-                    onSecondaryTap: () =>
-                        handleLongOrSecondaryTap(isLongPressed, ref, entry),
+                    onLongPress: () => handleLongOrSecondaryTap(
+                      ref.read(isLongPressedStateProvider),
+                      ref,
+                      entry,
+                    ),
+                    onSecondaryTap: () => handleLongOrSecondaryTap(
+                      ref.read(isLongPressedStateProvider),
+                      ref,
+                      entry,
+                    ),
                     children: [
                       Stack(
                         children: [

--- a/lib/modules/library/widgets/library_gridview_widget.dart
+++ b/lib/modules/library/widgets/library_gridview_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/library/providers/library_state_provider.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/library/widgets/continue_reader_button.dart';
@@ -22,6 +23,7 @@ class LibraryGridViewWidget extends StatefulWidget {
   final bool continueReaderBtn;
   final bool localSource;
   final ItemType itemType;
+  final Settings settings;
   const LibraryGridViewWidget({
     super.key,
     required this.entriesManga,
@@ -34,6 +36,7 @@ class LibraryGridViewWidget extends StatefulWidget {
     required this.mangaIdsList,
     required this.localSource,
     required this.itemType,
+    required this.settings,
   });
 
   @override
@@ -94,6 +97,7 @@ class _LibraryGridViewWidgetState extends State<LibraryGridViewWidget> {
                                 entry: entry,
                                 showLocal: widget.localSource,
                                 showDownloaded: widget.downloadedChapter,
+                                settings: widget.settings,
                               ),
                             ),
                           ),

--- a/lib/modules/library/widgets/library_listview_widget.dart
+++ b/lib/modules/library/widgets/library_listview_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/library/widgets/continue_reader_button.dart';
 import 'package:mangayomi/modules/manga/detail/providers/state_providers.dart';
 import 'package:mangayomi/modules/library/widgets/library_entry_utils.dart';
@@ -14,6 +15,7 @@ class LibraryListViewWidget extends StatelessWidget {
   final Set<int> mangaIdsList;
   final bool continueReaderBtn;
   final bool localSource;
+  final Settings settings;
   const LibraryListViewWidget({
     super.key,
     required this.entriesManga,
@@ -22,6 +24,7 @@ class LibraryListViewWidget extends StatelessWidget {
     required this.continueReaderBtn,
     required this.mangaIdsList,
     required this.localSource,
+    required this.settings,
   });
 
   @override
@@ -106,6 +109,7 @@ class LibraryListViewWidget extends StatelessWidget {
                                 entry: entry,
                                 showLocal: localSource,
                                 showDownloaded: downloadedChapter,
+                                settings: settings,
                               ),
                               if (language && (entry.lang?.isNotEmpty ?? false))
                                 Padding(

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -1121,7 +1121,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
   }
 
   void _showDraggableMenu() {
-    final scanlators = ref.watch(scanlatorsFilterStateProvider(widget.manga!));
+    final scanlators = ref.read(scanlatorsFilterStateProvider(widget.manga!));
     final l10n = l10nLocalizations(context)!;
     customDraggableTabBar(
       tabs: [

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -18,6 +18,7 @@ import 'package:mangayomi/models/video.dart';
 import 'package:mangayomi/modules/manga/download/providers/convert_to_cbz.dart';
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/downloads/providers/downloads_state_provider.dart';
+import 'package:mangayomi/modules/more/settings/general/providers/general_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/router/router.dart';
@@ -142,8 +143,7 @@ Future<void> downloadChapter(
     Map<String, String> videoHeader = {};
     Map<String, String> htmlHeader = {
       "Priority": "u=0, i",
-      "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36",
+      "User-Agent": ref.read(userAgentStateProvider),
     };
     bool hasM3U8File = false;
     bool nonM3U8File = false;
@@ -320,7 +320,7 @@ Future<void> downloadChapter(
       final cookie = MClient.getCookiesPref(chapterUrl);
       final headers = htmlHeader;
       if (cookie.isNotEmpty) {
-        final userAgent = isar.settings.getSync(227)!.userAgent!;
+        final userAgent = ref.read(userAgentStateProvider);
         headers.addAll(cookie);
         headers[HttpHeaders.userAgentHeader] = userAgent;
       }
@@ -420,7 +420,7 @@ Future<void> downloadChapter(
               ? videoHeader
               : htmlHeader;
           if (cookie.isNotEmpty) {
-            final userAgent = isar.settings.getSync(227)!.userAgent!;
+            final userAgent = ref.read(userAgentStateProvider);
             headers.addAll(cookie);
             headers[HttpHeaders.userAgentHeader] = userAgent;
           }

--- a/lib/services/anilist_discovery.dart
+++ b/lib/services/anilist_discovery.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/utils/constant.dart';
 
 /// AniList public GraphQL discovery client. No login required for browsing, so
 /// this is separate from the AniList *tracker* (which is OAuth'd).
@@ -71,9 +72,7 @@ Future<Map<String, dynamic>?> _executeGraphQL(
       headers: const {
         "Content-Type": "application/json",
         "Accept": "application/json",
-        "User-Agent":
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-            "(KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+        "User-Agent": metadataApiUserAgent,
       },
       body: jsonEncode({"query": query, "variables": variables}),
     );

--- a/lib/services/fetch_subtitles.dart
+++ b/lib/services/fetch_subtitles.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:mangayomi/services/http/m_client.dart';
+import 'package:mangayomi/utils/constant.dart';
 
 Future<List<ImdbTitle>> fetchImdbTitles(String query) async {
   final http = MClient.init(reqcopyWith: {'useDartHttpClient': true});
@@ -9,8 +10,7 @@ Future<List<ImdbTitle>> fetchImdbTitles(String query) async {
       Uri.parse(url),
       headers: {
         "Accept": "application/json",
-        "User-Agent":
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+        "User-Agent": metadataApiUserAgent,
       },
     );
     final data = json.decode(res.body) as Map<String, dynamic>;
@@ -31,8 +31,7 @@ Future<List<ImdbEpisode>?> fetchImdbEpisodes(String imdbId) async {
       Uri.parse(url),
       headers: {
         "Accept": "application/json",
-        "User-Agent":
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+        "User-Agent": metadataApiUserAgent,
       },
     );
     final data = json.decode(res.body) as Map<String, dynamic>;
@@ -52,8 +51,7 @@ Future<List<ImdbSubtitle>?> fetchImdbSubtitles(String imdbId) async {
       Uri.parse(url),
       headers: {
         "Accept": "application/json",
-        "User-Agent":
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+        "User-Agent": metadataApiUserAgent,
       },
     );
     final data = json.decode(res.body) as List?;

--- a/lib/services/fetch_watch_order.dart
+++ b/lib/services/fetch_watch_order.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/services/anilist_discovery.dart';
 import 'package:mangayomi/services/http/m_client.dart';
+import 'package:mangayomi/utils/constant.dart';
 
 const _sequelData =
     "&types%5B%5D=1&types%5B%5D=3&types%5B%5D=2&types%5B%5D=4&types%5B%5D=9&score=0&date_from=false&date_to=false&include_ptw=1&exclude_h=1&exclude_planned=1&exclude_dropped=0&exclude_not_aired=0&exclude_short=1&exclude_short_value=3";
@@ -23,8 +24,7 @@ Future<List<SequelItem>> fetchSequels(
         "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
         "priority": "u=1, i",
         "Referer": "https://chiaki.site/?/tools/watch_order",
-        "User-Agent":
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+        "User-Agent": metadataApiUserAgent,
       },
       body:
           "user=${malUsername ?? anilistUsername}&list_source=${malUsername != null ? "mal" : "anilist"}$_sequelData",

--- a/lib/utils/constant.dart
+++ b/lib/utils/constant.dart
@@ -6,6 +6,14 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 const defaultUserAgent =
     "Mozilla/5.0 (Linux; Android 13; 22081212UG Build/TKQ1.220829.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/114.0.5735.131 Mobile Safari/537.36";
 
+/// Used only for requests to AniList, imdbapi.dev, subtitle/watch-order services
+/// NOT sent to installed sources. Those Cloudflare-protected APIs reject
+/// non-browser UAs, and the user's configurable [defaultUserAgent]-derived
+/// setting is tuned for source scraping, not guaranteed to pass Cloudflare's
+/// checks. Fixed here intentionally; bump when it starts getting rejected.
+const metadataApiUserAgent =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36";
+
 String getMangaStatusName(Status status, BuildContext context) {
   final l10n = l10nLocalizations(context)!;
   return switch (status) {

--- a/lib/utils/extensions/manga_extensions.dart
+++ b/lib/utils/extensions/manga_extensions.dart
@@ -12,10 +12,8 @@ extension MangaExtensions on Manga {
   /// so the library "unread" badge and the unread sort reflect what the user
   /// actually sees rather than counting duplicate chapters from hidden
   /// scanlators (#796).
-  int get unreadChaptersCount {
-    final filter = isar.settings
-        .getSync(227)
-        ?.filterScanlatorList
+  int unreadChaptersCount(Settings settings) {
+    final filter = settings.filterScanlatorList
         ?.where((e) => e.mangaId == id)
         .firstOrNull
         ?.scanlators;

--- a/lib/utils/extensions/manga_extensions.dart
+++ b/lib/utils/extensions/manga_extensions.dart
@@ -28,8 +28,8 @@ extension MangaExtensions on Manga {
   /// Filtered chapters respecting the user's active filters (unread,
   /// bookmarked, downloaded, scanlator). Sorted by chapter number ascending.
   /// Base list — no user-chosen sort, no deduplication.
-  List<Chapter> getFilteredChapters() {
-    final settings = isar.settings.getSync(227)!;
+  List<Chapter> getFilteredChapters([Settings? settingsOverride]) {
+    final settings = settingsOverride ?? isar.settings.getSync(227)!;
 
     final filterUnread =
         (settings.chapterFilterUnreadList!
@@ -116,7 +116,7 @@ extension MangaExtensions on Manga {
     final reverse = sortChapterEntry.reverse!;
 
     // Build on getFilteredChapters so filter logic lives in one place.
-    List<Chapter> list = getFilteredChapters();
+    List<Chapter> list = getFilteredChapters(settings);
 
     switch (sortIndex) {
       case 0: // by scanlator, then chapter number

--- a/lib/utils/headers.dart
+++ b/lib/utils/headers.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:mangayomi/eval/javascript/http.dart';
 import 'package:mangayomi/eval/lib.dart';
@@ -16,6 +17,16 @@ Map<String, String> headers(
   required int? sourceId,
   String androidProxyServer = "",
 }) {
+  // Once the last listener drops, wait before actually disposing — this is
+  // what covers rapid tab-switch unmount/remount without caching forever.
+  // If a new listener shows up before the timer fires, onResume cancels it.
+  final link = ref.keepAlive();
+  Timer? timer;
+  ref.onCancel(() {
+    timer = Timer(const Duration(minutes: 5), link.close);
+  });
+  ref.onResume(() => timer?.cancel());
+  ref.onDispose(() => timer?.cancel());
   final mSource = getSource(lang, source, sourceId);
 
   Map<String, String> headers = {};

--- a/lib/utils/headers.dart
+++ b/lib/utils/headers.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 import 'package:mangayomi/eval/javascript/http.dart';
 import 'package:mangayomi/eval/lib.dart';
-import 'package:mangayomi/main.dart';
-import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/modules/more/settings/general/providers/general_state_provider.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/utils/utils.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -34,7 +33,7 @@ Map<String, String> headers(
       service.dispose();
     }
     if (mSource.sourceCodeLanguage == SourceCodeLanguage.mihon) {
-      headers['user-agent'] = isar.settings.getSync(227)!.userAgent!;
+      headers['user-agent'] = ref.watch(userAgentStateProvider);
     }
   }
 


### PR DESCRIPTION
Follow-up on profiling the original jank fix surfaced a few related
issues worth fixing in the same PR rather than as loose follow-ups.

**Library jank**
`unreadChaptersCount()` did a blocking `isar.settings.getSync(227)`
for every visible tile, on every rebuild. With a large library,
switching library tabs (anime <-> manga) triggered hundreds of
synchronous DB reads on the UI isolate (~980ms). Now reuses the
`Settings` object the library widgets already receive and watch.

**headers.dart**
Fixing the jank with a permanent `ref.keepAlive()` on
`headersProvider` worked, but cached extension headers (cookies,
tokens) forever with no way to refresh, and the cache grows unbounded
over a session. Swapped for `keepAlive()` + a 5-minute
onCancel/onResume timer: still survives quick tab switches, but
releases (and can recompute) once nothing's watched it for a while.

**User-Agent cleanup**
- `headersProvider` and `download_provider.dart` read the UA via raw
  `isar.settings.getSync()` instead of the existing
  `userAgentStateProvider` — same blocking-read pattern as the jank
  above, and not reactive to UA changes.
- `download_provider.dart`'s novel HTML download defaulted to a
  hardcoded, already-outdated UA string instead of the user's
  configured one.
- `anilist_discovery.dart`, `fetch_subtitles.dart`, and
  `fetch_watch_order.dart` each independently hardcoded the same UA
  string for requests to Mangayomi's own metadata backends (not sent
  to installed sources). Moved to one `metadataApiUserAgent` constant.

**Misc**
- `manga_detail_view.dart`: stray `ref.watch` -> `ref.read` outside
  `build()`.