### PR TITLE
Revert ChapterCount badge style

### DIFF
--- a/lib/modules/library/widgets/library_entry_utils.dart
+++ b/lib/modules/library/widgets/library_entry_utils.dart
@@ -193,11 +193,7 @@ class LibraryBadgeWidget extends ConsumerWidget {
               padding: const EdgeInsets.only(left: 3),
               child: Text(
                 unreadCount.toString(),
-                style: TextStyle(
-                  color: context.dynamicBlackWhiteColor,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 10,
-                ),
+                style: TextStyle(color: context.dynamicBlackWhiteColor),
               ),
             ),
         ],


### PR DESCRIPTION
This reverts the badge style choice introduced in commit 6e0d0022e8903c20227f08f7969dd795d4da62f2

The bold and small font is hard to read and subjectively ugly. Now it looks like before that commit.