### PR TITLE
Add Edit Metadata button to local extensions

### DIFF
--- a/lib/modules/browse/extension/extension_detail.dart
+++ b/lib/modules/browse/extension/extension_detail.dart
@@ -230,6 +230,51 @@ class _ExtensionDetailState extends ConsumerState<ExtensionDetail> {
                 ),
               ),
             ),
+            if (source.isLocal ?? false)
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: SizedBox(
+                  width: context.width(1),
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      padding: const EdgeInsets.all(0),
+                      backgroundColor: Colors.transparent,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(5),
+                      ),
+                      elevation: 0,
+                      shadowColor: Colors.transparent,
+                    ),
+                    onPressed: () async {
+                      final res = await context.push(
+                        '/createExtension',
+                        extra: source,
+                      );
+                      if (res != null && mounted) {
+                        setState(() {
+                          source = res as Source;
+                        });
+                      }
+                    },
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 10),
+                          child: Text(
+                            "Edit metadata",
+                            style: const TextStyle(
+                              fontSize: 20,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        const Icon(Icons.edit_outlined),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: SizedBox(

--- a/lib/modules/browse/extension/widgets/create_extension.dart
+++ b/lib/modules/browse/extension/widgets/create_extension.dart
@@ -8,23 +8,34 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 
 class CreateExtension extends StatefulWidget {
-  const CreateExtension({super.key});
+  final Source? editSource;
+  const CreateExtension({super.key, this.editSource});
 
   @override
   State<CreateExtension> createState() => _CreateExtensionState();
 }
 
 class _CreateExtensionState extends State<CreateExtension> {
-  bool _isNsfw = false;
-  String _name = "";
-  String _lang = "";
-  String _baseUrl = "";
-  String _apiUrl = "";
-  String _iconUrl = "";
-  String _notes = "";
-  int _sourceTypeIndex = 0;
-  int _itemTypeIndex = 0;
-  int _languageIndex = 0;
+  late bool _isNsfw = widget.editSource?.isNsfw ?? false;
+  bool get _isEditMode => widget.editSource != null;
+
+  late String _name = widget.editSource?.name ?? "";
+  late String _lang = widget.editSource?.lang ?? "";
+  late String _baseUrl = widget.editSource?.baseUrl ?? "";
+  late String _apiUrl = widget.editSource?.apiUrl ?? "";
+  late String _iconUrl = widget.editSource?.iconUrl ?? "";
+  late String _notes = widget.editSource?.notes ?? "";
+  late int _sourceTypeIndex = widget.editSource == null
+      ? 0
+      : _sourceTypes
+            .indexOf(widget.editSource!.typeSource ?? "")
+            .clamp(0, _sourceTypes.length - 1);
+  late int _itemTypeIndex = widget.editSource?.itemType.index ?? 0;
+  late int _languageIndex = switch (widget.editSource?.sourceCodeLanguage) {
+    SourceCodeLanguage.javascript => 1,
+    SourceCodeLanguage.lnreader => 2,
+    _ => 0,
+  };
   final List<String> _sourceTypes = ["single", "multi", "torrent"];
   final List<String> _itemTypes = ["Manga", "Anime", "Novel"];
   final List<String> _languages = [
@@ -32,11 +43,14 @@ class _CreateExtensionState extends State<CreateExtension> {
     "JavaScript",
     "LNReader compiled JS",
   ];
-  SourceCodeLanguage _sourceCodeLanguage = SourceCodeLanguage.dart;
+  late SourceCodeLanguage _sourceCodeLanguage =
+      widget.editSource?.sourceCodeLanguage ?? SourceCodeLanguage.dart;
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("Create Extension")),
+      appBar: AppBar(
+        title: Text(_isEditMode ? "Edit Extension" : "Create Extension"),
+      ),
       body: SingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.all(8.0),
@@ -47,6 +61,14 @@ class _CreateExtensionState extends State<CreateExtension> {
                 child: Row(
                   children: [
                     const Text("Choose extension language"),
+                    if (_isEditMode) ...[
+                      const SizedBox(width: 6),
+                      Icon(
+                        Icons.lock_outline,
+                        size: 14,
+                        color: Theme.of(context).hintColor,
+                      ),
+                    ],
                     const SizedBox(width: 20),
                     Flexible(
                       child: DropdownButton(
@@ -68,39 +90,57 @@ class _CreateExtensionState extends State<CreateExtension> {
                               ),
                             )
                             .toList(),
-                        onChanged: (v) {
-                          setState(() {
-                            if (v == 0) {
-                              _sourceCodeLanguage = SourceCodeLanguage.dart;
-                            } else if (v == 1) {
-                              _sourceCodeLanguage =
-                                  SourceCodeLanguage.javascript;
-                            } else {
-                              _sourceCodeLanguage = SourceCodeLanguage.lnreader;
-                            }
-                            _languageIndex = v!;
-                          });
-                        },
+                        onChanged: _isEditMode
+                            ? null
+                            : (int? v) {
+                                setState(() {
+                                  if (v == 0) {
+                                    _sourceCodeLanguage =
+                                        SourceCodeLanguage.dart;
+                                  } else if (v == 1) {
+                                    _sourceCodeLanguage =
+                                        SourceCodeLanguage.javascript;
+                                  } else {
+                                    _sourceCodeLanguage =
+                                        SourceCodeLanguage.lnreader;
+                                  }
+                                  _languageIndex = v!;
+                                });
+                              },
                       ),
                     ),
                   ],
                 ),
               ),
-              _textEditing("Name", context, "ex: myAnime", (v) {
-                setState(() {
-                  _name = v;
-                });
-              }),
-              _textEditing("Lang", context, "ex: en", (v) {
-                setState(() {
-                  _lang = v;
-                });
-              }),
+              _textEditing(
+                "Name",
+                context,
+                "ex: myAnime",
+                (v) {
+                  setState(() {
+                    _name = v;
+                  });
+                },
+                initialValue: _name,
+                enabled: !_isEditMode,
+              ),
+              _textEditing(
+                "Lang",
+                context,
+                "ex: en",
+                (v) {
+                  setState(() {
+                    _lang = v;
+                  });
+                },
+                initialValue: _lang,
+                enabled: !_isEditMode,
+              ),
               _textEditing("BaseUrl", context, "ex: https://example.com", (v) {
                 setState(() {
                   _baseUrl = v;
                 });
-              }),
+              }, initialValue: _baseUrl),
               _textEditing(
                 "ApiUrl (optional)",
                 context,
@@ -110,12 +150,13 @@ class _CreateExtensionState extends State<CreateExtension> {
                     _apiUrl = v;
                   });
                 },
