### PR TITLE
feat(ios): adopt the UIScene lifecycle

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,41 +1,56 @@
 import UIKit
 import Flutter
 import Libmtorrentserver
-import app_links
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-      let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
-      let mChannel = FlutterMethodChannel(name: "com.kodjodevf.mangayomi.libmtorrentserver", binaryMessenger: controller.binaryMessenger)
-              mChannel.setMethodCallHandler({
-                  (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
-                  switch call.method {
-                  case "start":
-                      let args = call.arguments as? Dictionary<String, Any>
-                      let config = args?["config"] as? String
-                      var error: NSError?
-                      let mPort = UnsafeMutablePointer<Int>.allocate(capacity: MemoryLayout<Int>.stride)
-                      if LibmtorrentserverStart(config, mPort, &error){
-                          result(mPort.pointee)
-                      }else{
-                          result(FlutterError(code: "ERROR", message: error.debugDescription, details: nil))
-                      }
-                  default:
-                      result(FlutterMethodNotImplemented)
-                  }
-              })
-
-    GeneratedPluginRegistrant.register(with: self)
-
-    if let url = AppLinks.shared.getLink(launchOptions: launchOptions) {
-      AppLinks.shared.handleLink(url: url)
-      return true
-    }
-
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+
+  /// Called once, when the implicit engine is created.
+  ///
+  /// Everything here used to live in `didFinishLaunchingWithOptions`, which is
+  /// the reason Picture in Picture was disabled: PiP opens a second `UIScene`,
+  /// that re-entered launch, and re-running plugin registration segfaulted.
+  /// This callback fires once per engine rather than once per scene, so a
+  /// second scene is now harmless.
+  ///
+  /// It also removes the `window?.rootViewController as! FlutterViewController`
+  /// force-cast the channel used to need. Under `UIScene` the app delegate owns
+  /// no window, so that cast would crash outright.
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+
+    let mChannel = FlutterMethodChannel(
+      name: "com.kodjodevf.mangayomi.libmtorrentserver",
+      binaryMessenger: engineBridge.applicationRegistrar.messenger()
+    )
+    mChannel.setMethodCallHandler({
+      (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+      switch call.method {
+      case "start":
+        let args = call.arguments as? Dictionary<String, Any>
+        let config = args?["config"] as? String
+        var error: NSError?
+        let mPort = UnsafeMutablePointer<Int>.allocate(capacity: MemoryLayout<Int>.stride)
+        if LibmtorrentserverStart(config, mPort, &error) {
+          result(mPort.pointee)
+        } else {
+          result(FlutterError(code: "ERROR", message: error.debugDescription, details: nil))
+        }
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    })
+  }
 }
+
+// Deep links are no longer opened from here. app_links conforms to
+// FlutterSceneLifeCycleDelegate and FlutterSceneDelegate forwards
+// scene:willConnectToSession:options: to it, so it picks up both cold-start and
+// warm links itself. The old AppLinks.shared.getLink(launchOptions:) block read
+// launch options that UIScene never populates.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -39,12 +39,34 @@
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>fetch</string>
 	</array>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Mangayomi needs to authenticate using Face ID.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -843,14 +843,21 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             : "libmpv",
       ),
     );
-    // Picture-in-Picture (media_kit fork VideoOutputPIP, iOS 15+) is DISABLED:
-    // on iOS 26 the second UIScene that PiP creates re-runs plugin registration
-    // and connectivity_plus segfaults (EXC_BAD_ACCESS in didFinishLaunching).
-    // PiP is only the trigger; the real fix is the UIScene lifecycle migration
-    // (flutter.dev/to/uiscene-migration). Re-enable after that. See closed #757.
-    // if (Platform.isIOS) {
-    //   _controller.enableAutoPictureInPicture();
-    // }
+    // Picture-in-Picture is still off, but the reason has changed.
+    //
+    // It was disabled because the second UIScene PiP creates re-entered
+    // didFinishLaunchingWithOptions and re-ran plugin registration, which
+    // segfaulted connectivity_plus. That cause is now gone: the app is on the
+    // UIScene lifecycle and registration happens once per engine in
+    // didInitializeImplicitFlutterEngine.
+    //
+    // What blocks it now is the media_kit fork. The old call was
+    // `_controller.enableAutoPictureInPicture()`, and that method no longer
+    // exists: the fork moved PiP onto `VideoController.pictureInPicture`, a
+    // PictureInPictureController with `isSupported()` and
+    // `start(handle:, videoSize:, autoEnter:)` taking a native libmpv handle.
+    // Re-enabling means porting to that API and testing on a device, so it is
+    // deliberately left for its own change. See closed #757.
     // If player is being launched the first time,
     // use global "Use Fullscreen" setting.
     // Else (if user already watches an episode and just changes it),
