### PR TITLE
refactor: use the shared error state across screens

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -40,6 +40,7 @@ import 'package:mangayomi/modules/more/settings/player/providers/player_audio_st
 import 'package:mangayomi/modules/more/settings/player/providers/player_decoder_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/player/providers/player_state_provider.dart';
 import 'package:mangayomi/modules/widgets/custom_draggable_tabbar.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
@@ -141,7 +142,13 @@ class _AnimePlayerViewState extends riv.ConsumerState<AnimePlayerView> {
             },
           ),
         ),
-        body: Center(child: Text(error.toString())),
+        // The back button above already claims TV focus, so the retry must
+        // not also ask for it; it stays reachable with the d-pad.
+        body: ErrorState(
+          autofocusRetry: false,
+          detail: error.toString(),
+          onRetry: () => ref.invalidate(getVideoListProvider(episode: episode)),
+        ),
       ),
       loading: () {
         return Scaffold(

--- a/lib/modules/browse/global_search/global_search_screen.dart
+++ b/lib/modules/browse/global_search/global_search_screen.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/migrate_screen.dart';
 import 'package:mangayomi/modules/manga/home/manga_home_screen.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/models/source.dart';
@@ -208,7 +209,17 @@ class _SourceSearchScreenState extends ConsumerState<SourceSearchScreen> {
                   : Builder(
                       builder: (context) {
                         if (_errorMessage.isNotEmpty) {
-                          return Center(child: Text(_errorMessage));
+                          return ErrorState(
+                            compact: true,
+                            detail: _errorMessage,
+                            onRetry: () {
+                              setState(() {
+                                _isLoading = true;
+                                _errorMessage = "";
+                              });
+                              _init();
+                            },
+                          );
                         }
                         if (pages!.list.isNotEmpty) {
                           return SuperListView.builder(

--- a/lib/modules/browse/sources/sources_screen.dart
+++ b/lib/modules/browse/sources/sources_screen.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/modules/browse/sources/widgets/source_list_tile.dart';
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/modules/widgets/extension_server_warning_banner.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/language.dart';
@@ -284,7 +285,11 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
             ),
           );
         },
-        error: (error, _) => Center(child: Text(error.toString())),
+        error: (error, _) => ErrorState(
+          detail: error.toString(),
+          onRetry: () =>
+              ref.invalidate(getSourcesStreamProvider(widget.itemType)),
+        ),
         loading: () => const Center(child: CircularProgressIndicator()),
       ),
     );

--- a/lib/modules/manga/detail/widgets/migrate_screen.dart
+++ b/lib/modules/manga/detail/widgets/migrate_screen.dart
@@ -13,6 +13,7 @@ import 'package:mangayomi/modules/mass_migration/services/mass_migration_service
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/chapter_filter_list_tile_widget.dart';
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/services/get_detail.dart';
@@ -247,7 +248,17 @@ class _MigrationSourceSearchScreenState
                   : Builder(
                       builder: (context) {
                         if (_errorMessage.isNotEmpty) {
-                          return Center(child: Text(_errorMessage));
+                          return ErrorState(
+                            compact: true,
+                            detail: _errorMessage,
+                            onRetry: () {
+                              setState(() {
+                                _isLoading = true;
+                                _errorMessage = "";
+                              });
+                              _init();
+                            },
+                          );
                         }
                         if (pages!.list.isNotEmpty) {
                           return SuperListView.builder(

--- a/lib/modules/manga/detail/widgets/recommendation_screen.dart
+++ b/lib/modules/manga/detail/widgets/recommendation_screen.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/recommendation.dart';
@@ -77,7 +78,16 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
             : Builder(
                 builder: (context) {
                   if (_errorMessage.isNotEmpty) {
-                    return Center(child: Text(_errorMessage));
+                    return ErrorState(
+                      detail: _errorMessage,
+                      onRetry: () {
+                        setState(() {
+                          _isLoading = true;
+                          _errorMessage = "";
+                        });
+                        _init();
+                      },
+                    );
                   }
                   if (data != null && data!.isNotEmpty) {
                     return SuperListView.builder(

--- a/lib/modules/manga/detail/widgets/watch_order_screen.dart
+++ b/lib/modules/manga/detail/widgets/watch_order_screen.dart
@@ -7,6 +7,7 @@ import 'package:mangayomi/models/track.dart';
 import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_screen.dart';
 import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/fetch_watch_order.dart';
@@ -92,7 +93,16 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
             : Builder(
                 builder: (context) {
                   if (_errorMessage.isNotEmpty) {
-                    return Center(child: Text(_errorMessage));
+                    return ErrorState(
+                      detail: _errorMessage,
+                      onRetry: () {
+                        setState(() {
+                          _isLoading = true;
+                          _errorMessage = "";
+                        });
+                        _init();
+                      },
+                    );
                   }
                   return isSequels ? _buildSequels() : _buildWatchOrder();
                 },

--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -924,9 +924,20 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                       ],
                     ),
                   ),
+                  // This screen keeps its own recovery actions above (refresh
+                  // with the right provider, and a webview for Cloudflare), so
+                  // only the cause is demoted here to match ErrorState.
                   Padding(
                     padding: const EdgeInsets.all(8.0),
-                    child: Text(error.toString(), textAlign: TextAlign.center),
+                    child: Text(
+                      error.toString(),
+                      textAlign: TextAlign.center,
+                      maxLines: 4,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.textColor.withValues(alpha: 0.7),
+                      ),
+                    ),
                   ),
                 ],
               ),

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:photo_view/photo_view.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/modules/manga/archive_reader/providers/archive_reader_providers.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
@@ -77,8 +78,14 @@ class _MangaReaderViewState extends ConsumerState<MangaReaderView> {
 
     return chapterData.when(
       loading: () => scaffoldWith(context, const ProgressCenter()),
-      error: (error, _) =>
-          scaffoldWith(context, Center(child: Text(error.toString()))),
+      error: (error, _) => scaffoldWith(
+        context,
+        ErrorState(
+          detail: error.toString(),
+          onRetry: () =>
+              ref.invalidate(mangaReaderProvider(widget.chapterId)),
+        ),
+      ),
       data: (data) {
         final chapter = data.chapter;
         final model = data.pages;

--- a/lib/modules/novel/novel_reader_view.dart
+++ b/lib/modules/novel/novel_reader_view.dart
@@ -22,6 +22,7 @@ import 'package:mangayomi/modules/novel/tts/tts_player_bar.dart';
 import 'package:mangayomi/modules/novel/tts/tts_settings_tab.dart';
 import 'package:mangayomi/modules/novel/widgets/novel_reader_settings_sheet.dart';
 import 'package:mangayomi/modules/widgets/custom_draggable_tabbar.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/get_html_content.dart';
 import 'package:mangayomi/src/rust/api/epub.dart';
@@ -776,8 +777,15 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
                 context,
                 Center(child: CircularProgressIndicator()),
               ),
-              error: (err, stack) =>
-                  scaffoldWith(context, Center(child: Text(err.toString()))),
+              error: (err, stack) => scaffoldWith(
+                context,
+                ErrorState(
+                  detail: err.toString(),
+                  onRetry: () => ref.invalidate(
+                    getHtmlContentProvider(chapter: widget.chapter),
+                  ),
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/modules/tracker_library/tracker_section_screen.dart
+++ b/lib/modules/tracker_library/tracker_section_screen.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/models/track.dart';
 import 'package:mangayomi/models/track_search.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_card.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_section.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
@@ -83,7 +84,17 @@ class _TrackerSectionScreenState extends State<TrackerSectionScreen> {
                   : Builder(
                       builder: (context) {
                         if (_errorMessage.isNotEmpty) {
-                          return Center(child: Text(_errorMessage));
+                          return ErrorState(
+                            compact: true,
+                            detail: _errorMessage,
+                            onRetry: () {
+                              setState(() {
+                                _isLoading = true;
+                                _errorMessage = "";
+                              });
+                              _fetchData();
+                            },
+                          );
                         }
                         if (_tracks.isNotEmpty) {
                           return SuperListView.builder(

--- a/lib/modules/widgets/error_state.dart
+++ b/lib/modules/widgets/error_state.dart
@@ -19,6 +19,7 @@ class ErrorState extends StatelessWidget {
     this.detail,
     this.onRetry,
     this.compact = false,
+    this.autofocusRetry,
   });
 
   /// Human readable line. Falls back to a generic message when null.
@@ -34,6 +35,12 @@ class ErrorState extends StatelessWidget {
   /// Tightens the padding for use inside a list or a sheet rather than as a
   /// whole page.
   final bool compact;
+
+  /// Whether the retry button claims focus on a TV. Defaults to taking it,
+  /// since it is usually the only control on the screen. Pass false where the
+  /// route already autofocuses something else, because two widgets competing
+  /// for autofocus in one scope resolve arbitrarily.
+  final bool? autofocusRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -84,7 +91,7 @@ class ErrorState extends StatelessWidget {
               FilledButton.tonalIcon(
                 // On a TV there is no pointer, so the only actionable control
                 // on the screen takes focus straight away.
-                autofocus: isTv,
+                autofocus: autofocusRetry ?? isTv,
                 onPressed: onRetry,
                 icon: const Icon(Icons.refresh),
                 label: Text(l10n.retry),


### PR DESCRIPTION
Follow up to #853, now merged, which added the shared `ErrorState`.

Nine screens rendered a bare `Center(child: Text(error.toString()))`. They now use `ErrorState`, each with a retry that re-runs what failed: invalidate the provider on the `AsyncValue` screens, reset the flags and re-init on the ones holding `_errorMessage`.

`retry` was already translated into fifteen languages but only reachable from reader image retries and the download queue.

Two deliberate exceptions:

- `manga_home_screen` keeps its layout. It already has source specific recovery including a webview for Cloudflare, so only the raw cause is demoted there.
- `ErrorState` gains `autofocusRetry` because `anime_player_view` deliberately autofocuses its back button for TV, and two autofocus widgets in one scope resolve arbitrarily.

Rebased on current main. `flutter analyze` clean.
