### PR TITLE
fix: show a real error state when startup fails

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -912,5 +912,7 @@
   "saved_searches": "Saved searches",
   "enter_search_to_save_first": "Enter a search to save first",
   "no_saved_searches": "No saved searches for this source yet.\nRun a search, then pick \"Save search\".",
-  "source": "Source"
+  "source": "Source",
+  "something_went_wrong": "Something went wrong",
+  "startup_failed": "Mangayomi could not finish starting up"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -4612,6 +4612,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Source'**
   String get source;
+
+  /// No description provided for @something_went_wrong.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong'**
+  String get something_went_wrong;
+
+  /// No description provided for @startup_failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Mangayomi could not finish starting up'**
+  String get startup_failed;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2495,4 +2494,10 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2495,4 +2494,10 @@ class AppLocalizationsAs extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2510,4 +2509,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2488,4 +2487,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2520,6 +2519,12 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2520,4 +2519,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2493,4 +2492,10 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2499,4 +2498,10 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2521,4 +2520,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2456,4 +2455,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get source => 'ソース';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2515,6 +2514,12 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2530,4 +2529,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2490,4 +2489,10 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2502,4 +2501,10 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2418,4 +2417,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get source => 'Source';
+
+  @override
+  String get something_went_wrong => 'Something went wrong';
+
+  @override
+  String get startup_failed => 'Mangayomi could not finish starting up';
 }

--- a/lib/modules/main_view/main_screen.dart
+++ b/lib/modules/main_view/main_screen.dart
@@ -16,6 +16,7 @@ import 'package:mangayomi/modules/more/about/providers/download_file_screen.dart
 import 'package:mangayomi/modules/more/providers/downloaded_only_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/sync/providers/sync_providers.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/modules/widgets/loading_icon.dart';
 import 'package:mangayomi/services/fetch_item_sources.dart';
 import 'package:mangayomi/modules/main_view/providers/migration.dart';
@@ -330,7 +331,16 @@ class _MainScreenState extends ConsumerState<MainScreen> {
               );
             },
           ),
-          error: (error, _) => const LoadingIcon(),
+          // A failed migration used to render the loading screen, so the app
+          // sat on a blank splash forever with nothing to act on. Show what
+          // happened and let the user run it again.
+          error: (error, _) => Scaffold(
+            body: ErrorState(
+              message: l10n.startup_failed,
+              detail: error.toString(),
+              onRetry: () => ref.invalidate(migrationProvider),
+            ),
+          ),
           loading: () => const LoadingIcon(),
         );
   }

--- a/lib/modules/widgets/error_state.dart
+++ b/lib/modules/widgets/error_state.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
+
+/// The shared failure state.
+///
+/// Screens used to render a bare `Center(child: Text(error.toString()))`, which
+/// shows the user a stack trace, gives them nothing to do about it and looks
+/// different in every place it appears. Use this instead: a readable line, the
+/// technical cause kept but demoted, and a retry when the caller can offer one.
+///
+/// Every colour here comes from the theme, because the palette is chosen at
+/// runtime and any fixed colour would be wrong on somebody else's scheme.
+class ErrorState extends StatelessWidget {
+  const ErrorState({
+    super.key,
+    this.message,
+    this.detail,
+    this.onRetry,
+    this.compact = false,
+  });
+
+  /// Human readable line. Falls back to a generic message when null.
+  final String? message;
+
+  /// Technical cause, kept for bug reports but visually demoted. Nothing is
+  /// rendered for it when null or empty.
+  final String? detail;
+
+  /// Omitted when the caller has nothing useful to re-run.
+  final VoidCallback? onRetry;
+
+  /// Tightens the padding for use inside a list or a sheet rather than as a
+  /// whole page.
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final detailText = detail?.trim();
+
+    return Center(
+      child: SingleChildScrollView(
+        padding: EdgeInsets.symmetric(
+          horizontal: 24,
+          vertical: compact ? 16 : 32,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: compact ? 32 : 44,
+              color: theme.colorScheme.error,
+            ),
+            SizedBox(height: compact ? 10 : 14),
+            Text(
+              message ?? l10n.something_went_wrong,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            if (detailText != null && detailText.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 520),
+                child: Text(
+                  detailText,
+                  textAlign: TextAlign.center,
+                  maxLines: 4,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: context.textColor.withValues(alpha: 0.7),
+                  ),
+                ),
+              ),
+            ],
+            if (onRetry != null) ...[
+              SizedBox(height: compact ? 14 : 20),
+              FilledButton.tonalIcon(
+                // On a TV there is no pointer, so the only actionable control
+                // on the screen takes focus straight away.
+                autofocus: isTv,
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: Text(l10n.retry),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/widgets/loading_icon.dart
+++ b/lib/modules/widgets/loading_icon.dart
@@ -1,16 +1,23 @@
 import 'package:flutter/material.dart';
 
+/// The full screen shown while the app finishes starting up.
+///
+/// This used to paint a fixed white background with a black icon, which meant a
+/// full screen white flash on every cold start under a dark theme. Both colours
+/// now come from the active scheme, so the splash matches whatever palette the
+/// user picked.
 class LoadingIcon extends StatelessWidget {
   const LoadingIcon({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: theme.scaffoldBackgroundColor,
       body: Center(
         child: Image.asset(
           "assets/app_icons/icon.png",
-          color: Colors.black,
+          color: theme.colorScheme.onSurface,
           fit: BoxFit.cover,
           height: 100,
         ),


### PR DESCRIPTION
`main_screen` rendered `LoadingIcon` for both the loading and the error branch of `migrationProvider`, so a failed migration sat on a blank splash with no message and nothing to act on.

Adds a shared `ErrorState` (message, demoted cause, optional retry) and uses it for the error branch, wired to re-run the migration.

`LoadingIcon` also hardcoded white on black, so it flashed white on every cold start under a dark theme. Both colours now come from the scheme.

Nine screens still hand roll `Center(child: Text(error.toString()))`; they move over in a follow up.

Two new strings in `app_en.arb`, regenerated. `flutter analyze` clean. The failure path is not runtime tested.