+                initialValue: _apiUrl,
               ),
               _textEditing("iconUrl", context, "Source icon url", (v) {
                 setState(() {
                   _iconUrl = v;
                 });
-              }),
+              }, initialValue: _iconUrl),
               _textEditing(
                 "notes",
                 context,
@@ -125,12 +166,21 @@ class _CreateExtensionState extends State<CreateExtension> {
                     _notes = v;
                   });
                 },
+                initialValue: _notes,
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 17),
                 child: Row(
                   children: [
                     const Text("Type"),
+                    if (_isEditMode) ...[
+                      const SizedBox(width: 6),
+                      Icon(
+                        Icons.lock_outline,
+                        size: 14,
+                        color: Theme.of(context).hintColor,
+                      ),
+                    ],
                     const SizedBox(width: 20),
                     Flexible(
                       child: DropdownButton(
@@ -152,11 +202,13 @@ class _CreateExtensionState extends State<CreateExtension> {
                               ),
                             )
                             .toList(),
-                        onChanged: (v) {
-                          setState(() {
-                            _sourceTypeIndex = v!;
-                          });
-                        },
+                        onChanged: _isEditMode
+                            ? null
+                            : (int? v) {
+                                setState(() {
+                                  _sourceTypeIndex = v!;
+                                });
+                              },
                       ),
                     ),
                   ],
