### PR TITLE
fix: guard the native assets hook before reading code config

### DIFF
--- a/hook/build.dart
+++ b/hook/build.dart
@@ -4,6 +4,11 @@ import 'package:code_assets/code_assets.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
+    // The hook is also invoked when code assets are not being built, and
+    // reading input.config.code in that case throws, which fails the whole
+    // build rather than skipping the native library.
+    if (!input.config.buildCodeAssets) return;
+
     final builder = CBuilder.library(
       name: 'subsampling_scale_image_view',
       assetName: 'subsampling_scale_image_view.dart',


### PR DESCRIPTION
`hook/build.dart` reads `input.config.code` unconditionally. The hook also runs when code assets are not being built, and reading that config then throws, which fails the whole build rather than skipping the native library:

```
Unhandled exception:
Bad state: HookConfig.code should only be accessed when building code assets.
Check HookConfig.buildCodeAssets (e.g. `input.config.buildCodeAssets`) before
accessing HookConfig.code.
#1  main.<anonymous closure> (file:///.../hook/build.dart:13:26)

Building native assets failed.
```

Guarded with `input.config.buildCodeAssets`, which is what the error asks for. When code assets are being built nothing changes, so the native library is built exactly as before.

Easy to miss because a warm build does not re-run the hook. It surfaces after the build cache is cleared, or on a fresh clone.

Reproduced and verified on an iOS simulator build with Flutter 3.47: before the guard the build fails with the above and installs nothing; after it, the build completes and installs normally.
