### PR TITLE
feat: show a cover grid skeleton while a source page loads

### DIFF
--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -26,6 +26,7 @@ import 'package:mangayomi/services/supports_latest.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/modules/library/widgets/search_text_form_field.dart';
 import 'package:mangayomi/modules/manga/home/widget/mangas_card_selector.dart';
+import 'package:mangayomi/modules/widgets/cover_grid_skeleton.dart';
 import 'package:mangayomi/modules/widgets/gridview_widget.dart';
 import 'package:mangayomi/modules/widgets/manga_image_card_widget.dart';
 import 'package:mangayomi/utils/global_style.dart';
@@ -707,7 +708,25 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
         ),
       ),
       body: _getManga!.isLoading
-          ? const ProgressCenter()
+          // Fetching a source page is the app's longest routine wait. Lay out
+          // the grid the covers will land in rather than a centred spinner;
+          // the list mode has no fixed cell shape to stand in for, so it keeps
+          // the spinner.
+          ? (displayType == DisplayType.list
+                ? const ProgressCenter()
+                : Consumer(
+                    builder: (context, ref, child) => CoverGridSkeleton(
+                      gridSize: ref.watch(
+                        libraryGridSizeStateProvider(
+                          itemType: source.itemType,
+                        ),
+                      ),
+                      childAspectRatio:
+                          displayType == DisplayType.comfortableGrid
+                          ? 0.642
+                          : 0.69,
+                    ),
+                  ))
           : _getManga!.when(
               data: (data) {
                 if (_hasNextPage) {

--- a/lib/modules/widgets/cover_grid_skeleton.dart
+++ b/lib/modules/widgets/cover_grid_skeleton.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:mangayomi/modules/widgets/gridview_widget.dart';
+
+/// Placeholder grid shown while a page of covers is loading.
+///
+/// A centred spinner says nothing about what is coming and reads as a stall.
+/// This lays out the shape the content will land in, and it goes through the
+/// real [GridViewWidget] so the delegate, spacing, padding and TV insets match
+/// exactly. Nothing shifts when the covers arrive.
+///
+/// The tint is the theme foreground at low alpha rather than a fixed grey,
+/// because the palette is chosen at runtime and a grey that reads correctly on
+/// one scheme is wrong on another.
+class CoverGridSkeleton extends StatefulWidget {
+  const CoverGridSkeleton({
+    super.key,
+    this.gridSize,
+    this.childAspectRatio = 0.69,
+    this.itemCount = 12,
+  });
+
+  /// Fixed column count, or null to follow the max-extent delegate. Pass the
+  /// same value the real grid uses so the columns line up.
+  final int? gridSize;
+
+  /// Must match the real grid, otherwise the cells resize on load.
+  final double childAspectRatio;
+
+  final int itemCount;
+
+  @override
+  State<CoverGridSkeleton> createState() => _CoverGridSkeletonState();
+}
+
+class _CoverGridSkeletonState extends State<CoverGridSkeleton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulse = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 900),
+  );
+
+  bool _animate = true;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Respect the platform's reduce-motion setting: hold a flat tint instead
+    // of breathing. Decided here rather than in build so the controller is not
+    // started as a build side effect.
+    _animate = !MediaQuery.disableAnimationsOf(context);
+    if (_animate) {
+      if (!_pulse.isAnimating) _pulse.repeat(reverse: true);
+    } else {
+      _pulse.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _pulse.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = Theme.of(context).colorScheme.onSurface;
+
+    return AnimatedBuilder(
+      animation: _pulse,
+      builder: (context, _) {
+        // Rebuilding a dozen plain boxes is cheaper than wrapping the grid in
+        // an Opacity, which would force a save layer on every frame.
+        final tint = fg.withValues(
+          alpha: _animate ? 0.06 + (_pulse.value * 0.06) : 0.08,
+        );
+        return GridViewWidget(
+          itemCount: widget.itemCount,
+          gridSize: widget.gridSize,
+          childAspectRatio: widget.childAspectRatio,
+          itemBuilder: (context, index) => _CoverPlaceholder(tint: tint),
+        );
+      },
+    );
+  }
+}
+
+class _CoverPlaceholder extends StatelessWidget {
+  const _CoverPlaceholder({required this.tint});
+
+  final Color tint;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: tint,
+                borderRadius: BorderRadius.circular(6),
+              ),
+            ),
+          ),
+          const SizedBox(height: 6),
+          // Stands in for the title line under the cover.
+          FractionallySizedBox(
+            alignment: Alignment.centerLeft,
+            widthFactor: 0.72,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: tint,
+                borderRadius: BorderRadius.circular(3),
+              ),
+              child: const SizedBox(height: 10),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/widgets/cover_grid_skeleton_test.dart
+++ b/test/widgets/cover_grid_skeleton_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/widgets/cover_grid_skeleton.dart';
+import 'package:mangayomi/modules/widgets/gridview_widget.dart';
+
+Widget _host(Widget child, {bool disableAnimations = false}) {
+  return MediaQuery(
+    data: MediaQueryData(disableAnimations: disableAnimations),
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  testWidgets('goes through the real grid so the geometry matches', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(const CoverGridSkeleton(gridSize: 3, itemCount: 6)),
+    );
+    await tester.pump();
+
+    // Not a lookalike grid: the same widget the covers land in, so the
+    // delegate, spacing and padding cannot drift apart.
+    final grid = tester.widget<GridViewWidget>(find.byType(GridViewWidget));
+    expect(grid.gridSize, 3);
+    expect(grid.itemCount, 6);
+  });
+
+  testWidgets('passes the aspect ratio through unchanged', (tester) async {
+    await tester.pumpWidget(
+      _host(const CoverGridSkeleton(childAspectRatio: 0.642)),
+    );
+    await tester.pump();
+
+    final grid = tester.widget<GridViewWidget>(find.byType(GridViewWidget));
+    expect(grid.childAspectRatio, 0.642);
+  });
+
+  testWidgets('settles when the platform asks for reduced motion', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(const CoverGridSkeleton(), disableAnimations: true),
+    );
+
+    // pumpAndSettle times out against a repeating animation, so this failing
+    // is the signal that the reduce-motion path stopped being honoured.
+    await tester.pumpAndSettle();
+    expect(find.byType(GridViewWidget), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Fetching a source page is the app's longest routine wait and it showed a centred spinner, which says nothing about what is coming and reads as a stall.

`CoverGridSkeleton` lays out the shape the covers will land in. It renders through the real `GridViewWidget` with the same `gridSize` and aspect ratio, so the delegate, spacing, padding and TV insets cannot drift from the loaded grid and nothing shifts when the data arrives.

Details worth knowing:

- The tint is the theme foreground at low alpha, not a fixed grey, since the palette is chosen at runtime.
- The pulse rebuilds a dozen plain boxes rather than wrapping the grid in an `Opacity`, which would force a save layer every frame.
- It holds a flat tint when the platform asks for reduced motion.
- List display keeps the spinner, having no fixed cell shape to stand in for.

`flutter analyze` clean. The three new widget tests pass; the one failing test in the suite is the pre-existing Flutter counter template, which #855 removes.