@@ -167,6 +219,14 @@ class _CreateExtensionState extends State<CreateExtension> {
                 child: Row(
                   children: [
                     const Text("Target"),
+                    if (_isEditMode) ...[
+                      const SizedBox(width: 6),
+                      Icon(
+                        Icons.lock_outline,
+                        size: 14,
+                        color: Theme.of(context).hintColor,
+                      ),
+                    ],
                     const SizedBox(width: 20),
                     Flexible(
                       child: DropdownButton(
@@ -188,11 +248,13 @@ class _CreateExtensionState extends State<CreateExtension> {
                               ),
                             )
                             .toList(),
-                        onChanged: (v) {
-                          setState(() {
-                            _itemTypeIndex = v!;
-                          });
-                        },
+                        onChanged: _isEditMode
+                            ? null
+                            : (int? v) {
+                                setState(() {
+                                  _itemTypeIndex = v!;
+                                });
+                              },
                       ),
                     ),
                   ],
@@ -215,6 +277,25 @@ class _CreateExtensionState extends State<CreateExtension> {
                           _baseUrl.isNotEmpty &&
                           _iconUrl.isNotEmpty) {
                         try {
+                          if (_isEditMode) {
+                            final source = widget.editSource!
+                              ..baseUrl = _baseUrl
+                              ..apiUrl = _apiUrl
+                              ..iconUrl = _iconUrl
+                              ..notes = _notes
+                              ..isNsfw = _isNsfw
+                              ..typeSource = _sourceTypes[_sourceTypeIndex];
+                            isar.writeTxnSync(() {
+                              isar.sources.putSync(
+                                source
+                                  ..updatedAt =
+                                      DateTime.now().millisecondsSinceEpoch,
+                              );
+                            });
+                            Navigator.pop(context, source);
+                            botToast("Source updated successfully");
+                            return;
+                          }
                           final id =
                               _sourceCodeLanguage == SourceCodeLanguage.dart
                               ? 'mangayomi-$_lang.$_name'.hashCode
@@ -257,7 +338,11 @@ class _CreateExtensionState extends State<CreateExtension> {
                             botToast("Source already exists");
                           }
                         } catch (e) {
-                          botToast("Error when creating source");
+                          botToast(
+                            _isEditMode
+                                ? "Error when updating source"
+                                : "Error when creating source",
+                          );
                         }
                       }
                     },
@@ -277,11 +362,15 @@ Widget _textEditing(
   String label,
   BuildContext context,
   String hintText,
-  void Function(String)? onChanged,
-) {
+  void Function(String)? onChanged, {
+  String? initialValue,
+  bool enabled = true,
+}) {
   return Padding(
     padding: const EdgeInsets.symmetric(horizontal: 17, vertical: 5),
     child: TextFormField(
+      initialValue: initialValue,
+      enabled: enabled,
       keyboardType: TextInputType.text,
       onChanged: onChanged,
       decoration: InputDecoration(

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -228,7 +228,10 @@ class RouterNotifier extends ChangeNotifier {
       name: "codeEditor",
       builder: (sourceId) => CodeEditorPage(sourceId: sourceId),
     ),
-    _genericRoute(name: "createExtension", child: const CreateExtension()),
+    _genericRoute<Source?>(
+      name: "createExtension",
+      builder: (source) => CreateExtension(editSource: source),
+    ),
     _genericRoute(name: "createBackup", child: const CreateBackup()),
     _genericRoute(
       name: "customNavigationSettings",


### PR DESCRIPTION
Adds an "Edit metadata" button, shown only on manually-created local extensions:

<img width="1280" height="752" alt="image" src="https://github.com/user-attachments/assets/b66e7cd4-0cef-4bf6-b30d-35d3485fd3d7" />
&nbsp;

It allows the fields `baseUrl`, `apiUrl`, `iconUrl`, `notes`, and `NSFW` to be editable and blocks some fields from being edited. 
<img width="1280" height="752" alt="image" src="https://github.com/user-attachments/assets/915fedf6-35fc-468e-803f-2647df03fd14" />
&nbsp;

- Extension language, because you can't just convert dart code to javascript and vice versa.
- Extension name, because the name is part of the source.id
- Content language, because it's also part of the source.id
- Type because letting someone flip an existing extension between torrent and non-torrent after the fact could break code that was written assuming one or the other
- Target: it's not part of source.id, but it's how the browse tabs and extension list bucket a source, and any library manga already added under it assume that type — changing it later wouldn't retroactively move anything, just create a mismatch.

Source.id is computed from name + lang + language (`'mangayomi-$lang.$name'.hashCode`, or `mangayomi-js-$lang.$name` for the JS/LNReader branch). Changing either Extension name or Content language would silently produce a different id, orphaning any library manga and source preferences tied to the old one.
