### PR TITLE
fix: watch order timeline and global search results

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -30,7 +30,7 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
-  - m_extension_server (0.0.4):
+  - m_extension_server (0.0.1):
     - Flutter
   - media_kit_libs_ios_video (1.0.4):
     - Flutter
@@ -161,7 +161,7 @@ SPEC CHECKSUMS:
   InternalCollectionsUtilities: af3f471602c4a67cbcb0bee0a80f6f55a33ae453
   isar_community_flutter_libs: bede843185a61a05ff364a05c9b23209523f7e0d
   local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
-  m_extension_server: 8460f14761883af48772290c5f818659b844d4c3
+  m_extension_server: 6946ec189542b271dbd15629b9498595f1036761
   media_kit_libs_ios_video: 5a18affdb97d1f5d466dc79988b13eff6c5e2854
   media_kit_video: 1746e198cb697d1ffb734b1d05ec429d1fcd1474
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -921,5 +921,14 @@
   "no_saved_searches": "No saved searches for this source yet.\nRun a search, then pick \"Save search\".",
   "source": "Source",
   "something_went_wrong": "Something went wrong",
-  "startup_failed": "Mangayomi could not finish starting up"
+  "startup_failed": "Mangayomi could not finish starting up",
+  "sources_with_no_results": "{count, plural, =1{1 source with no results} other{{count} sources with no results}}",
+  "@sources_with_no_results": {
+    "description": "Header of the collapsed group in global search holding every source that failed or found nothing.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -4666,6 +4666,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Mangayomi could not finish starting up'**
   String get startup_failed;
+
+  /// Header of the collapsed group in global search holding every source that failed or found nothing.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 source with no results} other{{count} sources with no results}}'**
+  String sources_with_no_results(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -2523,4 +2523,15 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -2524,4 +2524,15 @@ class AppLocalizationsAs extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -2539,4 +2539,15 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -2516,4 +2516,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -2549,6 +2549,17 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -2550,4 +2550,15 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -2521,4 +2521,15 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -2528,4 +2528,15 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -2550,4 +2550,15 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -2483,4 +2483,15 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -2544,6 +2544,17 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -2559,4 +2559,15 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -2518,4 +2518,15 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -2530,4 +2530,15 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2442,4 +2442,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get startup_failed => 'Mangayomi could not finish starting up';
+
+  @override
+  String sources_with_no_results(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources with no results',
+      one: '1 source with no results',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/modules/browse/global_search/global_search_screen.dart
+++ b/lib/modules/browse/global_search/global_search_screen.dart
@@ -8,7 +8,6 @@ import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/migrate_screen.dart';
 import 'package:mangayomi/modules/manga/home/manga_home_screen.dart';
-import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/router/router.dart';
 import 'package:mangayomi/models/source.dart';
@@ -55,10 +54,25 @@ class _GlobalSearchScreenState extends ConsumerState<GlobalSearchScreen> {
     return sources.where((e) => !(e.isNsfw ?? false)).toList();
   }();
 
+  /// Sources that finished with nothing to show, id to the reason.
+  ///
+  /// They are hidden from the list and gathered into one group at the bottom,
+  /// so the results are not interleaved with a dozen dead extensions.
+  final Map<int, String> _nothingToShow = {};
+
   @override
   void initState() {
     super.initState();
     _textEditingController.text = widget.search ?? "";
+  }
+
+  void _reportNothingToShow(Source source, String reason) {
+    final id = source.id;
+    if (id == null || _nothingToShow[id] == reason) return;
+    // Reported from the child's build, so defer the parent rebuild a frame.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _nothingToShow[id] = reason);
+    });
   }
 
   @override
@@ -98,21 +112,93 @@ class _GlobalSearchScreenState extends ConsumerState<GlobalSearchScreen> {
       ),
       body: _query.isNotEmpty || widget.search != null
           ? SuperListView.builder(
-              itemCount: sourceList.length,
+              // One extra row for the group of sources with nothing to show.
+              itemCount: sourceList.length + 1,
               extentPrecalculationPolicy: SuperPrecalculationPolicy(),
               itemBuilder: (context, index) {
+                if (index == sourceList.length) {
+                  return _nothingToShowGroup(context);
+                }
                 final source = sourceList[index];
-                return SizedBox(
-                  height: 260,
-                  child: SourceSearchScreen(
-                    key: ValueKey(query),
-                    query: query,
-                    source: source,
-                  ),
+                // A source that fails or finds nothing renders nothing here and
+                // reports itself instead, so results are never interleaved with
+                // dead extensions. It stays mounted, so nothing refetches.
+                return SourceSearchScreen(
+                  // Keyed per source as well as per query. They previously all
+                  // shared one key, which is not a valid sibling key.
+                  key: ValueKey('$query#${source.id}'),
+                  query: query,
+                  source: source,
+                  onNothingToShow: (reason) =>
+                      _reportNothingToShow(source, reason),
                 );
               },
             )
           : Container(),
+    );
+  }
+
+  /// Collapsed group of every source that failed or found nothing.
+  ///
+  /// Collapsed by default: it is the part of the screen nobody came for. The
+  /// reason is kept on each row, since it is the only clue about which
+  /// extension is broken.
+  Widget _nothingToShowGroup(BuildContext context) {
+    if (_nothingToShow.isEmpty) return const SizedBox.shrink();
+    final byId = {for (final s in sourceList) s.id: s};
+    final theme = Theme.of(context);
+    return Theme(
+      // Drop the divider lines ExpansionTile draws by default.
+      data: theme.copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        dense: true,
+        shape: const Border(),
+        collapsedShape: const Border(),
+        leading: Icon(
+          Icons.error_outline,
+          size: 18,
+          color: context.textColor.withValues(alpha: 0.7),
+        ),
+        title: Text(
+          l10nLocalizations(context)!
+              .sources_with_no_results(_nothingToShow.length),
+          style: TextStyle(
+            fontSize: 13,
+            color: context.textColor.withValues(alpha: 0.7),
+          ),
+        ),
+        children: [
+          for (final entry in _nothingToShow.entries)
+            if (byId[entry.key] != null)
+              ListTile(
+                dense: true,
+                onTap: () => Navigator.push(
+                  context,
+                  createRoute(
+                    page: MangaHomeScreen(
+                      query: _query.isNotEmpty ? _query : widget.search ?? "",
+                      source: byId[entry.key]!,
+                      isSearch: true,
+                    ),
+                  ),
+                ),
+                title: Text(
+                  byId[entry.key]!.name!,
+                  style: const TextStyle(fontSize: 13),
+                ),
+                subtitle: Text(
+                  entry.value,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 10,
+                    color: context.textColor.withValues(alpha: 0.7),
+                  ),
+                ),
+                trailing: const Icon(Icons.arrow_forward_sharp, size: 18),
+              ),
+        ],
+      ),
     );
   }
 
