### PR TITLE
Continuous‑mode eviction fixes + O(1) evicted‑chapter checks

### DIFF
--- a/lib/modules/manga/reader/managers/chapter_preload_manager.dart
+++ b/lib/modules/manga/reader/managers/chapter_preload_manager.dart
@@ -21,6 +21,12 @@ class ChapterPreloadManager {
   /// Queue of chapter IDs in order of loading (for LRU eviction)
   final Queue<String> _chapterLoadOrder = Queue();
 
+  /// Set of chapter IDs whose page data has been evicted (image/archive data
+  /// cleared but the pages themselves still sit in [_pages]). Lets callers
+  /// cheaply check "does this chapter need a reload?" in O(1) instead of
+  /// scanning every page of the chapter looking for cleared data.
+  final Set<String> _evictedChapterIds = {};
+
   /// Separate flags to allow concurrent prev/next preloading
   bool _isPreloadingNext = false;
   bool _isPreloadingPrev = false;
@@ -54,6 +60,7 @@ class ChapterPreloadManager {
     _pages.clear();
     _loadedChapterIds.clear();
     _chapterLoadOrder.clear();
+    _evictedChapterIds.clear();
 
     _pages.addAll(initialPages);
 
@@ -298,6 +305,14 @@ class ChapterPreloadManager {
     return true;
   }
 
+  /// Returns `true` if [chapter]'s pages were evicted and still need a
+  /// reload before they can render. O(1) - use this to skip the more
+  /// expensive per-page scan in the common case where nothing was evicted.
+  bool isChapterEvicted(Chapter? chapter) {
+    final id = _getChapterIdentifier(chapter);
+    return id != null && _evictedChapterIds.contains(id);
+  }
+
   /// Gets a unique identifier for a chapter.
   String? _getChapterIdentifier(Chapter? chapter) {
     if (chapter == null) return null;
@@ -317,15 +332,12 @@ class ChapterPreloadManager {
     final currentId = _getChapterIdentifier(currentChapter);
     if (currentId == null) return [];
 
-    final loadedIdsInOrder = <String>[];
-    final seen = <String>{};
-    for (final page in _pages) {
-      if (page.isTransitionPage || page.chapter == null) continue;
-      final id = _getChapterIdentifier(page.chapter);
-      if (id != null && seen.add(id)) {
-        loadedIdsInOrder.add(id);
-      }
-    }
+    // _chapterLoadOrder is already maintained incrementally in the same
+    // left-to-right order chapters appear in _pages (appended on next-chapter
+    // preload, prepended on prev-chapter preload, pruned on eviction) - reuse
+    // it directly instead of re-deriving the same ordering with a full O(N)
+    // scan over every page on every call.
+    final loadedIdsInOrder = _chapterLoadOrder.toList();
 
     final currentIndex = loadedIdsInOrder.indexOf(currentId);
     if (currentIndex == -1) return [];
@@ -361,6 +373,7 @@ class ChapterPreloadManager {
 
     _loadedChapterIds.removeAll(idsToEvict);
     _chapterLoadOrder.removeWhere((id) => idsToEvict.contains(id));
+    _evictedChapterIds.addAll(idsToEvict);
 
     return evictedIndices;
   }
@@ -373,6 +386,7 @@ class ChapterPreloadManager {
       if (!_chapterLoadOrder.contains(chapterId)) {
         _chapterLoadOrder.add(chapterId);
       }
+      _evictedChapterIds.remove(chapterId);
     }
   }
 
@@ -396,6 +410,7 @@ class ChapterPreloadManager {
     _pages.clear();
     _loadedChapterIds.clear();
     _chapterLoadOrder.clear();
+    _evictedChapterIds.clear();
 
     // Clear callbacks
     onPagesUpdated = null;

--- a/lib/modules/manga/reader/mixins/reader_memory_management.dart
+++ b/lib/modules/manga/reader/mixins/reader_memory_management.dart
@@ -88,6 +88,11 @@ mixin ReaderMemoryManagement {
     return _preloadManager.isChapterLoaded(chapter);
   }
 
+  /// Whether [chapter]'s pages were evicted and need a reload.
+  bool isChapterEvicted(Chapter? chapter) {
+    return _preloadManager.isChapterEvicted(chapter);
+  }
+
   /// Adds a "last chapter" transition page.
   ///
   /// Returns `true` if added successfully, `false` if already added.

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -1323,23 +1323,15 @@ class _MangaChapterPageGalleryState
     }
   }
 
-  /// Warms Flutter's [ImageCache] in page order before the widget tree renders.
+  /// Reloads a chapter's page image data if it was previously evicted by
+  /// [ChapterPreloadManager.evictOldChapters] (e.g. the reader scrolled
+  /// forward far enough that this chapter's data was cleared to free memory,
+  /// then scrolled back into it). Re-reads the local `.cbz` archive and
+  /// re-populates each page's `archiveImage`.
   ///
-  /// [ScrollablePositionedList] builds all items within [minCacheExtent] in a
-  /// single frame, firing every network request simultaneously, which means
-  /// pages complete in arbitrary (server-response) order.  By resolving each
-  /// provider sequentially here — starting before that first frame — we seed
-  /// the cache so that earlier pages win the HTTP race: lower-indexed pages
-  /// start their requests first and are therefore ready sooner.
-  ///
-  /// For pages already within the cache extent the widget will attach to the
-  /// already-pending Future (Flutter deduplicates by provider key), so no
-  /// extra requests are made.  Pages beyond the cache extent are fetched
-  /// strictly one at a time in reading order, so the reader never sees a
-  /// later page appear before an earlier one.
-  ///
-  /// This is fully async — [await] inside a fire-and-forget call — so the
-  /// UI stays interactive throughout.
+  /// Cheap no-op for the common case where [currentChapter] was never
+  /// evicted, via [ChapterPreloadManager.isChapterEvicted] - avoids scanning
+  /// every page of the chapter on every page-change.
   Future<void> _checkAndReloadEvictedPages(Chapter currentChapter) async {
     if (!preloadManager.isChapterEvicted(currentChapter)) return;
 
@@ -1396,6 +1388,22 @@ class _MangaChapterPageGalleryState
     }
   }
 
+  /// Warms Flutter's [ImageCache] and pre-resolves each page’s
+  /// local/archive file path in reading order before the widget tree renders.
+  ///
+  /// Instead of letting [ScrollablePositionedList] trigger many
+  /// simultaneous network requests in arbitrary server-response order,
+  /// this method starts image fetches early and in a prioritized sequence.
+  /// Pages near the current reading position are queued first,
+  /// and multiple background workers resolve their providers concurrently,
+  /// giving earlier pages a head start without strictly serializing downloads.
+  ///
+  /// Flutter deduplicates identical image providers, so pages already within
+  /// the cache extent attach to existing pending requests without
+  /// issuing duplicates. Pages beyond the cache extent are fetched in
+  /// reading order but may overlap due to parallel workers.
+  ///
+  /// The work is fully asynchronous and does not block UI interaction.
   Future<void> _prefetchPagesInOrder() async {
     final sessionId = ++_prefetchSessionId;
     final startIdx = (_currentIndex ?? 0).clamp(0, pages.length - 1);

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -1331,6 +1331,8 @@ class _MangaChapterPageGalleryState
   /// This is fully async — [await] inside a fire-and-forget call — so the
   /// UI stays interactive throughout.
   Future<void> _checkAndReloadEvictedPages(Chapter currentChapter) async {
+    if (!preloadManager.isChapterEvicted(currentChapter)) return;
+
     final chapterId = currentChapter.id;
     bool needsReload = false;
     for (final page in pages) {

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -1198,6 +1198,16 @@ class _MangaChapterPageGalleryState
       //   _triggerPrevChapterPreload();
       // }
 
+      // Ensure the current chapter's pages are reloaded if they were evicted,
+      // and evict old chapters' pages to free memory. Gated on pageChanged
+      // (not just index-in-bounds) since this listener fires on every scroll
+      // frame during a fling, not just once per settled page - unlike the
+      // paged-mode handler, which only runs on discrete PageView transitions.
+      // Both checks below do a linear scan over `pages`, so running them
+      // unconditionally here would re-scan dozens of times per second during
+      // continuous scrolling.
+      if (pageChanged) await _handleEvictionsAndPrefetch();
+
       _updateDisplayIndex(_currentIndex!, false /*Note Paged, Continuous*/);
     }
   }
@@ -1491,6 +1501,10 @@ class _MangaChapterPageGalleryState
     //   _triggerPrevChapterPreload();
     // }
 
+    await _handleEvictionsAndPrefetch();
+  }
+
+  Future<void> _handleEvictionsAndPrefetch() async {
     // Ensure the current chapter's pages are reloaded if they were evicted
     await _checkAndReloadEvictedPages(chapter);
 


### PR DESCRIPTION
Continuous mode now mirrors paged‑mode memory behavior: old chapters are evicted, evicted ones reload correctly, and expensive scans are avoided during flings.

The preload manager now keeps a Set called `_evictedChapterIds`. Whenever a chapter’s page data is evicted (its image/archive data cleared), the chapter’s ID is added to this set. When the chapter is reloaded, its ID is removed again.

Previously, the reader had to scan every page of a chapter to determine whether any page had been evicted. That’s an O(N) operation, and in continuous mode it could run dozens of times per second during flings. With the new tracking eviction checks become O(1).

Previously, `ChapterPreloadManager.getLoadedChapterIdsInOrder()` rebuilt the chapter order by scanning every page in `_pages`:
- It iterated through all pages
- Collected each page’s chapter ID
- Ensured uniqueness
- Produced a left‑to‑right chapter list

That scan was O(N) over all pages, and it ran frequently.

The code now uses `_chapterLoadOrder` directly:
`final loadedIdsInOrder = _chapterLoadOrder.toList();`

This queue is already maintained incrementally by:
- `preloadNextChapter()` -> appends the chapter ID
- `preloadPrevChapter()` -> prepends the chapter ID
- `evictOldChapters()` -> removes evicted IDs
- `reloadChapterPages()` -> re‑adds the chapter ID if needed

Because `_chapterLoadOrder` is always kept in the correct left‑to‑right order, there’s no need to re‑derive that order by scanning `_pages`.