### PR TITLE
Better performance in code editor

### DIFF
--- a/lib/modules/browse/extension/edit_code.dart
+++ b/lib/modules/browse/extension/edit_code.dart
@@ -40,6 +40,16 @@ class _CodeEditorPageState extends ConsumerState<CodeEditorPage> {
       ? null
       : isar.sources.getSync(widget.sourceId!);
   final CodeLineEditingController _controller = CodeLineEditingController();
+  Timer? _saveDebounceTimer;
+
+  void _persistSourceCodeNow() {
+    if (source == null) return;
+    isar.writeTxnSync(() {
+      isar.sources.putSync(
+        source!..updatedAt = DateTime.now().millisecondsSinceEpoch,
+      );
+    });
+  }
 
   List<(String, int)> _getServices(BuildContext context) => [
     ("getPopular", 0),
@@ -177,6 +187,10 @@ class _CodeEditorPageState extends ConsumerState<CodeEditorPage> {
 
   @override
   void dispose() {
+    if (_saveDebounceTimer?.isActive ?? false) {
+      _saveDebounceTimer!.cancel();
+      _persistSourceCodeNow();
+    }
     _logSubscription.cancel();
     _logsNotifier.value.clear();
     _scrollController.dispose();
@@ -276,13 +290,11 @@ class _CodeEditorPageState extends ConsumerState<CodeEditorPage> {
                         onChanged: (_) {
                           source?.sourceCode = _controller.text;
                           if (source != null && context.mounted) {
-                            isar.writeTxnSync(() {
-                              isar.sources.putSync(
-                                source!
-                                  ..updatedAt =
-                                      DateTime.now().millisecondsSinceEpoch,
-                              );
-                            });
+                            _saveDebounceTimer?.cancel();
+                            _saveDebounceTimer = Timer(
+                              const Duration(milliseconds: 1500),
+                              _persistSourceCodeNow,
+                            );
                           }
                         },
                         wordWrap: false,


### PR DESCRIPTION
Before, every keystroke was saving to the DB.
Now there is a debounce timer, so it only saves when the user is pausing for 1.5 seconds. Until then, the keystrokes are saved to memory.
Also saves on exit, in dispose.