@@ -2154,9 +2161,9 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
                   )
                   .toList(),
         ),
-        // PiP button disabled: entering PiP crashes on iOS 26 (see the
-        // enableAutoPictureInPicture note above / closed #757). Re-enable with
-        // the UIScene migration.
+        // PiP button stays off. The UIScene crash that originally disabled it
+        // is fixed, but the media_kit fork moved the API; see the note on
+        // pictureInPicture above and closed #757.
         // if (Platform.isIOS && _controller.isPictureInPictureAvailable())
         //   IconButton(
         //     tooltip: 'Picture in Picture',


### PR DESCRIPTION
The app was still on the pre-scene `UIApplicationDelegate` lifecycle. That is what disabled Picture in Picture: PiP opens a second `UIScene`, which re-entered `didFinishLaunchingWithOptions` and re-ran plugin registration, and connectivity_plus segfaulted. `AppDelegate` also reached the binary messenger through `window?.rootViewController as! FlutterViewController`, and under `UIScene` the app delegate owns no window, so that force-cast would crash outright.

This follows the migration `flutter_tools` performs automatically for unmodified templates. It skips this project because `AppDelegate` is customised.

- `Info.plist` declares `UIApplicationSceneManifest` using Flutter's own `FlutterSceneDelegate` and the existing `Main` storyboard.
- Plugin registration and the libmtorrentserver channel move into `didInitializeImplicitFlutterEngine`, which fires **once per engine** rather than once per scene. The channel takes its messenger from the engine bridge's `applicationRegistrar`, so the force-cast is gone.
- The manual `AppLinks.shared.getLink(launchOptions:)` block is removed. `app_links` already conforms to `FlutterSceneLifeCycleDelegate` and `FlutterSceneDelegate` forwards `scene:willConnectToSession:options:` to it, so it picks up cold-start and warm links itself. Those launch options are never populated under `UIScene` anyway.
- `UIBackgroundModes` gains `audio`, needed for PiP and background playback.

**PiP is not re-enabled here.** Its original blocker is fixed, but the media_kit fork has since moved the API: `enableAutoPictureInPicture` no longer exists, and PiP now lives on `VideoController.pictureInPicture` as a controller taking a native libmpv handle. That port needs device testing, so it belongs in its own change. The stale comments telling the reader to re-enable PiP "after the UIScene migration" are corrected to say this instead.

## Tested on the simulator

Built and launched on an iPhone 17 Pro simulator (iOS 26.5, Xcode 26.6), on this branch:

- **Launches to the real app shell**, not the startup-error fallback. Isar initialises (it prints its inspector URL, which needs `path_provider`) and `flutter_inappwebview` prints its banner. All of that requires `GeneratedPluginRegistrant` to have run, so `didInitializeImplicitFlutterEngine` is firing.
- **Cold-start deep link works with no AppDelegate code.** Terminated the app, then `xcrun simctl openurl` with a `mangayomi://add-repo?...` URL pointing at a real extension index. The app cold-started, the handler ran, it validated the index over the network and showed "Source repository added!". That is `app_links` receiving the URL through `scene(_:willConnectToSession:options:)`, which is the path this PR removes the manual `launchOptions` handling for.

- **Real end to end use.** Added an extension repo, installed a source, and played an episode. Video playback works, and the log shows no `EXC_BAD_ACCESS` or crash signatures. That exercises media_kit, the JS extension runtime and networking together, which is worth noting because media_kit is the package whose PiP API moved.

Not covered: PiP (still disabled, see above), and iOS 27, since the installed Xcode ships the 26.5 SDK.

### Unrelated pre-existing build failure

`flutter build ios --simulator` fails on Apple Silicon with `Unsupported Swift architecture` at `media_kit_video-Swift.h:426`. **This is not caused by this PR.** I built pristine `main` in a separate worktree with the same command and got a byte-identical failure at the same file and line. The generic `iOS Simulator` destination pulls in an x86_64 slice the media_kit fork does not ship; targeting a specific arm64 simulator builds fine. Worth a separate look.

`flutter analyze` and `flutter test` pass.