### PR TITLE
ci: pin Flutter + Rust codegen for reproducible Android builds (Gradle 8.14, drop Jetifier)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,11 @@
 org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
+# Jetifier rewrites legacy com.android.support artifacts to AndroidX. This app
+# is fully AndroidX and depends on no support-library artifact, so Jetifier only
+# adds a per-jar transform step that has no work to do. Dropping it removes that
+# step (which was intermittently OOMing on CI while transforming Flutter's
+# embedding jar) and speeds up every build.
+android.enableJetifier=false
 
 # Optimizations for build performance
 org.gradle.parallel=true


### PR DESCRIPTION
## Problem

CI has started failing on unrelated PRs with:

```
Error: Your project's Gradle version (8.13.0) is lower than
Flutter's minimum supported version of 8.14.0.
```

No code caused this. The workflow pins nothing: both jobs use `subosito/flutter-action` with a bare `channel: stable`, and the Rust codegen is installed with `cargo install flutter_rust_bridge_codegen` (latest). So every run floats to whatever is newest at that moment. A new `stable` Flutter raised its minimum Gradle to 8.14, and every fresh run broke, while older cached runs still pass. That is the same "green yesterday, red today, no diff" flakiness in both directions.

## Fix: pin the moving parts, then align the build

1. **Pin Flutter to 3.44.6** (both jobs). This is the version the app is developed against (matches `pubspec` `sdk: ^3.12.2` / Dart 3.12.2), so CI is now reproducible. Bump it deliberately, not implicitly on every Flutter release.
2. **Pin `flutter_rust_bridge_codegen` to 2.12.0** to match the `flutter_rust_bridge` runtime in `pubspec.lock`. The codegen and runtime must be the same version; tracking latest can generate code incompatible with the pinned crate.
3. **Bump the Gradle wrapper to 8.14.** Satisfies Flutter's current minimum and is forward-safe, so a later Flutter pin bump does not need a Gradle change. AGP 8.12.1 is compatible with Gradle 8.14.
4. **Disable Jetifier** (`android.enableJetifier=false`). The app is fully AndroidX and depends on no `com.android.support` artifact, so Jetifier's per-jar transform does nothing except occasionally OOM on CI while processing Flutter's embedding jar. The only `android.support.*` reference is the `FILE_PROVIDER_PATHS` meta-data key, which AndroidX's `FileProvider` reads by that name (a string, not an artifact).

## Result

A green Android build here proves the pinned combination (Flutter 3.44.6 + codegen 2.12.0 + Gradle 8.14 + AGP 8.12.1) builds, and that CI no longer depends on whatever `stable` happens to be that day.
