### PR TITLE
feat: rebuild recommendations and watch order for TV

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -40,6 +40,7 @@ import 'package:mangayomi/modules/more/settings/player/providers/player_audio_st
 import 'package:mangayomi/modules/more/settings/player/providers/player_decoder_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/player/providers/player_state_provider.dart';
 import 'package:mangayomi/modules/widgets/custom_draggable_tabbar.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
@@ -141,7 +142,13 @@ class _AnimePlayerViewState extends riv.ConsumerState<AnimePlayerView> {
             },
           ),
         ),
-        body: Center(child: Text(error.toString())),
+        // The back button above already claims TV focus, so the retry must
+        // not also ask for it; it stays reachable with the d-pad.
+        body: ErrorState(
+          autofocusRetry: false,
+          detail: error.toString(),
+          onRetry: () => ref.invalidate(getVideoListProvider(episode: episode)),
+        ),
       ),
       loading: () {
         return Scaffold(

--- a/lib/modules/browse/global_search/global_search_screen.dart
+++ b/lib/modules/browse/global_search/global_search_screen.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/migrate_screen.dart';
 import 'package:mangayomi/modules/manga/home/manga_home_screen.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/models/source.dart';
@@ -208,7 +209,17 @@ class _SourceSearchScreenState extends ConsumerState<SourceSearchScreen> {
                   : Builder(
                       builder: (context) {
                         if (_errorMessage.isNotEmpty) {
-                          return Center(child: Text(_errorMessage));
+                          return ErrorState(
+                            compact: true,
+                            detail: _errorMessage,
+                            onRetry: () {
+                              setState(() {
+                                _isLoading = true;
+                                _errorMessage = "";
+                              });
+                              _init();
+                            },
+                          );
                         }
                         if (pages!.list.isNotEmpty) {
                           return SuperListView.builder(

--- a/lib/modules/browse/sources/sources_screen.dart
+++ b/lib/modules/browse/sources/sources_screen.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/modules/browse/sources/widgets/source_list_tile.dart';
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/modules/widgets/extension_server_warning_banner.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/language.dart';
@@ -284,7 +285,11 @@ class _SourcesScreenState extends ConsumerState<SourcesScreen> {
             ),
           );
         },
-        error: (error, _) => Center(child: Text(error.toString())),
+        error: (error, _) => ErrorState(
+          detail: error.toString(),
+          onRetry: () =>
+              ref.invalidate(getSourcesStreamProvider(widget.itemType)),
+        ),
         loading: () => const Center(child: CircularProgressIndicator()),
       ),
     );

--- a/lib/modules/manga/detail/widgets/migrate_screen.dart
+++ b/lib/modules/manga/detail/widgets/migrate_screen.dart
@@ -13,6 +13,7 @@ import 'package:mangayomi/modules/mass_migration/services/mass_migration_service
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/chapter_filter_list_tile_widget.dart';
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/services/get_detail.dart';
@@ -247,7 +248,17 @@ class _MigrationSourceSearchScreenState
                   : Builder(
                       builder: (context) {
                         if (_errorMessage.isNotEmpty) {
-                          return Center(child: Text(_errorMessage));
+                          return ErrorState(
+                            compact: true,
+                            detail: _errorMessage,
+                            onRetry: () {
+                              setState(() {
+                                _isLoading = true;
+                                _errorMessage = "";
+                              });
+                              _init();
+                            },
+                          );
                         }
                         if (pages!.list.isNotEmpty) {
                           return SuperListView.builder(

--- a/lib/modules/manga/detail/widgets/recommendation_screen.dart
+++ b/lib/modules/manga/detail/widgets/recommendation_screen.dart
@@ -2,18 +2,31 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
-import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
 import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/recommendation.dart';
+import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/constant.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
-import 'package:marquee/marquee.dart';
-import 'package:photo_view/photo_view.dart';
-import 'package:photo_view/photo_view_gallery.dart';
-import 'package:super_sliver_list/super_sliver_list.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
+
+/// Covers are 2:3, so a grid of mixed sources does not visibly jitter.
+const double _coverWidth = 96;
+const double _coverHeight = 144;
+
+/// Cover plus the card's vertical padding.
+const double _cardExtent = _coverHeight + 12;
+
+/// One column on a phone, two above this, and never more than two: a third
+/// column turns a scannable list of cover-plus-prose into a wall.
+const double _twoColumnBreakpoint = 700;
+
+/// Tints are an alpha over the theme foreground or the accent, never a fixed
+/// colour, because the palette is chosen at runtime.
+const double _alphaTint = 0.08;
+const double _alphaFocus = 0.14;
+const double _alphaSecondary = 0.70;
 
 class RecommendationScreen extends StatefulWidget {
   final String name;
@@ -71,322 +84,172 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.recommendations)),
-      body: Padding(
-        padding: EdgeInsetsGeometry.all(5),
-        child: _isLoading
-            ? const Center(child: CircularProgressIndicator())
-            : Builder(
-                builder: (context) {
-                  if (_errorMessage.isNotEmpty) {
-                    return ErrorState(
-                      detail: _errorMessage,
-                      onRetry: () {
-                        setState(() {
-                          _isLoading = true;
-                          _errorMessage = "";
-                        });
-                        _init();
-                      },
-                    );
-                  }
-                  if (data != null && data!.isNotEmpty) {
-                    return SuperListView.builder(
-                      padding: tvPageInsets,
-                      extentPrecalculationPolicy: SuperPrecalculationPolicy(),
-                      itemCount: data!.length,
-                      itemBuilder: (context, index) {
-                        final recommendation = data![index];
-                        return ListTile(
-                          onTap: () => context.push(
-                            '/globalSearch',
-                            extra: (
-                              recommendation.titleEnglish ??
-                                  recommendation.titleRomaji ??
-                                  recommendation.titleNative,
-                              widget.itemType,
-                            ),
-                          ),
-                          title: Row(
-                            children: [
-                              if (recommendation.imgURLs.isNotEmpty)
-                                _thumbnailPreview(
-                                  context,
-                                  recommendation.imgURLs.first,
-                                ),
-                              const SizedBox(width: 15),
-                              recommendation.description != null
-                                  ? Flexible(
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          _buildTitle(
-                                            recommendation.titleEnglish ??
-                                                recommendation.titleRomaji ??
-                                                recommendation.titleNative ??
-                                                "",
-                                            context,
-                                          ),
-                                          Text(
-                                            recommendation.description!,
-                                            style: const TextStyle(
-                                              fontSize: 11,
-                                            ),
-                                            overflow: TextOverflow.clip,
-                                          ),
-                                        ],
-                                      ),
-                                    )
-                                  : Flexible(
-                                      child: _buildTitle(
-                                        recommendation.titleEnglish ??
-                                            recommendation.titleRomaji ??
-                                            recommendation.titleNative ??
-                                            "",
-                                        context,
-                                      ),
-                                    ),
-                            ],
-                          ),
-                          subtitle: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 15),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 12,
-                                  ),
-                                  child: recommendation.genres.isEmpty
-                                      ? const SizedBox(height: 15)
-                                      : context.isTablet
-                                      ? Wrap(
-                                          children: [
-                                            for (
-                                              var i = 0;
-                                              i < recommendation.genres.length;
-                                              i++
-                                            )
-                                              Padding(
-                                                padding: const EdgeInsets.only(
-                                                  left: 2,
-                                                  right: 2,
-                                                  bottom: 5,
-                                                ),
-                                                child: SizedBox(
-                                                  height: 30,
-                                                  child: ElevatedButton(
-                                                    style: ElevatedButton.styleFrom(
-                                                      elevation: 0,
-                                                      backgroundColor: Colors
-                                                          .grey
-                                                          .withValues(
-                                                            alpha: 0.2,
-                                                          ),
-                                                      shape: RoundedRectangleBorder(
-                                                        borderRadius:
-                                                            BorderRadius.circular(
-                                                              5,
-                                                            ),
-                                                      ),
-                                                    ),
-                                                    onPressed: null,
-                                                    child: Text(
-                                                      recommendation.genres[i],
-                                                      style: TextStyle(
-                                                        fontSize: 11.5,
-                                                        color: context.isLight
-                                                            ? Colors.black
-                                                            : Colors.white,
-                                                      ),
-                                                    ),
-                                                  ),
-                                                ),
-                                              ),
-                                          ],
-                                        )
-                                      : SingleChildScrollView(
-                                          scrollDirection: Axis.horizontal,
-                                          child: Row(
-                                            mainAxisAlignment:
-                                                MainAxisAlignment.start,
-                                            children: [
-                                              for (
-                                                var i = 0;
-                                                i <
-                                                    recommendation
-                                                        .genres
-                                                        .length;
-                                                i++
-                                              )
-                                                Padding(
-                                                  padding:
-                                                      const EdgeInsets.only(
-                                                        left: 2,
-                                                        right: 2,
-                                                        bottom: 5,
-                                                      ),
-                                                  child: SizedBox(
-                                                    height: 30,
-                                                    child: ElevatedButton(
-                                                      style: ElevatedButton.styleFrom(
-                                                        elevation: 0,
-                                                        backgroundColor: Colors
-                                                            .grey
-                                                            .withValues(
-                                                              alpha: 0.2,
-                                                            ),
-                                                        shape: RoundedRectangleBorder(
-                                                          borderRadius:
-                                                              BorderRadius.circular(
-                                                                5,
-                                                              ),
-                                                        ),
-                                                      ),
-                                                      onPressed: () {},
-                                                      child: Text(
-                                                        recommendation
-                                                            .genres[i],
-                                                        style: TextStyle(
-                                                          fontSize: 11.5,
-                                                          color: context.isLight
-                                                              ? Colors.black
-                                                              : Colors.white,
-                                                        ),
-                                                      ),
-                                                    ),
-                                                  ),
-                                                ),
-                                            ],
-                                          ),
-                                        ),
-                                ),
-                                const SizedBox(width: 15),
-                                Text(
-                                  "${recommendation.score}% ${l10n.recommendations_similar}",
-                                  style: TextStyle(
-                                    background: Paint()
-                                      ..color = Theme.of(context)
-                                          .scaffoldBackgroundColor
-                                          .withValues(alpha: 0.75)
-                                      ..strokeWidth = 30.0
-                                      ..strokeJoin = StrokeJoin.round
-                                      ..style = PaintingStyle.stroke,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        );
-                      },
-                    );
-                  }
-                  return Center(child: Text(l10n.no_result));
-                },
+      body: _isLoading
+          ? const ProgressCenter()
+          : _errorMessage.isNotEmpty
+          ? ErrorState(
+              detail: _errorMessage,
+              onRetry: () {
+                setState(() {
+                  _isLoading = true;
+                  _errorMessage = "";
+                });
+                _init();
+              },
+            )
+          : (data == null || data!.isEmpty)
+          ? Center(child: Text(l10n.no_result))
+          // Poster list: a cover, the similarity score as a filled pill, the
+          // title, a two-line capped synopsis and genre chips. Rows used to
+          // stretch the full width of a TV or desktop panel; the grid reflows
+          // to two columns instead so they never run into empty space.
+          : LayoutBuilder(
+              builder: (context, constraints) {
+                final columns =
+                    constraints.maxWidth >= _twoColumnBreakpoint ? 2 : 1;
+                return GridView.builder(
+                  padding: tvPageInsets,
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: columns,
+                    mainAxisExtent: _cardExtent,
+                    crossAxisSpacing: 10,
+                    mainAxisSpacing: 10,
+                  ),
+                  itemCount: data!.length,
+                  itemBuilder: (context, index) =>
+                      _card(context, data![index], index),
+                );
+              },
+            ),
+    );
+  }
+
+  Widget _card(BuildContext context, RecommendationResult rec, int index) {
+    final title = rec.titleEnglish ?? rec.titleRomaji ?? rec.titleNative ?? "";
+    final coverUrl = rec.imgURLs.isNotEmpty ? rec.imgURLs.first : "";
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(8),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        // Nothing was focusable on entry, so a remote did nothing until the
+        // user guessed a direction. The first card claims focus on a TV.
+        autofocus: isTv && index == 0,
+        focusColor: context.primaryColor.withValues(alpha: _alphaFocus),
+        onTap: () =>
+            context.push('/globalSearch', extra: (title, widget.itemType)),
+        child: Padding(
+          padding: const EdgeInsets.all(6),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(6),
+                child: Image(
+                  image: coverProvider(toImgUrl(coverUrl)),
+                  width: _coverWidth,
+                  height: _coverHeight,
+                  fit: BoxFit.cover,
+                ),
               ),
-      ),
-    );
-  }
-
-  Widget _buildTitle(String text, BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        // Make sure that (constraints.maxWidth - (35 + 5)) is strictly positive.
-        final double availableWidth = constraints.maxWidth - (35 + 5);
-        final textPainter = TextPainter(
-          text: TextSpan(text: text, style: const TextStyle(fontSize: 13)),
-          maxLines: 1,
-          textDirection: TextDirection.ltr,
-        )..layout(maxWidth: availableWidth > 0 ? availableWidth : 1.0); // - Download icon size (download_page_widget.dart, Widget Build SizedBox width: 35)
-
-        final isOverflowing = textPainter.didExceedMaxLines;
-
-        if (isOverflowing) {
-          return SizedBox(
-            height: 20,
-            child: Marquee(
-              text: text,
-              style: const TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
-              blankSpace: 40.0,
-              velocity: 30.0,
-              pauseAfterRound: const Duration(seconds: 1),
-              startPadding: 10.0,
-            ),
-          );
-        } else {
-          return Text(
-            text,
-            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
-            overflow: TextOverflow.ellipsis,
-          );
-        }
-      },
-    );
-  }
-
-  Widget _thumbnailPreview(BuildContext context, String? imageUrl) {
-    final imageProvider = CustomExtendedNetworkImageProvider(
-      toImgUrl(imageUrl ?? ""),
-    );
-    return Padding(
-      padding: const EdgeInsets.all(3),
-      child: GestureDetector(
-        onTap: () {
-          _openImage(context, imageProvider);
-        },
-        child: SizedBox(
-          width: 100,
-          height: 150,
-          child: Container(
-            decoration: BoxDecoration(
-              borderRadius: const BorderRadius.all(Radius.circular(5)),
-              image: DecorationImage(image: imageProvider, fit: BoxFit.cover),
-            ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _scorePill(context, rec.score),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (rec.description != null &&
+                        rec.description!.isNotEmpty) ...[
+                      const SizedBox(height: 5),
+                      Text(
+                        rec.description!,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 12,
+                          height: 1.35,
+                          color: context.textColor.withValues(
+                            alpha: _alphaSecondary,
+                          ),
+                        ),
+                      ),
+                    ],
+                    if (rec.genres.isNotEmpty) ...[
+                      const SizedBox(height: 7),
+                      Wrap(
+                        spacing: 5,
+                        runSpacing: 4,
+                        children: [
+                          for (final g in rec.genres.take(3)) _chip(context, g),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
           ),
         ),
       ),
     );
   }
 
-  void _openImage(BuildContext context, ImageProvider imageProvider) {
-    showDialog(
-      context: context,
-      builder: (context) {
-        return Scaffold(
-          backgroundColor: Colors.transparent,
-          body: Stack(
-            children: [
-              GestureDetector(
-                onTap: () => Navigator.pop(context),
-                child: PhotoViewGallery.builder(
-                  backgroundDecoration: const BoxDecoration(
-                    color: Colors.transparent,
-                  ),
-                  itemCount: 1,
-                  builder: (context, index) {
-                    return PhotoViewGalleryPageOptions(
-                      imageProvider: imageProvider,
-                      minScale: PhotoViewComputedScale.contained,
-                      maxScale: 2.0,
-                    );
-                  },
-                  loadingBuilder: (context, event) {
-                    return const ProgressCenter();
-                  },
-                ),
-              ),
-            ],
-          ),
-        );
-      },
+  /// Filled with the accent. The label colour is computed against the accent
+  /// rather than the theme, so it stays readable whichever hue the user picked
+  /// and in either brightness.
+  Widget _scorePill(BuildContext context, int score) {
+    final accent = context.primaryColor;
+    final onAccent = accent.computeLuminance() > 0.5
+        ? Colors.black
+        : Colors.white;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: accent,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        "$score%",
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w800,
+          color: onAccent,
+        ),
+      ),
     );
   }
-}
 
-class SuperPrecalculationPolicy extends ExtentPrecalculationPolicy {
-  @override
-  bool shouldPrecalculateExtents(ExtentPrecalculationContext context) {
-    return context.numberOfItems < 100;
+  Widget _chip(BuildContext context, String text) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: context.textColor.withValues(alpha: _alphaTint),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 11,
+          color: context.textColor.withValues(alpha: _alphaSecondary),
+        ),
+      ),
+    );
   }
 }

