### PR TITLE
remove orphaned obsolete extensions from list

### DIFF
--- a/lib/modules/browse/extension/extension_detail.dart
+++ b/lib/modules/browse/extension/extension_detail.dart
@@ -289,7 +289,8 @@ class _ExtensionDetailState extends ConsumerState<ExtensionDetail> {
                                         .idProperty()
                                         .findAllSync();
                                     isar.writeTxnSync(() {
-                                      if (source.isObsolete ?? false) {
+                                      if ((source.isObsolete ?? false) ||
+                                          (source.isLocal ?? false)) {
                                         isar.sources.deleteSync(
                                           widget.source.id!,
                                         );

--- a/lib/modules/browse/extension/widgets/extension_list_tile_widget.dart
+++ b/lib/modules/browse/extension/widgets/extension_list_tile_widget.dart
@@ -123,7 +123,8 @@ class _ExtensionListTileWidgetState
                         .idProperty()
                         .findAllSync();
                     isar.writeTxnSync(() {
-                      if (widget.source.isObsolete ?? false) {
+                      if ((widget.source.isObsolete ?? false) ||
+                          (widget.source.isLocal ?? false)) {
                         isar.sources.deleteSync(widget.source.id!);
                         ref
                             .read(synchingProvider(syncId: 1).notifier)

--- a/lib/modules/main_view/providers/migration.dart
+++ b/lib/modules/main_view/providers/migration.dart
@@ -1,15 +1,33 @@
-// import 'package:isar_community/isar.dart';
-// import 'package:mangayomi/main.dart';
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart';
 // import 'package:mangayomi/models/category.dart';
 // import 'package:mangayomi/models/history.dart';
 // import 'package:mangayomi/models/manga.dart';
-// import 'package:mangayomi/models/source.dart';
+import 'package:mangayomi/models/source.dart';
 // import 'package:mangayomi/models/track.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'migration.g.dart';
 
 @riverpod
 Future<void> migration(Ref ref) async {
+  // One-time cleanup: locally-created extensions that were uninstalled
+  // before the fix that hard-deletes them on uninstall are stuck as dead
+  // rows (isAdded: false, sourceCode: "", no repo to reinstall from). Prune
+  // any that are still lingering.
+  final orphanedLocalIds = isar.sources
+      .filter()
+      .idIsNotNull()
+      .isLocalEqualTo(true)
+      .isAddedEqualTo(false)
+      .idProperty()
+      .findAllSync();
+
+  if (orphanedLocalIds.isNotEmpty) {
+    isar.writeTxnSync(() {
+      isar.sources.deleteAllSync(orphanedLocalIds);
+    });
+  }
+
   // final mangas = isar.mangas
   //     .filter()
   //     .idIsNotNull()

--- a/lib/services/fetch_sources_list.dart
+++ b/lib/services/fetch_sources_list.dart
@@ -259,19 +259,29 @@ Future<void> checkIfSourceIsObsolete(
   if (sourceIds.isEmpty) return;
 
   final toUpdate = <Source>[];
+  final toDelete = <int>[];
   for (var source in sources) {
     final isNowObsolete =
         !sourceIds.contains(source.id) && source.repo?.jsonUrl == repo.jsonUrl;
 
+    if (!(source.isAdded ?? false) && isNowObsolete) {
+      // Not installed and gone from the repo: nothing to install, so
+      // remove the dead row instead of leaving it in the browse list.
+      toDelete.add(source.id!);
+      continue;
+    }
     if (source.isObsolete != isNowObsolete) {
       source.isObsolete = isNowObsolete;
       source.updatedAt = DateTime.now().millisecondsSinceEpoch;
       toUpdate.add(source);
     }
   }
-  if (toUpdate.isEmpty) return;
-
-  await isar.writeTxn(() => isar.sources.putAll(toUpdate));
+  if (toUpdate.isNotEmpty) {
+    await isar.writeTxn(() => isar.sources.putAll(toUpdate));
+  }
+  if (toDelete.isNotEmpty) {
+    await isar.writeTxn(() => isar.sources.deleteAll(toDelete));
+  }
 }
 
 int compareVersions(String version1, String version2) {


### PR DESCRIPTION
Extensions that were removed from a repo but never installed used to stick around in the browse list forever, showing an OBSOLETE badge with a non-functional download button. `checkIfSourceIsObsolete` now deletes those rows instead of just flagging them, since nothing references an extension that was never installed. Installed sources still get flagged obsolete as before, so uninstall keeps working the same way.

Fixes this:

<img width="1280" height="752" alt="image" src="https://github.com/user-attachments/assets/c655691b-7be5-40d5-9c14-d92bc8e279f8" />
