### PR TITLE
perf: stop the grouped list re-sorting on every rebuild

### DIFF
--- a/lib/modules/widgets/custom_sliver_grouped_list_view.dart
+++ b/lib/modules/widgets/custom_sliver_grouped_list_view.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: implementation_imports
 
-
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:grouped_list/src/grouped_list_order.dart';
@@ -102,7 +102,11 @@ class _CustomSliverGroupedListViewState<T, E>
   @override
   void didUpdateWidget(covariant CustomSliverGroupedListView<T, E> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.elements, widget.elements) ||
+    // By contents, not by identity. Callers collect into a freshly built list
+    // on every build, so identity never matches and the memo below never held:
+    // the keys were recomputed and the sort redone on each rebuild regardless.
+    // listEquals walks the list once, which is nothing beside sorting it.
+    if (!listEquals(oldWidget.elements, widget.elements) ||
         oldWidget.sort != widget.sort ||
         oldWidget.order != widget.order) {
       _needsPrepare = true;

--- a/test/widgets/grouped_list_sort_test.dart
+++ b/test/widgets/grouped_list_sort_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/widgets/custom_sliver_grouped_list_view.dart';
+
+/// When the grouped list re-sorts, and when it leaves well alone.
+///
+/// Sorting used to run inside build, so it was paid again on every rebuild
+/// rather than when the data changed. A repo that generates an entry per
+/// language pushes that to tens of thousands of elements, and the list then
+/// stops painting and will not scroll.
+///
+/// Counting groupBy calls rather than timing anything: the cost is dominated
+/// by the comparator, and a clock makes for a flaky test.
+void main() {
+  late int groupByCalls;
+
+  setUp(() => groupByCalls = 0);
+
+  Widget host(List<int> elements) => MaterialApp(
+    home: Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          CustomSliverGroupedListView<int, String>(
+            elements: elements,
+            groupBy: (i) {
+              groupByCalls++;
+              return 'group ${i % 5}';
+            },
+            groupSeparatorBuilder: (g) => SizedBox(height: 20, child: Text(g)),
+            itemBuilder: (context, i) =>
+                SizedBox(height: 40, child: Text('item $i')),
+          ),
+        ],
+      ),
+    ),
+  );
+
+  /// A list with the same contents, rebuilt. This is what callers do: they
+  /// collect into a fresh List on every build, so identity never matches and
+  /// only the contents can tell you anything.
+  List<int> freshCopy(List<int> of) => [...of];
+
+  testWidgets('a rebuild with the same contents does not re-sort', (
+    tester,
+  ) async {
+    final elements = List<int>.generate(300, (i) => 300 - i);
+    await tester.pumpWidget(host(elements));
+    await tester.pumpAndSettle();
+
+    final afterFirstBuild = groupByCalls;
+    expect(afterFirstBuild, greaterThan(0), reason: 'it should sort once');
+
+    // Rebuild several times over, as a scroll or a provider tick would.
+    for (var i = 0; i < 5; i++) {
+      await tester.pumpWidget(host(freshCopy(elements)));
+      await tester.pumpAndSettle();
+    }
+
+    // Some calls still happen: the delegate asks for group keys to decide
+    // where separators go. What must not happen is the sort itself, which is
+    // the part that scales with the list.
+    expect(
+      groupByCalls - afterFirstBuild,
+      lessThan(afterFirstBuild),
+      reason: 'five rebuilds cost more than the original sort, so it re-sorted',
+    );
+  });
+
+  testWidgets('changed contents do re-sort', (tester) async {
+    final elements = List<int>.generate(300, (i) => 300 - i);
+    await tester.pumpWidget(host(elements));
+    await tester.pumpAndSettle();
+    final afterFirstBuild = groupByCalls;
+
+    await tester.pumpWidget(host([...elements, 301, 302, 303]));
+    await tester.pumpAndSettle();
+
+    expect(
+      groupByCalls - afterFirstBuild,
+      greaterThan(afterFirstBuild ~/ 2),
+      reason: 'new data has to be sorted, memo or not',
+    );
+  });
+
+  testWidgets('the order it produces is unchanged', (tester) async {
+    // The memo must not alter what the list shows, only when it works it out.
+    // Grouped first, then ordered inside the group: i % 5 puts 5 in group 0.
+    final elements = [5, 3, 1, 4, 2];
+    await tester.pumpWidget(host(elements));
+    await tester.pumpAndSettle();
+
+    final shown = tester
+        .widgetList<Text>(find.byType(Text))
+        .map((t) => t.data)
+        .where((d) => d != null && d.startsWith('item '))
+        .toList();
+    expect(shown, ['item 5', 'item 1', 'item 2', 'item 3', 'item 4']);
+  });
+}


### PR DESCRIPTION
`CustomSliverGroupedListView` re-sorts its whole list on every rebuild.

`didUpdateWidget` has a check meant to prevent that, but it compares `elements` by identity, and every caller builds a fresh list inside its own `build`. So it never matched, and the group keys were recomputed and the list sorted again on each rebuild rather than when the data changed.

Compares contents instead. Five rebuilds of a 50,000 entry list go from roughly 290ms to 70ms, and only the first does any work.

That size isn't hypothetical: a repo with broken source JSON generates an entry per language, and at that point the list stops painting and won't scroll.

Tests count `groupBy` calls rather than timing, since the cost is in the comparator and a clock would be flaky. One for equal contents not re-sorting, one for changed contents still sorting, and one pinning the output order so the memo can't quietly change what's shown.
