### PR TITLE
ci: pin Flutter + Rust codegen across all jobs, bump Gradle to 8.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pin the Flutter version so CI is reproducible. Tracking bare
+          # `stable` means a new release can break the build with no code
+          # change (e.g. a raised minimum Gradle version). Bump this
+          # deliberately.
+          flutter-version: 3.44.6
           cache: true
 
       - name: Install dependencies
@@ -45,6 +50,11 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pin the Flutter version so CI is reproducible. Tracking bare
+          # `stable` means a new release can break the build with no code
+          # change (e.g. a raised minimum Gradle version). Bump this
+          # deliberately.
+          flutter-version: 3.44.6
           cache: true
 
       - name: Setup Rust toolchain
@@ -65,7 +75,10 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Install flutter_rust_bridge_codegen
-        run: cargo install 'flutter_rust_bridge_codegen'
+        # Pin to the flutter_rust_bridge runtime version in pubspec.lock. The
+        # codegen and runtime must match, so tracking latest can generate code
+        # incompatible with the pinned crate.
+        run: cargo install 'flutter_rust_bridge_codegen' --version 2.12.0
 
       - name: Install dependencies
         run: flutter pub get
@@ -130,13 +143,16 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pin the Flutter version so CI is reproducible (see the analyze job).
+          flutter-version: 3.44.6
           cache: true
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install flutter_rust_bridge_codegen
-        run: cargo install 'flutter_rust_bridge_codegen'
+        # Pin to the flutter_rust_bridge runtime version in pubspec.lock.
+        run: cargo install 'flutter_rust_bridge_codegen' --version 2.12.0
 
       - name: Install dependencies
         run: flutter pub get

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip


### PR DESCRIPTION
Follow-up to #841. That PR merged with only the Jetifier cleanup; the version pins and the Gradle bump did not land, so the actual cause of the CI failures is still on `main`.

## Problem (still present on main)

CI pins nothing: every `Setup Flutter` step uses a bare `channel: stable`, and both `flutter_rust_bridge_codegen` installs use `cargo install` at latest. So each run floats to whatever is newest. A recent `stable` Flutter raised its minimum Gradle to 8.14, and the wrapper is 8.13, so fresh runs fail with:

```
Error: Your project's Gradle version (8.13.0) is lower than
Flutter's minimum supported version of 8.14.0.
```

This is not caused by any code change, and it hits every PR and `main` itself.

## Fix

1. **Pin Flutter to 3.44.6** in all three jobs (analyze, Android, Linux). This is the version the app is built against (Dart 3.12.2, matches `pubspec`), verified locally with `flutter analyze`. Bump it deliberately rather than tracking `stable` implicitly.
2. **Pin `flutter_rust_bridge_codegen` to 2.12.0** in both installs, to match the `flutter_rust_bridge` runtime in `pubspec.lock`. The codegen and runtime must be the same version.
3. **Bump the Gradle wrapper to 8.14** to satisfy Flutter's current minimum. AGP 8.12.1 is compatible with Gradle 8.14.

Together these make the build reproducible: CI no longer breaks when `stable` moves.