--- a/lib/modules/manga/detail/widgets/recommendation_screen.dart
+++ b/lib/modules/manga/detail/widgets/recommendation_screen.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/recommendation.dart';
@@ -77,7 +78,16 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
             : Builder(
                 builder: (context) {
                   if (_errorMessage.isNotEmpty) {
-                    return Center(child: Text(_errorMessage));
+                    return ErrorState(
+                      detail: _errorMessage,
+                      onRetry: () {
+                        setState(() {
+                          _isLoading = true;
+                          _errorMessage = "";
+                        });
+                        _init();
+                      },
+                    );
                   }
                   if (data != null && data!.isNotEmpty) {
                     return SuperListView.builder(

--- a/lib/modules/manga/detail/widgets/watch_order_screen.dart
+++ b/lib/modules/manga/detail/widgets/watch_order_screen.dart
@@ -19,6 +19,15 @@ import 'package:photo_view/photo_view_gallery.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
 
+/// Tints are an alpha over the theme foreground or the accent, never a fixed
+/// colour, because the palette is chosen at runtime. Shared with
+/// recommendation_screen so the two sibling screens cannot drift apart.
+const double _alphaTint = 0.08;
+const double _alphaHairline = 0.16;
+const double _alphaFocus = 0.14;
+const double _alphaAccentTint = 0.16;
+const double _alphaSecondary = 0.70;
+
 class WatchOrderScreen extends StatefulWidget {
   final String name;
   final Track? track;
@@ -89,7 +98,7 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
       body: Padding(
         padding: EdgeInsetsGeometry.all(5),
         child: _isLoading
-            ? const Center(child: CircularProgressIndicator())
+            ? const ProgressCenter()
             : Builder(
                 builder: (context) {
                   if (_errorMessage.isNotEmpty) {
@@ -165,109 +174,252 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
   }
 
   Widget _buildWatchOrder() {
-    final isSearch = dataSearch != null && dataSearch!.isNotEmpty;
-    final isWatchOrder = data != null && data!.isNotEmpty;
-    if (isSearch || isWatchOrder) {
-      return SuperListView.builder(
-        // Sibling view to _buildSequels, so it takes the same inset.
-        padding: tvPageInsets,
-        extentPrecalculationPolicy: SuperPrecalculationPolicy(),
-        itemCount: data?.length ?? dataSearch!.length,
-        itemBuilder: (context, index) {
-          final search = !isWatchOrder && isSearch ? dataSearch![index] : null;
-          final watchOrder = isWatchOrder ? data![index] : null;
-          return ListTile(
-            onTap: () async {
-              if (isWatchOrder) {
-                context.push(
-                  '/globalSearch',
-                  extra: (
-                    watchOrder!.nameEnglish ?? watchOrder.name,
-                    ItemType.anime,
-                  ),
-                );
-              } else {
-                if (mounted) {
-                  setState(() {
-                    _isLoading = true;
-                    _errorMessage = "";
-                  });
-                  data = await fetchWatchOrder(search!.id);
-                  setState(() {
-                    _isLoading = false;
-                  });
-                }
-              }
-            },
-            trailing: watchOrder != null
-                ? _roleBadge(context, watchOrder.role)
-                : null,
-            title: Row(
-              children: [
-                if (watchOrder != null)
-                  SizedBox(
-                    width: 24,
-                    child: Text(
-                      "${index + 1}",
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                _thumbnailPreview(context, watchOrder?.image ?? search!.image),
-                const SizedBox(width: 15),
-                Flexible(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      _buildTitle(watchOrder?.name ?? search!.name, context),
-                      if (watchOrder?.nameEnglish != null &&
-                          watchOrder?.nameEnglish != watchOrder?.text)
-                        Text(
-                          watchOrder!.nameEnglish!,
-                          style: const TextStyle(fontSize: 11),
-                          overflow: TextOverflow.clip,
-                        ),
-                      Text(
-                        watchOrder?.text ?? "${search!.type} - ${search.year}",
-                        style: const TextStyle(fontSize: 11),
-                        overflow: TextOverflow.clip,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          );
-        },
-      );
+    if (data != null && data!.isNotEmpty) return _timeline(data!);
+    if (dataSearch != null && dataSearch!.isNotEmpty) {
+      return _searchList(dataSearch!);
     }
     return Center(child: Text(context.l10n.no_result));
   }
 
-  Widget _roleBadge(BuildContext context, WatchOrderRole role) {
-    final (label, color) = switch (role) {
-      WatchOrderRole.current => ("Currently watching", context.primaryColor),
-      WatchOrderRole.previous => ("Previous", Colors.grey),
-      WatchOrderRole.next => ("Up next", Colors.blueGrey),
-    };
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.18),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
-          color: color,
+  // Chronological franchise as a rail: a vertical timeline on phones, and a
+  // horizontal one on TV/desktop where a single stretched column would leave the
+  // width empty. "Current" is the anchor (enlarged cover + accent ring + a filled
+  // badge); position carries previous vs up next.
+  Widget _timeline(List<WatchOrderItem> items) {
+    // One layout on every form factor: a vertical rail. On a wide TV/desktop
+    // window it centres at a comfortable width with side padding rather than
+    // stretching a single column across the whole panel.
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 820),
+        child: ListView.builder(
+          padding: tvPageInsets,
+          itemCount: items.length,
+          itemBuilder: (context, index) {
+            final item = items[index];
+            final isLast = index == items.length - 1;
+            final isCurrent = item.role == WatchOrderRole.current;
+            return Material(
+              color: Colors.transparent,
+              child: InkWell(
+                autofocus: isTv && index == 0,
+                focusColor: context.primaryColor.withValues(alpha: _alphaFocus),
+                onTap: () => _openWatchOrder(item),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Cover, then a short connector stub down to the next
+                      // cover so the chain reads as an ordered rail.
+                      SizedBox(
+                        width: 132,
+                        child: Column(
+                          children: [
+                            _cover(context, item.image, isCurrent: isCurrent),
+                            if (!isLast)
+                              Container(
+                                width: 2,
+                                height: 22,
+                                color: context.textColor.withValues(
+                                  alpha: _alphaHairline,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 14),
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.only(top: 6),
+                          child: _timelineBody(context, item),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
         ),
       ),
     );
+  }
+
+  Widget _timelineBody(BuildContext context, WatchOrderItem item) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          item.name,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+        ),
+        if (item.nameEnglish != null &&
+            item.nameEnglish!.isNotEmpty &&
+            item.nameEnglish != item.name)
+          Text(
+            item.nameEnglish!,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 11,
+              color: context.textColor.withValues(alpha: _alphaSecondary),
+            ),
+          ),
+        if (item.text.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: 1),
+            child: Text(
+              item.text,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 11,
+                color: context.textColor.withValues(alpha: _alphaSecondary),
+              ),
+            ),
+          ),
+        const SizedBox(height: 7),
+        _roleBadge(context, item.role),
+      ],
+    );
+  }
+
+  Widget _cover(
+    BuildContext context,
+    String? imageUrl, {
+    required bool isCurrent,
+  }) {
+    final width = isCurrent ? 120.0 : 96.0;
+    final height = isCurrent ? 180.0 : 144.0;
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(6),
+        border: isCurrent
+            ? Border.all(color: context.primaryColor, width: 3)
+            : null,
+        image: DecorationImage(
+          image: CustomExtendedNetworkImageProvider(toImgUrl(imageUrl ?? "")),
+          fit: BoxFit.cover,
+        ),
+      ),
+    );
+  }
+
+  void _openWatchOrder(WatchOrderItem item) {
+    context.push(
+      '/globalSearch',
+      extra: (item.nameEnglish ?? item.name, ItemType.anime),
+    );
+  }
+
+  Widget _searchList(List<WatchOrderSearch> results) {
+    return SuperListView.builder(
+      padding: tvPageInsets,
+      extentPrecalculationPolicy: SuperPrecalculationPolicy(),
+      itemCount: results.length,
+      itemBuilder: (context, index) {
+        final search = results[index];
+        return ListTile(
+          onTap: () async {
+            if (mounted) {
+              setState(() {
+                _isLoading = true;
+                _errorMessage = "";
+              });
+              data = await fetchWatchOrder(search.id);
+              setState(() {
+                _isLoading = false;
+              });
+            }
+          },
+          title: Row(
+            children: [
+              _thumbnailPreview(context, search.image),
+              const SizedBox(width: 15),
+              Flexible(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildTitle(search.name, context),
+                    Text(
+                      "${search.type} - ${search.year}",
+                      style: const TextStyle(fontSize: 11),
+                      overflow: TextOverflow.clip,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _roleBadge(BuildContext context, WatchOrderRole role) {
+    final accent = context.primaryColor;
+    switch (role) {
+      case WatchOrderRole.current:
+        // Filled accent + a label colour computed for contrast against the
+        // accent (not the theme): legible on any accent hue and in either theme.
+        // The old grey / blue-grey tags washed out on dark with a light accent.
+        final onAccent = accent.computeLuminance() > 0.5
+            ? Colors.black
+            : Colors.white;
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: accent,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            "Currently watching",
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: onAccent,
+            ),
+          ),
+        );
+      case WatchOrderRole.next:
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: accent.withValues(alpha: _alphaAccentTint),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            "Up next",
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: accent,
+            ),
+          ),
+        );
+      case WatchOrderRole.previous:
+        final neutral = context.textColor;
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: neutral.withValues(alpha: _alphaTint),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            "Previous",
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: neutral.withValues(alpha: _alphaSecondary),
+            ),
+          ),
+        );
+    }
   }
 
   Widget _buildTitle(String text, BuildContext context) {
@@ -275,11 +427,14 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
       builder: (context, constraints) {
         // Make sure that (constraints.maxWidth - (35 + 5)) is strictly positive.
         final double availableWidth = constraints.maxWidth - (35 + 5);
-        final textPainter = TextPainter(
-          text: TextSpan(text: text, style: const TextStyle(fontSize: 13)),
-          maxLines: 1,
-          textDirection: TextDirection.ltr,
-        )..layout(maxWidth: availableWidth > 0 ? availableWidth : 1.0); // - Download icon size (download_page_widget.dart, Widget Build SizedBox width: 35)
+        final textPainter =
+            TextPainter(
+              text: TextSpan(text: text, style: const TextStyle(fontSize: 13)),
+              maxLines: 1,
+              textDirection: TextDirection.ltr,
+            )..layout(
+              maxWidth: availableWidth > 0 ? availableWidth : 1.0,
+            ); // - Download icon size (download_page_widget.dart, Widget Build SizedBox width: 35)
 
         final isOverflowing = textPainter.didExceedMaxLines;
 

--- a/lib/modules/manga/detail/widgets/watch_order_screen.dart
+++ b/lib/modules/manga/detail/widgets/watch_order_screen.dart
@@ -7,6 +7,7 @@ import 'package:mangayomi/models/track.dart';
 import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_screen.dart';
 import 'package:mangayomi/modules/widgets/custom_extended_image_provider.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/fetch_watch_order.dart';
@@ -92,7 +93,16 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
             : Builder(
                 builder: (context) {
                   if (_errorMessage.isNotEmpty) {
-                    return Center(child: Text(_errorMessage));
+                    return ErrorState(
+                      detail: _errorMessage,
+                      onRetry: () {
+                        setState(() {
+                          _isLoading = true;
+                          _errorMessage = "";
+                        });
+                        _init();
+                      },
+                    );
                   }
                   return isSequels ? _buildSequels() : _buildWatchOrder();
                 },

--- a/lib/modules/manga/home/manga_home_screen.dart
+++ b/lib/modules/manga/home/manga_home_screen.dart
@@ -924,9 +924,20 @@ class _MangaHomeScreenState extends ConsumerState<MangaHomeScreen> {
                       ],
                     ),
                   ),
+                  // This screen keeps its own recovery actions above (refresh
+                  // with the right provider, and a webview for Cloudflare), so
+                  // only the cause is demoted here to match ErrorState.
                   Padding(
                     padding: const EdgeInsets.all(8.0),
-                    child: Text(error.toString(), textAlign: TextAlign.center),
+                    child: Text(
+                      error.toString(),
+                      textAlign: TextAlign.center,
+                      maxLines: 4,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.textColor.withValues(alpha: 0.7),
+                      ),
+                    ),
                   ),
                 ],
               ),

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:photo_view/photo_view.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/modules/manga/archive_reader/providers/archive_reader_providers.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
@@ -77,8 +78,14 @@ class _MangaReaderViewState extends ConsumerState<MangaReaderView> {
 
     return chapterData.when(
       loading: () => scaffoldWith(context, const ProgressCenter()),
-      error: (error, _) =>
-          scaffoldWith(context, Center(child: Text(error.toString()))),
+      error: (error, _) => scaffoldWith(
+        context,
+        ErrorState(
+          detail: error.toString(),
+          onRetry: () =>
+              ref.invalidate(mangaReaderProvider(widget.chapterId)),
+        ),
+      ),
       data: (data) {
         final chapter = data.chapter;
         final model = data.pages;

--- a/lib/modules/novel/novel_reader_view.dart
+++ b/lib/modules/novel/novel_reader_view.dart
@@ -22,6 +22,7 @@ import 'package:mangayomi/modules/novel/tts/tts_player_bar.dart';
 import 'package:mangayomi/modules/novel/tts/tts_settings_tab.dart';
 import 'package:mangayomi/modules/novel/widgets/novel_reader_settings_sheet.dart';
 import 'package:mangayomi/modules/widgets/custom_draggable_tabbar.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/get_html_content.dart';
 import 'package:mangayomi/src/rust/api/epub.dart';
@@ -776,8 +777,15 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
                 context,
                 Center(child: CircularProgressIndicator()),
               ),
-              error: (err, stack) =>
-                  scaffoldWith(context, Center(child: Text(err.toString()))),
+              error: (err, stack) => scaffoldWith(
+                context,
+                ErrorState(
+                  detail: err.toString(),
+                  onRetry: () => ref.invalidate(
+                    getHtmlContentProvider(chapter: widget.chapter),
+                  ),
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/modules/tracker_library/tracker_section_screen.dart
+++ b/lib/modules/tracker_library/tracker_section_screen.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/models/track.dart';
 import 'package:mangayomi/models/track_search.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_card.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_section.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
@@ -83,7 +84,17 @@ class _TrackerSectionScreenState extends State<TrackerSectionScreen> {
                   : Builder(
                       builder: (context) {
                         if (_errorMessage.isNotEmpty) {
-                          return Center(child: Text(_errorMessage));
+                          return ErrorState(
+                            compact: true,
+                            detail: _errorMessage,
+                            onRetry: () {
+                              setState(() {
+                                _isLoading = true;
+                                _errorMessage = "";
+                              });
+                              _fetchData();
+                            },
+                          );
                         }
                         if (_tracks.isNotEmpty) {
                           return SuperListView.builder(

--- a/lib/modules/widgets/error_state.dart
+++ b/lib/modules/widgets/error_state.dart
@@ -19,6 +19,7 @@ class ErrorState extends StatelessWidget {
     this.detail,
     this.onRetry,
     this.compact = false,
+    this.autofocusRetry,
   });
 
   /// Human readable line. Falls back to a generic message when null.
@@ -34,6 +35,12 @@ class ErrorState extends StatelessWidget {
   /// Tightens the padding for use inside a list or a sheet rather than as a
   /// whole page.
   final bool compact;
+
+  /// Whether the retry button claims focus on a TV. Defaults to taking it,
+  /// since it is usually the only control on the screen. Pass false where the
+  /// route already autofocuses something else, because two widgets competing
+  /// for autofocus in one scope resolve arbitrarily.
+  final bool? autofocusRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -84,7 +91,7 @@ class ErrorState extends StatelessWidget {
               FilledButton.tonalIcon(
                 // On a TV there is no pointer, so the only actionable control
                 // on the screen takes focus straight away.
-                autofocus: isTv,
+                autofocus: autofocusRetry ?? isTv,
                 onPressed: onRetry,
                 icon: const Icon(Icons.refresh),
                 label: Text(l10n.retry),


### PR DESCRIPTION
Follows #854, which these two files also touch, so merge that first.

Both screens were unusable with a remote. Neither had a single `autofocus` or any `isTv` branch, so opening either left nothing focused: the d-pad did nothing until the user guessed a direction, and there was no ring to show where they were. Rows also stretched the full width of a TV or desktop panel, and the watch order role badges were hardcoded `Colors.grey` and `Colors.blueGrey`, which washed out on dark themes with a light accent.

**Recommendations** becomes a poster list: cover, accent score pill, title, two line capped synopsis, genre chips. One column on a phone, reflowing to two above 700px and capped there so rows never run into empty space.

**Watch order** becomes a vertical timeline rail on every form factor, centred at 820px on wide windows, with the current entry enlarged and ringed in the accent. Role badges are theme safe now: "currently watching" fills with the accent and computes its label colour from that fill's luminance rather than the app brightness, "up next" is accent tinted, "previous" is a neutral tint of the foreground.

The first card or row claims focus on TV, so a remote lands somewhere.

The two files also disagreed with each other six ways about the same concepts: focus wash 0.16 against 0.12, neutral tint 0.08 against 0.09, secondary text 0.7 against 0.6, badge radius 5 against 6, cover aspect 0.681 against 0.685 and 0.690, and three sub pixel type steps. They now share one set of alpha constants, covers are 2:3 at both sizes, and the type scale is whole pixels.

Both designs were validated on a device. `flutter analyze` clean.