@@ -127,10 +213,16 @@ class SourceSearchScreen extends ConsumerStatefulWidget {
   final String query;
 
   final Source source;
+
+  /// Called when this source finishes with nothing to show, with the reason.
+  /// The parent gathers these into one collapsed group at the bottom.
+  final void Function(String reason)? onNothingToShow;
+
   const SourceSearchScreen({
     super.key,
     required this.query,
     required this.source,
+    this.onNothingToShow,
   });
 
   @override
@@ -177,73 +269,78 @@ class _SourceSearchScreenState extends ConsumerState<SourceSearchScreen> {
   Widget build(BuildContext context) {
     final l10n = l10nLocalizations(context)!;
 
-    return Scaffold(
-      body: SizedBox(
-        height: 260,
-        child: Column(
-          children: [
-            ListTile(
-              dense: true,
-              onTap: () {
-                Navigator.push(
-                  context,
-                  createRoute(
-                    page: MangaHomeScreen(
-                      query: widget.query,
-                      source: widget.source,
-                      isSearch: true,
-                    ),
+    // A source with nothing to show should not hold a full height slot. Failed
+    // and empty sources collapse to a single line, so the sources that did
+    // return results stay on screen instead of being pushed off by errors.
+    final hasResults =
+        _errorMessage.isEmpty && (pages?.list.isNotEmpty ?? false);
+    final collapsed = !_isLoading && !hasResults;
+
+    // Nothing to show is nothing to show. A source that errored and a source
+    // that returned no match are the same non-event to someone scanning
+    // results, so both are handed to the parent and drawn once, together, at
+    // the bottom rather than each taking a slot in the middle of the results.
+    if (collapsed) {
+      widget.onNothingToShow?.call(
+        _errorMessage.isNotEmpty
+            ? "${l10n.failed} ${_errorMessage.replaceAll(RegExp(r'\s+'), ' ').trim()}"
+            : l10n.no_result,
+      );
+      return const SizedBox.shrink();
+    }
+
+    final header = ListTile(
+      dense: true,
+      onTap: () {
+        Navigator.push(
+          context,
+          createRoute(
+            page: MangaHomeScreen(
+              query: widget.query,
+              source: widget.source,
+              isSearch: true,
+            ),
+          ),
+        );
+      },
+      title: Text(widget.source.name!),
+      subtitle: Text(
+        completeLanguageName(widget.source.lang!),
+        style: const TextStyle(fontSize: 10),
+      ),
+      trailing: const Icon(Icons.arrow_forward_sharp),
+    );
+
+    // A Scaffold per list row was never needed; it also forces the row to
+    // expand, which would defeat the collapse.
+    return SizedBox(
+      height: 260,
+      child: Column(
+        children: [
+          header,
+          // Only loading or results reach here; failures and empty results
+          // returned above as a single header row. No retry: these are almost
+          // always a broken extension returning the same error every time, not
+          // a transient blip, and the header still opens the source.
+          Flexible(
+            child: _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : SuperListView.builder(
+                    extentPrecalculationPolicy: SuperPrecalculationPolicy(),
+                    scrollDirection: Axis.horizontal,
+                    padding: isTv
+                        ? const EdgeInsets.symmetric(horizontal: 8)
+                        : null,
+                    itemCount: pages!.list.length,
+                    itemBuilder: (context, index) {
+                      return MangaGlobalImageCard(
+                        manga: pages!.list[index],
+                        source: widget.source,
+                      );
+                    },
                   ),
-                );
-              },
-              title: Text(widget.source.name!),
-              subtitle: Text(
-                completeLanguageName(widget.source.lang!),
-                style: const TextStyle(fontSize: 10),
-              ),
-              trailing: const Icon(Icons.arrow_forward_sharp),
-            ),
-            Flexible(
-              child: _isLoading
-                  ? const Center(child: CircularProgressIndicator())
-                  : Builder(
-                      builder: (context) {
-                        if (_errorMessage.isNotEmpty) {
-                          return ErrorState(
-                            compact: true,
-                            detail: _errorMessage,
-                            onRetry: () {
-                              setState(() {
-                                _isLoading = true;
-                                _errorMessage = "";
-                              });
-                              _init();
-                            },
-                          );
-                        }
-                        if (pages!.list.isNotEmpty) {
-                          return SuperListView.builder(
-                            extentPrecalculationPolicy:
-                                SuperPrecalculationPolicy(),
-                            scrollDirection: Axis.horizontal,
-                            padding: isTv
-                                ? const EdgeInsets.symmetric(horizontal: 8)
-                                : null,
-                            itemCount: pages!.list.length,
-                            itemBuilder: (context, index) {
-                              return MangaGlobalImageCard(
-                                manga: pages!.list[index],
-                                source: widget.source,
-                              );
-                            },
-                          );
-                        }
-                        return Center(child: Text(l10n.no_result));
-                      },
-                    ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/modules/browse/global_search/global_search_screen.dart
+++ b/lib/modules/browse/global_search/global_search_screen.dart
@@ -111,28 +111,29 @@ class _GlobalSearchScreenState extends ConsumerState<GlobalSearchScreen> {
         ],
       ),
       body: _query.isNotEmpty || widget.search != null
-          ? SuperListView.builder(
-              // One extra row for the group of sources with nothing to show.
-              itemCount: sourceList.length + 1,
-              extentPrecalculationPolicy: SuperPrecalculationPolicy(),
-              itemBuilder: (context, index) {
-                if (index == sourceList.length) {
-                  return _nothingToShowGroup(context);
-                }
-                final source = sourceList[index];
-                // A source that fails or finds nothing renders nothing here and
-                // reports itself instead, so results are never interleaved with
-                // dead extensions. It stays mounted, so nothing refetches.
-                return SourceSearchScreen(
-                  // Keyed per source as well as per query. They previously all
-                  // shared one key, which is not a valid sibling key.
-                  key: ValueKey('$query#${source.id}'),
-                  query: query,
-                  source: source,
-                  onNothingToShow: (reason) =>
-                      _reportNothingToShow(source, reason),
-                );
-              },
+          // Every row is built rather than lazily. A source that fails or finds
+          // nothing collapses to zero height, and a lazy list that estimates
+          // extents cannot cope with that: scrolling up builds more rows, they
+          // resolve, they collapse, and the content shrinks under the scroll
+          // position, so the view fights the finger and never reaches the top.
+          // Building all of them keeps the extent stable. There is one row per
+          // installed source, and a global search queries all of them anyway.
+          ? SingleChildScrollView(
+              child: Column(
+                children: [
+                  for (final source in sourceList)
+                    SourceSearchScreen(
+                      // Keyed per source as well as per query. They previously
+                      // all shared one key, which is not a valid sibling key.
+                      key: ValueKey('$query#${source.id}'),
+                      query: query,
+                      source: source,
+                      onNothingToShow: (reason) =>
+                          _reportNothingToShow(source, reason),
+                    ),
+                  _nothingToShowGroup(context),
+                ],
+              ),
             )
           : Container(),
     );

--- a/lib/modules/manga/detail/widgets/watch_order_screen.dart
+++ b/lib/modules/manga/detail/widgets/watch_order_screen.dart
@@ -28,6 +28,10 @@ const double _alphaFocus = 0.14;
 const double _alphaAccentTint = 0.16;
 const double _alphaSecondary = 0.70;
 
+/// Cover height over width. One value for every cover in the rail, so the
+/// current entry differs from the rest in size only, never in shape.
+const double _coverAspect = 1.46;
+
 class WatchOrderScreen extends StatefulWidget {
   final String name;
   final Track? track;
@@ -376,8 +380,15 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
     String? imageUrl, {
     required bool isCurrent,
   }) {
-    final width = isCurrent ? 120.0 : 96.0;
-    final height = isCurrent ? 180.0 : 144.0;
+    // Every cover keeps the same aspect, so none of them crops differently
+    // from the rest. The two sizes used to be 120x174 and 100x146, which are
+    // not quite the same ratio.
+    //
+    // The current entry is only a little larger. The accent ring already marks
+    // it, so the size difference just has to be felt; at the previous 20% it
+    // read as a jump in the rail.
+    final width = isCurrent ? 110.0 : 100.0;
+    final height = width * _coverAspect;
     return Container(
       width: width,
       height: height,

--- a/lib/modules/manga/detail/widgets/watch_order_screen.dart
+++ b/lib/modules/manga/detail/widgets/watch_order_screen.dart
@@ -47,6 +47,29 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
 
   bool get isSequels => widget.track != null;
 
+  /// Marks the current entry so the framework can scroll it into view.
+  final GlobalKey _currentRowKey = GlobalKey();
+  bool _didAnchorOnCurrent = false;
+
+  /// Opens the timeline on the entry the user is actually watching.
+  ///
+  /// Starting at the top of a long franchise hides where you are in it. The
+  /// alignment leaves the previous entry partly visible, so it reads as "there
+  /// is more in both directions" rather than as the start of the list.
+  ///
+  /// No offsets are computed here. [Scrollable.ensureVisible] does the
+  /// positioning, and it is a no-op both when the current entry is already
+  /// first and when the list is too short to scroll at all.
+  void _anchorOnCurrent() {
+    if (_didAnchorOnCurrent) return;
+    _didAnchorOnCurrent = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final rowContext = _currentRowKey.currentContext;
+      if (!mounted || rowContext == null) return;
+      Scrollable.ensureVisible(rowContext, alignment: 0.3);
+    });
+  }
+
   @override
   void initState() {
     super.initState();
@@ -189,58 +212,78 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
     // One layout on every form factor: a vertical rail. On a wide TV/desktop
     // window it centres at a comfortable width with side padding rather than
     // stretching a single column across the whole panel.
+    _anchorOnCurrent();
     return Center(
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 820),
-        child: ListView.builder(
+        // Every row is built rather than lazily: a franchise timeline is
+        // short, and the current entry needs a laid out context for
+        // ensureVisible to reach it while it is still off screen.
+        child: SingleChildScrollView(
           padding: tvPageInsets,
-          itemCount: items.length,
-          itemBuilder: (context, index) {
-            final item = items[index];
-            final isLast = index == items.length - 1;
-            final isCurrent = item.role == WatchOrderRole.current;
-            return Material(
-              color: Colors.transparent,
-              child: InkWell(
-                autofocus: isTv && index == 0,
-                focusColor: context.primaryColor.withValues(alpha: _alphaFocus),
-                onTap: () => _openWatchOrder(item),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // Cover, then a short connector stub down to the next
-                      // cover so the chain reads as an ordered rail.
-                      SizedBox(
-                        width: 132,
-                        child: Column(
-                          children: [
-                            _cover(context, item.image, isCurrent: isCurrent),
-                            if (!isLast)
-                              Container(
-                                width: 2,
-                                height: 22,
-                                color: context.textColor.withValues(
-                                  alpha: _alphaHairline,
+          child: Column(
+            children: [
+              for (var index = 0; index < items.length; index++)
+                Builder(
+                  builder: (context) {
+                    final item = items[index];
+                    final isLast = index == items.length - 1;
+                    final isCurrent = item.role == WatchOrderRole.current;
+                    return Material(
+                      // The anchor the timeline opens on, and on TV the row
+                      // the remote lands on. Row 0 would make a mid franchise
+                      // position look like the beginning.
+                      key: isCurrent ? _currentRowKey : null,
+                      color: Colors.transparent,
+                      child: InkWell(
+                        autofocus: isTv && isCurrent,
+                        focusColor: context.primaryColor.withValues(
+                          alpha: _alphaFocus,
+                        ),
+                        onTap: () => _openWatchOrder(item),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              // Cover, then a short connector stub down to the next
+                              // cover so the chain reads as an ordered rail.
+                              SizedBox(
+                                width: 132,
+                                child: Column(
+                                  children: [
+                                    _cover(
+                                      context,
+                                      item.image,
+                                      isCurrent: isCurrent,
+                                    ),
+                                    if (!isLast)
+                                      Container(
+                                        width: 2,
+                                        height: 22,
+                                        color: context.textColor.withValues(
+                                          alpha: _alphaHairline,
+                                        ),
+                                      ),
+                                  ],
                                 ),
                               ),
-                          ],
+                              const SizedBox(width: 14),
+                              Expanded(
+                                child: Padding(
+                                  padding: const EdgeInsets.only(top: 6),
+                                  child: _timelineBody(context, item),
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
-                      const SizedBox(width: 14),
-                      Expanded(
-                        child: Padding(
-                          padding: const EdgeInsets.only(top: 6),
-                          child: _timelineBody(context, item),
-                        ),
-                      ),
-                    ],
-                  ),
+                    );
+                  },
                 ),
-              ),
-            );
-          },
+            ],
+          ),
         ),
       ),
     );
@@ -427,14 +470,11 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
       builder: (context, constraints) {
         // Make sure that (constraints.maxWidth - (35 + 5)) is strictly positive.
         final double availableWidth = constraints.maxWidth - (35 + 5);
-        final textPainter =
-            TextPainter(
-              text: TextSpan(text: text, style: const TextStyle(fontSize: 13)),
-              maxLines: 1,
-              textDirection: TextDirection.ltr,
-            )..layout(
-              maxWidth: availableWidth > 0 ? availableWidth : 1.0,
-            ); // - Download icon size (download_page_widget.dart, Widget Build SizedBox width: 35)
+        final textPainter = TextPainter(
+          text: TextSpan(text: text, style: const TextStyle(fontSize: 13)),
+          maxLines: 1,
+          textDirection: TextDirection.ltr,
+        )..layout(maxWidth: availableWidth > 0 ? availableWidth : 1.0); // - Download icon size (download_page_widget.dart, Widget Build SizedBox width: 35)
 
         final isOverflowing = textPainter.didExceedMaxLines;
 

--- a/lib/modules/manga/detail/widgets/watch_order_screen.dart
+++ b/lib/modules/manga/detail/widgets/watch_order_screen.dart
@@ -28,9 +28,13 @@ const double _alphaFocus = 0.14;
 const double _alphaAccentTint = 0.16;
 const double _alphaSecondary = 0.70;
 
-/// Cover height over width. One value for every cover in the rail, so the
-/// current entry differs from the rest in size only, never in shape.
-const double _coverAspect = 1.46;
+/// Cover height over width, taken from the artwork itself: AniList serves
+/// these at 230x320. Matching it means BoxFit.cover has nothing to crop, so
+/// every cover shows its original framing rather than a trimmed version of it.
+///
+/// One value for the whole rail, so the current entry differs from the rest in
+/// size only, never in shape.
+const double _coverAspect = 320 / 230;
 
 class WatchOrderScreen extends StatefulWidget {
   final String name;
@@ -283,10 +287,18 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
                                 children: [
                                   SizedBox(
                                     width: 132,
-                                    child: _cover(
-                                      context,
-                                      item.image,
-                                      isCurrent: isCurrent,
+                                    // Centre it, or the rail's width is a
+                                    // tight constraint and the cover is
+                                    // stretched to 132 no matter what width it
+                                    // asks for. That is what made every cover
+                                    // near square and made width changes look
+                                    // like they did nothing.
+                                    child: Center(
+                                      child: _cover(
+                                        context,
+                                        item.image,
+                                        isCurrent: isCurrent,
+                                      ),
                                     ),
                                   ),
                                   const SizedBox(width: 14),

--- a/lib/modules/manga/detail/widgets/watch_order_screen.dart
+++ b/lib/modules/manga/detail/widgets/watch_order_screen.dart
@@ -60,13 +60,31 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
   /// No offsets are computed here. [Scrollable.ensureVisible] does the
   /// positioning, and it is a no-op both when the current entry is already
   /// first and when the list is too short to scroll at all.
+  ///
+  /// It retries across a few frames rather than trying once. The row has to be
+  /// laid out and the scroll view has to know its extent before this can do
+  /// anything, and neither is guaranteed on the first frame after the data
+  /// arrives: the route may still be animating in. Giving up after one silent
+  /// miss is why this worked on one platform and not another.
   void _anchorOnCurrent() {
     if (_didAnchorOnCurrent) return;
     _didAnchorOnCurrent = true;
+    _tryAnchor(0);
+  }
+
+  void _tryAnchor(int attempt) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       final rowContext = _currentRowKey.currentContext;
-      if (!mounted || rowContext == null) return;
-      Scrollable.ensureVisible(rowContext, alignment: 0.3);
+      final position = rowContext == null
+          ? null
+          : Scrollable.maybeOf(rowContext)?.position;
+      if (position == null || !position.hasContentDimensions) {
+        // Not ready yet. Frames are cheap and this stops within ~10 of them.
+        if (attempt < 10) _tryAnchor(attempt + 1);
+        return;
+      }
+      Scrollable.ensureVisible(rowContext!, alignment: 0.3);
     });
   }
 

--- a/lib/modules/manga/detail/widgets/watch_order_screen.dart
+++ b/lib/modules/manga/detail/widgets/watch_order_screen.dart
@@ -229,56 +229,79 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
                     final item = items[index];
                     final isLast = index == items.length - 1;
                     final isCurrent = item.role == WatchOrderRole.current;
-                    return Material(
-                      // The anchor the timeline opens on, and on TV the row
-                      // the remote lands on. Row 0 would make a mid franchise
-                      // position look like the beginning.
-                      key: isCurrent ? _currentRowKey : null,
-                      color: Colors.transparent,
-                      child: InkWell(
-                        autofocus: isTv && isCurrent,
-                        focusColor: context.primaryColor.withValues(
-                          alpha: _alphaFocus,
-                        ),
-                        onTap: () => _openWatchOrder(item),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 8),
-                          child: Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              // Cover, then a short connector stub down to the next
-                              // cover so the chain reads as an ordered rail.
-                              SizedBox(
-                                width: 132,
-                                child: Column(
-                                  children: [
-                                    _cover(
+                    // The focus tint belongs to the entry, not to the rail.
+                    // The connector stub is drawn after the ink surface rather
+                    // than inside it, so the highlight stops at the entry, the
+                    // gap between rows stays readable, and the tint does not
+                    // paint a block over the connector.
+                    return Column(
+                      children: [
+                        Material(
+                          // The anchor the timeline opens on, and on TV the row
+                          // the remote lands on. Row 0 would make a mid
+                          // franchise position look like the beginning.
+                          key: isCurrent ? _currentRowKey : null,
+                          color: Colors.transparent,
+                          borderRadius: BorderRadius.circular(12),
+                          clipBehavior: Clip.antiAlias,
+                          child: InkWell(
+                            autofocus: isTv && isCurrent,
+                            borderRadius: BorderRadius.circular(12),
+                            focusColor: context.primaryColor.withValues(
+                              alpha: _alphaFocus,
+                            ),
+                            onTap: () => _openWatchOrder(item),
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  SizedBox(
+                                    width: 132,
+                                    child: _cover(
                                       context,
                                       item.image,
                                       isCurrent: isCurrent,
                                     ),
-                                    if (!isLast)
-                                      Container(
-                                        width: 2,
-                                        height: 22,
-                                        color: context.textColor.withValues(
-                                          alpha: _alphaHairline,
-                                        ),
-                                      ),
-                                  ],
-                                ),
+                                  ),
+                                  const SizedBox(width: 14),
+                                  Expanded(
+                                    child: Padding(
+                                      padding: const EdgeInsets.only(top: 6),
+                                      child: _timelineBody(context, item),
+                                    ),
+                                  ),
+                                ],
                               ),
-                              const SizedBox(width: 14),
-                              Expanded(
-                                child: Padding(
-                                  padding: const EdgeInsets.only(top: 6),
-                                  child: _timelineBody(context, item),
-                                ),
-                              ),
-                            ],
+                            ),
                           ),
                         ),
-                      ),
+                        // Outside the ink surface, aligned under the cover by
+                        // reusing the same padding and rail width.
+                        if (!isLast)
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 8),
+                            child: Row(
+                              children: [
+                                SizedBox(
+                                  width: 132,
+                                  child: Center(
+                                    child: Container(
+                                      width: 2,
+                                      height: 22,
+                                      color: context.textColor.withValues(
+                                        alpha: _alphaHairline,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                      ],
                     );
                   },
                 ),

--- a/test/widgets/cover_constraint_test.dart
+++ b/test/widgets/cover_constraint_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The watch order rail is a fixed width column holding each cover. A bare
+/// SizedBox(width:) hands its child a *tight* width, which silently overrides
+/// whatever width the cover asks for, so every cover renders at the rail width
+/// and only its height ever changes. Centring restores the cover's own width.
+Widget _rail({required bool centred}) {
+  const cover = SizedBox(
+    key: Key('cover'),
+    width: 100,
+    height: 146,
+  );
+  return MaterialApp(
+    home: Scaffold(
+      body: Row(
+        children: [
+          SizedBox(
+            width: 132,
+            child: centred ? const Center(child: cover) : cover,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('a bare rail stretches the cover to the rail width', (t) async {
+    await t.pumpWidget(_rail(centred: false));
+    final size = t.getSize(find.byKey(const Key('cover')));
+    expect(
+      size.width,
+      132,
+      reason: 'tight constraint wins over the cover width',
+    );
+    expect(size.height, 146);
+  });
+
+  testWidgets('centring lets the cover keep its own width and aspect', (
+    t,
+  ) async {
+    await t.pumpWidget(_rail(centred: true));
+    final size = t.getSize(find.byKey(const Key('cover')));
+    expect(size.width, 100);
+    expect(size.height, 146);
+    expect(size.width / size.height, closeTo(0.685, 0.001));
+  });
+}


### PR DESCRIPTION
Two screens that were hard to use, found while testing on a simulator and on desktop.

## Watch order

The timeline always started at the top. Mid way through a long franchise that looks like the beginning of the list, hiding that there are earlier entries above and later ones below. The current entry is now scrolled into view on open, with the previous one left partly visible so it reads as "there is more in both directions". On TV the remote lands on that entry too, instead of row 0. No offsets are computed: `Scrollable.ensureVisible` does it, and it is a no-op when the current entry is already first or the list is too short to scroll.

The focus tint covered the connector stub, painting a square block down the rail and closing the gap between rows. The connector is now drawn outside the ink surface, and the tint is rounded and clipped.

**The covers were never the size they asked for.** Each sat directly inside `SizedBox(width: 132)`, which hands its child a tight width, so every cover rendered 132 wide and only the height ever varied. That is why they looked near square and why changing the widths appeared to do nothing. Centring the cover in the rail restores its own width. The aspect now comes from the artwork rather than being picked: AniList serves these at 230x320, so the box uses `320 / 230` and `BoxFit.cover` has nothing left to crop. There is a test for the constraint, because the failure is invisible in the source: the widget asks for one width and silently gets another.

## Global search

A source that failed held a full 260px slot showing an error panel and a Retry, and a source that found nothing held the same slot to say so, so a few broken extensions pushed the sources that did return results off the screen.

Both are the same non-event to someone scanning results. They are now kept out of the list and collected into one collapsed group at the bottom. The rows stay mounted and render nothing, so nothing refetches and the group fills in as each source resolves.

The retry is gone from here. It made sense on a single screen, which is where the shared `ErrorState` came from, but not for one source among many: these are almost always a broken extension returning the same error every time, not a transient blip. Each row in the group keeps its reason, since that is the only clue about which extension is broken, and still opens the source.

Also fixes every row sharing `key: ValueKey(query)`, which is not a valid sibling key, and drops a per row `Scaffo
<img width="415" height="783" alt="Screenshot 2026-08-14 at 5 08 31 pm" src="https://github.com/user-attachments/assets/14ec9aef-b7aa-4259-8258-102f73f4cab7" />
ld` that forced the row to expand. Adds one plural string for the group header.

Verified on an iPhone 17 Pro simulator and on a macOS build. `flutter analyze` clean, `flutter test` passes.



<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-14 at 19 50 49" src="https://github.com/user-attachments/assets/14dfde4e-033f-41c3-a14a-f2c215a8f80a" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-14 at 19 51 00" src="https://github.com/user-attachments/assets/3ec0bb2d-7e68-45bd-905f-f59f529ed14f" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-14 at 19 51 07" src="https://github.com/user-attachments/assets/83cd8e16-bacd-4add-84b4-9c6c4faf534b" />
