### PR TITLE
Db restore improvements

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1116,6 +1116,12 @@
       "description": {}
     }
   },
+  "roll_back_available_count": "{count} recent changes available to roll back to",
+  "@roll_back_available_count": {
+    "placeholders": {
+      "count": {}
+    }
+  },
   "delete_source_title": "Delete a source & its manga",
   "delete_source_subtitle": "Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.",
   "delete_source_pick_title": "Pick a source to delete",
@@ -1126,17 +1132,18 @@
       "sourceName": {}
     }
   },
-  "delete_source_confirm_message": "This permanently deletes {mangaCount} manga, {chapterCount} chapters, {historyCount} history entries, {updateCount} update entries and {trackCount} tracking links. This cannot be undone except by rolling back.",
+  "delete_source_confirm_message": "This permanently deletes {mangaCount} manga, {chapterCount} chapters, {historyCount} history entries and {updateCount} update entries. Tracking links are kept. This cannot be undone except by rolling back.",
   "@delete_source_confirm_message": {
     "placeholders": {
       "mangaCount": {},
       "chapterCount": {},
       "historyCount": {},
-      "updateCount": {},
-      "trackCount": {}
+      "updateCount": {}
     }
   },
   "delete_source_also_remove_extension": "Also remove the installed extension",
+  "delete_source_keep_history": "Keep reading history",
+  "delete_source_keep_downloads": "Keep download records",
   "delete_source_button": "Delete",
   "delete_source_result_message": "Deleted {mangaCount} manga from {sourceName}.",
   "@delete_source_result_message": {
@@ -1145,18 +1152,36 @@
       "sourceName": {}
     }
   },
-  "merge_sources_title": "Merge duplicate sources",
-  "merge_sources_subtitle": "Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.",
-  "merge_sources_none_found": "No likely duplicate sources found.",
-  "merge_sources_pick_title": "Possible duplicates",
-  "merge_sources_choose_primary_title": "Which one should the others merge into?",
-  "merge_sources_choose_primary_message": "The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.",
-  "merge_sources_button": "Merge",
-  "merge_sources_result_message": "Merged {mangaCount} manga into {sourceName}.",
-  "@merge_sources_result_message": {
+  "merge_manga_title": "Merge duplicate manga",
+  "merge_manga_subtitle": "Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you'd want kept.",
+  "merge_manga_none_found": "No likely duplicate manga found.",
+  "merge_manga_pick_title": "Possible duplicate manga",
+  "merge_manga_choose_primary_title": "Which one should the others merge into?",
+  "merge_manga_choose_primary_message": "Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.",
+  "merge_manga_chapters_subtitle": "{count, plural, =1{1 chapter} other{{count} chapters}}",
+  "@merge_manga_chapters_subtitle": {
     "placeholders": {
-      "mangaCount": {},
-      "sourceName": {}
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge_manga_button": "Merge",
+  "merge_manga_result_message": "Merged {count} duplicate manga into {mangaName}.",
+  "@merge_manga_result_message": {
+    "placeholders": {
+      "count": {},
+      "mangaName": {}
+    }
+  },
+  "merge_preview_title": "Confirm merge",
+  "merge_manga_preview_message": "{totalChapters} chapters found across the other entries. {duplicateChapters} are duplicates and will be dropped (keeping whichever copy has reading progress); {keptChapters} will be added. {duplicateTracks} duplicate tracking link(s) will also be dropped.",
+  "@merge_manga_preview_message": {
+    "placeholders": {
+      "totalChapters": {},
+      "duplicateChapters": {},
+      "keptChapters": {},
+      "duplicateTracks": {}
     }
   },
   "beta": "Beta"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1057,5 +1057,107 @@
         "type": "int"
       }
     }
-  }
+  },
+  "import_mode_title": "How should this be imported?",
+  "import_mode_message": "Choose whether to merge this backup into your current library, or replace your entire library with it.",
+  "import_mode_keep_existing": "Merge",
+  "import_mode_keep_existing_subtitle": "Adds new series and updates matching ones. Nothing in your current library is removed.",
+  "import_mode_replace": "Replace",
+  "import_mode_replace_subtitle": "Deletes your entire current library and replaces it with this backup.",
+  "replace_summary_title": "Ready to replace your library",
+  "replace_summary_message": "This deletes your entire current library ({currentCount} series) and replaces it with {backupCount} series from this backup. This can only be undone by rolling back.",
+  "@replace_summary_message": {
+    "placeholders": {
+      "currentCount": {},
+      "backupCount": {}
+    }
+  },
+  "replace_summary_confirm": "Replace",
+  "replace_result_message": "Replaced your library with {count} series from this backup.",
+  "@replace_result_message": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "category_conflict_title": "Existing categories found",
+  "category_conflict_message": "The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.",
+  "category_conflict_keep": "Keep — merge into existing category",
+  "category_conflict_delete": "Delete — leave series uncategorized",
+  "source_conflict_title": "Sources not found",
+  "source_conflict_message": "These backup sources don't match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.",
+  "source_conflict_keep": "Keep original name (no live source)",
+  "import_summary_title": "Ready to import",
+  "import_summary_message": "{newSeries} new series, {updatedSeries} existing series will be updated, and {newChapters} new chapters will be added. Nothing already in your library will be removed.",
+  "@import_summary_message": {
+    "placeholders": {
+      "newSeries": {},
+      "updatedSeries": {},
+      "newChapters": {}
+    }
+  },
+  "import_summary_confirm": "Import",
+  "import_result_message": "Imported {newSeries} new series, updated {updatedSeries} existing, added {newChapters} new chapters.",
+  "@import_result_message": {
+    "placeholders": {
+      "newSeries": {},
+      "updatedSeries": {},
+      "newChapters": {}
+    }
+  },
+  "roll_back": "Roll back",
+  "roll_back_confirm_message": "This restores your library to the safety snapshot taken right before this change, undoing everything it just did.",
+  "roll_back_done": "Rolled back to the pre-change snapshot.",
+  "restoring_backup": "Restoring your library…",
+  "roll_back_last_change": "Roll back last change",
+  "roll_back_last_change_subtitle": "Snapshot from {date} — {description}",
+  "@roll_back_last_change_subtitle": {
+    "placeholders": {
+      "date": {},
+      "description": {}
+    }
+  },
+  "delete_source_title": "Delete a source & its manga",
+  "delete_source_subtitle": "Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.",
+  "delete_source_pick_title": "Pick a source to delete",
+  "delete_source_empty": "No sources found in your library.",
+  "delete_source_confirm_title": "Delete {sourceName}?",
+  "@delete_source_confirm_title": {
+    "placeholders": {
+      "sourceName": {}
+    }
+  },
+  "delete_source_confirm_message": "This permanently deletes {mangaCount} manga, {chapterCount} chapters, {historyCount} history entries, {updateCount} update entries and {trackCount} tracking links. This cannot be undone except by rolling back.",
+  "@delete_source_confirm_message": {
+    "placeholders": {
+      "mangaCount": {},
+      "chapterCount": {},
+      "historyCount": {},
+      "updateCount": {},
+      "trackCount": {}
+    }
+  },
+  "delete_source_also_remove_extension": "Also remove the installed extension",
+  "delete_source_button": "Delete",
+  "delete_source_result_message": "Deleted {mangaCount} manga from {sourceName}.",
+  "@delete_source_result_message": {
+    "placeholders": {
+      "mangaCount": {},
+      "sourceName": {}
+    }
+  },
+  "merge_sources_title": "Merge duplicate sources",
+  "merge_sources_subtitle": "Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.",
+  "merge_sources_none_found": "No likely duplicate sources found.",
+  "merge_sources_pick_title": "Possible duplicates",
+  "merge_sources_choose_primary_title": "Which one should the others merge into?",
+  "merge_sources_choose_primary_message": "The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.",
+  "merge_sources_button": "Merge",
+  "merge_sources_result_message": "Merged {mangaCount} manga into {sourceName}.",
+  "@merge_sources_result_message": {
+    "placeholders": {
+      "mangaCount": {},
+      "sourceName": {}
+    }
+  },
+  "beta": "Beta"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -5008,6 +5008,290 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{1 source with no results} other{{count} sources with no results}}'**
   String sources_with_no_results(int count);
+
+  /// No description provided for @import_mode_title.
+  ///
+  /// In en, this message translates to:
+  /// **'How should this be imported?'**
+  String get import_mode_title;
+
+  /// No description provided for @import_mode_message.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose whether to merge this backup into your current library, or replace your entire library with it.'**
+  String get import_mode_message;
+
+  /// No description provided for @import_mode_keep_existing.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge'**
+  String get import_mode_keep_existing;
+
+  /// No description provided for @import_mode_keep_existing_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Adds new series and updates matching ones. Nothing in your current library is removed.'**
+  String get import_mode_keep_existing_subtitle;
+
+  /// No description provided for @import_mode_replace.
+  ///
+  /// In en, this message translates to:
+  /// **'Replace'**
+  String get import_mode_replace;
+
+  /// No description provided for @import_mode_replace_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Deletes your entire current library and replaces it with this backup.'**
+  String get import_mode_replace_subtitle;
+
+  /// No description provided for @replace_summary_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Ready to replace your library'**
+  String get replace_summary_title;
+
+  /// No description provided for @replace_summary_message.
+  ///
+  /// In en, this message translates to:
+  /// **'This deletes your entire current library ({currentCount} series) and replaces it with {backupCount} series from this backup. This can only be undone by rolling back.'**
+  String replace_summary_message(Object currentCount, Object backupCount);
+
+  /// No description provided for @replace_summary_confirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Replace'**
+  String get replace_summary_confirm;
+
+  /// No description provided for @replace_result_message.
+  ///
+  /// In en, this message translates to:
+  /// **'Replaced your library with {count} series from this backup.'**
+  String replace_result_message(Object count);
+
+  /// No description provided for @category_conflict_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Existing categories found'**
+  String get category_conflict_title;
+
+  /// No description provided for @category_conflict_message.
+  ///
+  /// In en, this message translates to:
+  /// **'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.'**
+  String get category_conflict_message;
+
+  /// No description provided for @category_conflict_keep.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep — merge into existing category'**
+  String get category_conflict_keep;
+
+  /// No description provided for @category_conflict_delete.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete — leave series uncategorized'**
+  String get category_conflict_delete;
+
+  /// No description provided for @source_conflict_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Sources not found'**
+  String get source_conflict_title;
+
+  /// No description provided for @source_conflict_message.
+  ///
+  /// In en, this message translates to:
+  /// **'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.'**
+  String get source_conflict_message;
+
+  /// No description provided for @source_conflict_keep.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep original name (no live source)'**
+  String get source_conflict_keep;
+
+  /// No description provided for @import_summary_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Ready to import'**
+  String get import_summary_title;
+
+  /// No description provided for @import_summary_message.
+  ///
+  /// In en, this message translates to:
+  /// **'{newSeries} new series, {updatedSeries} existing series will be updated, and {newChapters} new chapters will be added. Nothing already in your library will be removed.'**
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  );
+
+  /// No description provided for @import_summary_confirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Import'**
+  String get import_summary_confirm;
+
+  /// No description provided for @import_result_message.
+  ///
+  /// In en, this message translates to:
+  /// **'Imported {newSeries} new series, updated {updatedSeries} existing, added {newChapters} new chapters.'**
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  );
+
+  /// No description provided for @roll_back.
+  ///
+  /// In en, this message translates to:
+  /// **'Roll back'**
+  String get roll_back;
+
+  /// No description provided for @roll_back_confirm_message.
+  ///
+  /// In en, this message translates to:
+  /// **'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.'**
+  String get roll_back_confirm_message;
+
+  /// No description provided for @roll_back_done.
+  ///
+  /// In en, this message translates to:
+  /// **'Rolled back to the pre-change snapshot.'**
+  String get roll_back_done;
+
+  /// No description provided for @restoring_backup.
+  ///
+  /// In en, this message translates to:
+  /// **'Restoring your library…'**
+  String get restoring_backup;
+
+  /// No description provided for @roll_back_last_change.
+  ///
+  /// In en, this message translates to:
+  /// **'Roll back last change'**
+  String get roll_back_last_change;
+
+  /// No description provided for @roll_back_last_change_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Snapshot from {date} — {description}'**
+  String roll_back_last_change_subtitle(Object date, Object description);
+
+  /// No description provided for @delete_source_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete a source & its manga'**
+  String get delete_source_title;
+
+  /// No description provided for @delete_source_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.'**
+  String get delete_source_subtitle;
+
+  /// No description provided for @delete_source_pick_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick a source to delete'**
+  String get delete_source_pick_title;
+
+  /// No description provided for @delete_source_empty.
+  ///
+  /// In en, this message translates to:
+  /// **'No sources found in your library.'**
+  String get delete_source_empty;
+
+  /// No description provided for @delete_source_confirm_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete {sourceName}?'**
+  String delete_source_confirm_title(Object sourceName);
+
+  /// No description provided for @delete_source_confirm_message.
+  ///
+  /// In en, this message translates to:
+  /// **'This permanently deletes {mangaCount} manga, {chapterCount} chapters, {historyCount} history entries, {updateCount} update entries and {trackCount} tracking links. This cannot be undone except by rolling back.'**
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  );
+
+  /// No description provided for @delete_source_also_remove_extension.
+  ///
+  /// In en, this message translates to:
+  /// **'Also remove the installed extension'**
+  String get delete_source_also_remove_extension;
+
+  /// No description provided for @delete_source_button.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get delete_source_button;
+
+  /// No description provided for @delete_source_result_message.
+  ///
+  /// In en, this message translates to:
+  /// **'Deleted {mangaCount} manga from {sourceName}.'**
+  String delete_source_result_message(Object mangaCount, Object sourceName);
+
+  /// No description provided for @merge_sources_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge duplicate sources'**
+  String get merge_sources_title;
+
+  /// No description provided for @merge_sources_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.'**
+  String get merge_sources_subtitle;
+
+  /// No description provided for @merge_sources_none_found.
+  ///
+  /// In en, this message translates to:
+  /// **'No likely duplicate sources found.'**
+  String get merge_sources_none_found;
+
+  /// No description provided for @merge_sources_pick_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Possible duplicates'**
+  String get merge_sources_pick_title;
+
+  /// No description provided for @merge_sources_choose_primary_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Which one should the others merge into?'**
+  String get merge_sources_choose_primary_title;
+
+  /// No description provided for @merge_sources_choose_primary_message.
+  ///
+  /// In en, this message translates to:
+  /// **'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.'**
+  String get merge_sources_choose_primary_message;
+
+  /// No description provided for @merge_sources_button.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge'**
+  String get merge_sources_button;
+
+  /// No description provided for @merge_sources_result_message.
+  ///
+  /// In en, this message translates to:
+  /// **'Merged {mangaCount} manga into {sourceName}.'**
+  String merge_sources_result_message(Object mangaCount, Object sourceName);
+
+  /// No description provided for @beta.
+  ///
+  /// In en, this message translates to:
+  /// **'Beta'**
+  String get beta;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -5179,6 +5179,12 @@ abstract class AppLocalizations {
   /// **'Snapshot from {date} — {description}'**
   String roll_back_last_change_subtitle(Object date, Object description);
 
+  /// No description provided for @roll_back_available_count.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} recent changes available to roll back to'**
+  String roll_back_available_count(Object count);
+
   /// No description provided for @delete_source_title.
   ///
   /// In en, this message translates to:
@@ -5212,13 +5218,12 @@ abstract class AppLocalizations {
   /// No description provided for @delete_source_confirm_message.
   ///
   /// In en, this message translates to:
-  /// **'This permanently deletes {mangaCount} manga, {chapterCount} chapters, {historyCount} history entries, {updateCount} update entries and {trackCount} tracking links. This cannot be undone except by rolling back.'**
+  /// **'This permanently deletes {mangaCount} manga, {chapterCount} chapters, {historyCount} history entries and {updateCount} update entries. Tracking links are kept. This cannot be undone except by rolling back.'**
   String delete_source_confirm_message(
     Object mangaCount,
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   );
 
   /// No description provided for @delete_source_also_remove_extension.
@@ -5226,6 +5231,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Also remove the installed extension'**
   String get delete_source_also_remove_extension;
+
+  /// No description provided for @delete_source_keep_history.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep reading history'**
+  String get delete_source_keep_history;
+
+  /// No description provided for @delete_source_keep_downloads.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep download records'**
+  String get delete_source_keep_downloads;
 
   /// No description provided for @delete_source_button.
   ///
@@ -5239,53 +5256,76 @@ abstract class AppLocalizations {
   /// **'Deleted {mangaCount} manga from {sourceName}.'**
   String delete_source_result_message(Object mangaCount, Object sourceName);
 
-  /// No description provided for @merge_sources_title.
+  /// No description provided for @merge_manga_title.
   ///
   /// In en, this message translates to:
-  /// **'Merge duplicate sources'**
-  String get merge_sources_title;
+  /// **'Merge duplicate manga'**
+  String get merge_manga_title;
 
-  /// No description provided for @merge_sources_subtitle.
+  /// No description provided for @merge_manga_subtitle.
   ///
   /// In en, this message translates to:
-  /// **'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.'**
-  String get merge_sources_subtitle;
+  /// **'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.'**
+  String get merge_manga_subtitle;
 
-  /// No description provided for @merge_sources_none_found.
+  /// No description provided for @merge_manga_none_found.
   ///
   /// In en, this message translates to:
-  /// **'No likely duplicate sources found.'**
-  String get merge_sources_none_found;
+  /// **'No likely duplicate manga found.'**
+  String get merge_manga_none_found;
 
-  /// No description provided for @merge_sources_pick_title.
+  /// No description provided for @merge_manga_pick_title.
   ///
   /// In en, this message translates to:
-  /// **'Possible duplicates'**
-  String get merge_sources_pick_title;
+  /// **'Possible duplicate manga'**
+  String get merge_manga_pick_title;
 
-  /// No description provided for @merge_sources_choose_primary_title.
+  /// No description provided for @merge_manga_choose_primary_title.
   ///
   /// In en, this message translates to:
   /// **'Which one should the others merge into?'**
-  String get merge_sources_choose_primary_title;
+  String get merge_manga_choose_primary_title;
 
-  /// No description provided for @merge_sources_choose_primary_message.
+  /// No description provided for @merge_manga_choose_primary_message.
   ///
   /// In en, this message translates to:
-  /// **'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.'**
-  String get merge_sources_choose_primary_message;
+  /// **'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.'**
+  String get merge_manga_choose_primary_message;
 
-  /// No description provided for @merge_sources_button.
+  /// No description provided for @merge_manga_chapters_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 chapter} other{{count} chapters}}'**
+  String merge_manga_chapters_subtitle(int count);
+
+  /// No description provided for @merge_manga_button.
   ///
   /// In en, this message translates to:
   /// **'Merge'**
-  String get merge_sources_button;
+  String get merge_manga_button;
 
-  /// No description provided for @merge_sources_result_message.
+  /// No description provided for @merge_manga_result_message.
   ///
   /// In en, this message translates to:
-  /// **'Merged {mangaCount} manga into {sourceName}.'**
-  String merge_sources_result_message(Object mangaCount, Object sourceName);
+  /// **'Merged {count} duplicate manga into {mangaName}.'**
+  String merge_manga_result_message(Object count, Object mangaName);
+
+  /// No description provided for @merge_preview_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm merge'**
+  String get merge_preview_title;
+
+  /// No description provided for @merge_manga_preview_message.
+  ///
+  /// In en, this message translates to:
+  /// **'{totalChapters} chapters found across the other entries. {duplicateChapters} are duplicates and will be dropped (keeping whichever copy has reading progress); {keptChapters} will be added. {duplicateTracks} duplicate tracking link(s) will also be dropped.'**
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  );
 
   /// No description provided for @beta.
   ///

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -2842,6 +2842,11 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2865,14 +2870,19 @@ class AppLocalizationsAr extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2883,32 +2893,56 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -2735,4 +2735,182 @@ class AppLocalizationsAr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -2843,6 +2843,11 @@ class AppLocalizationsAs extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2866,14 +2871,19 @@ class AppLocalizationsAs extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2884,32 +2894,56 @@ class AppLocalizationsAs extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -2736,4 +2736,182 @@ class AppLocalizationsAs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -2751,4 +2751,182 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -2858,6 +2858,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2881,14 +2886,19 @@ class AppLocalizationsDe extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2899,32 +2909,56 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -2728,4 +2728,182 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -2835,6 +2835,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2858,14 +2863,19 @@ class AppLocalizationsEn extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2876,32 +2886,56 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -2761,6 +2761,184 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -2868,6 +2868,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2891,14 +2896,19 @@ class AppLocalizationsEs extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2909,32 +2919,56 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -2869,6 +2869,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2892,14 +2897,19 @@ class AppLocalizationsFr extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2910,32 +2920,56 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -2762,4 +2762,182 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -2840,6 +2840,11 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2863,14 +2868,19 @@ class AppLocalizationsHi extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2881,32 +2891,56 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -2733,4 +2733,182 @@ class AppLocalizationsHi extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -2740,4 +2740,182 @@ class AppLocalizationsId extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -2847,6 +2847,11 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2870,14 +2875,19 @@ class AppLocalizationsId extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2888,32 +2898,56 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -2869,6 +2869,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2892,14 +2897,19 @@ class AppLocalizationsIt extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2910,32 +2920,56 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -2762,4 +2762,182 @@ class AppLocalizationsIt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -2695,4 +2695,182 @@ class AppLocalizationsJa extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -2802,6 +2802,11 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2825,14 +2830,19 @@ class AppLocalizationsJa extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2843,32 +2853,56 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -2756,6 +2756,184 @@ class AppLocalizationsPt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -2863,6 +2863,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2886,14 +2891,19 @@ class AppLocalizationsPt extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2904,32 +2914,56 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -2771,4 +2771,182 @@ class AppLocalizationsRu extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -2878,6 +2878,11 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2901,14 +2906,19 @@ class AppLocalizationsRu extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2919,32 +2929,56 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -2730,4 +2730,182 @@ class AppLocalizationsTh extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -2837,6 +2837,11 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2860,14 +2865,19 @@ class AppLocalizationsTh extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2878,32 +2888,56 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -2849,6 +2849,11 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2872,14 +2877,19 @@ class AppLocalizationsTr extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2890,32 +2900,56 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -2742,4 +2742,182 @@ class AppLocalizationsTr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2654,4 +2654,182 @@ class AppLocalizationsZh extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get import_mode_title => 'How should this be imported?';
+
+  @override
+  String get import_mode_message =>
+      'Choose whether to merge this backup into your current library, or replace your entire library with it.';
+
+  @override
+  String get import_mode_keep_existing => 'Merge';
+
+  @override
+  String get import_mode_keep_existing_subtitle =>
+      'Adds new series and updates matching ones. Nothing in your current library is removed.';
+
+  @override
+  String get import_mode_replace => 'Replace';
+
+  @override
+  String get import_mode_replace_subtitle =>
+      'Deletes your entire current library and replaces it with this backup.';
+
+  @override
+  String get replace_summary_title => 'Ready to replace your library';
+
+  @override
+  String replace_summary_message(Object currentCount, Object backupCount) {
+    return 'This deletes your entire current library ($currentCount series) and replaces it with $backupCount series from this backup. This can only be undone by rolling back.';
+  }
+
+  @override
+  String get replace_summary_confirm => 'Replace';
+
+  @override
+  String replace_result_message(Object count) {
+    return 'Replaced your library with $count series from this backup.';
+  }
+
+  @override
+  String get category_conflict_title => 'Existing categories found';
+
+  @override
+  String get category_conflict_message =>
+      'The backup has categories that already exist in your library. Keep to fold incoming series into the existing category, or delete to leave those series uncategorized instead.';
+
+  @override
+  String get category_conflict_keep => 'Keep — merge into existing category';
+
+  @override
+  String get category_conflict_delete => 'Delete — leave series uncategorized';
+
+  @override
+  String get source_conflict_title => 'Sources not found';
+
+  @override
+  String get source_conflict_message =>
+      'These backup sources don\'t match an installed extension. Keep the original name (imported without a working source), or migrate to an installed extension so these series can be updated.';
+
+  @override
+  String get source_conflict_keep => 'Keep original name (no live source)';
+
+  @override
+  String get import_summary_title => 'Ready to import';
+
+  @override
+  String import_summary_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return '$newSeries new series, $updatedSeries existing series will be updated, and $newChapters new chapters will be added. Nothing already in your library will be removed.';
+  }
+
+  @override
+  String get import_summary_confirm => 'Import';
+
+  @override
+  String import_result_message(
+    Object newSeries,
+    Object updatedSeries,
+    Object newChapters,
+  ) {
+    return 'Imported $newSeries new series, updated $updatedSeries existing, added $newChapters new chapters.';
+  }
+
+  @override
+  String get roll_back => 'Roll back';
+
+  @override
+  String get roll_back_confirm_message =>
+      'This restores your library to the safety snapshot taken right before this change, undoing everything it just did.';
+
+  @override
+  String get roll_back_done => 'Rolled back to the pre-change snapshot.';
+
+  @override
+  String get restoring_backup => 'Restoring your library…';
+
+  @override
+  String get roll_back_last_change => 'Roll back last change';
+
+  @override
+  String roll_back_last_change_subtitle(Object date, Object description) {
+    return 'Snapshot from $date — $description';
+  }
+
+  @override
+  String get delete_source_title => 'Delete a source & its manga';
+
+  @override
+  String get delete_source_subtitle =>
+      'Pick a source and remove every manga it has in your library, along with their chapters, downloads, history and tracking.';
+
+  @override
+  String get delete_source_pick_title => 'Pick a source to delete';
+
+  @override
+  String get delete_source_empty => 'No sources found in your library.';
+
+  @override
+  String delete_source_confirm_title(Object sourceName) {
+    return 'Delete $sourceName?';
+  }
+
+  @override
+  String delete_source_confirm_message(
+    Object mangaCount,
+    Object chapterCount,
+    Object historyCount,
+    Object updateCount,
+    Object trackCount,
+  ) {
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+  }
+
+  @override
+  String get delete_source_also_remove_extension =>
+      'Also remove the installed extension';
+
+  @override
+  String get delete_source_button => 'Delete';
+
+  @override
+  String delete_source_result_message(Object mangaCount, Object sourceName) {
+    return 'Deleted $mangaCount manga from $sourceName.';
+  }
+
+  @override
+  String get merge_sources_title => 'Merge duplicate sources';
+
+  @override
+  String get merge_sources_subtitle =>
+      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+
+  @override
+  String get merge_sources_none_found => 'No likely duplicate sources found.';
+
+  @override
+  String get merge_sources_pick_title => 'Possible duplicates';
+
+  @override
+  String get merge_sources_choose_primary_title =>
+      'Which one should the others merge into?';
+
+  @override
+  String get merge_sources_choose_primary_message =>
+      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+
+  @override
+  String get merge_sources_button => 'Merge';
+
+  @override
+  String merge_sources_result_message(Object mangaCount, Object sourceName) {
+    return 'Merged $mangaCount manga into $sourceName.';
+  }
+
+  @override
+  String get beta => 'Beta';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2761,6 +2761,11 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String roll_back_available_count(Object count) {
+    return '$count recent changes available to roll back to';
+  }
+
+  @override
   String get delete_source_title => 'Delete a source & its manga';
 
   @override
@@ -2784,14 +2789,19 @@ class AppLocalizationsZh extends AppLocalizations {
     Object chapterCount,
     Object historyCount,
     Object updateCount,
-    Object trackCount,
   ) {
-    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries, $updateCount update entries and $trackCount tracking links. This cannot be undone except by rolling back.';
+    return 'This permanently deletes $mangaCount manga, $chapterCount chapters, $historyCount history entries and $updateCount update entries. Tracking links are kept. This cannot be undone except by rolling back.';
   }
 
   @override
   String get delete_source_also_remove_extension =>
       'Also remove the installed extension';
+
+  @override
+  String get delete_source_keep_history => 'Keep reading history';
+
+  @override
+  String get delete_source_keep_downloads => 'Keep download records';
 
   @override
   String get delete_source_button => 'Delete';
@@ -2802,32 +2812,56 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get merge_sources_title => 'Merge duplicate sources';
+  String get merge_manga_title => 'Merge duplicate manga';
 
   @override
-  String get merge_sources_subtitle =>
-      'Finds sources in your library that are likely the same one under different names (e.g. from separate imports) and folds them into one, without deleting anything.';
+  String get merge_manga_subtitle =>
+      'Finds manga with matching titles under the same source (e.g. after merging duplicate sources) and folds them into one, without deleting anything you\'d want kept.';
 
   @override
-  String get merge_sources_none_found => 'No likely duplicate sources found.';
+  String get merge_manga_none_found => 'No likely duplicate manga found.';
 
   @override
-  String get merge_sources_pick_title => 'Possible duplicates';
+  String get merge_manga_pick_title => 'Possible duplicate manga';
 
   @override
-  String get merge_sources_choose_primary_title =>
+  String get merge_manga_choose_primary_title =>
       'Which one should the others merge into?';
 
   @override
-  String get merge_sources_choose_primary_message =>
-      'The manga from the other source(s) will be rebound to whichever one you pick here — nothing is deleted.';
+  String get merge_manga_choose_primary_message =>
+      'Chapters, history and tracking from the other entries will be folded into whichever one you pick — nothing is deleted.';
 
   @override
-  String get merge_sources_button => 'Merge';
+  String merge_manga_chapters_subtitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count chapters',
+      one: '1 chapter',
+    );
+    return '$_temp0';
+  }
 
   @override
-  String merge_sources_result_message(Object mangaCount, Object sourceName) {
-    return 'Merged $mangaCount manga into $sourceName.';
+  String get merge_manga_button => 'Merge';
+
+  @override
+  String merge_manga_result_message(Object count, Object mangaName) {
+    return 'Merged $count duplicate manga into $mangaName.';
+  }
+
+  @override
+  String get merge_preview_title => 'Confirm merge';
+
+  @override
+  String merge_manga_preview_message(
+    Object totalChapters,
+    Object duplicateChapters,
+    Object keptChapters,
+    Object duplicateTracks,
+  ) {
+    return '$totalChapters chapters found across the other entries. $duplicateChapters are duplicates and will be dropped (keeping whichever copy has reading progress); $keptChapters will be added. $duplicateTracks duplicate tracking link(s) will also be dropped.';
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,4 @@
-import 'dart:async';
+git remote add myfork https://github.com/not-akari/mangayomi.gitimport 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,4 @@
-git remote add myfork https://github.com/not-akari/mangayomi.gitimport 'dart:async';
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 

--- a/lib/modules/history/history_screen.dart
+++ b/lib/modules/history/history_screen.dart
@@ -125,7 +125,13 @@ class _HistoryTabState extends ConsumerState<HistoryTab>
       ),
     );
     return history.when(
-      data: (entries) {
+      data: (allEntries) {
+        final entries = allEntries
+            .where(
+              (e) =>
+                  e.chapter.value != null && e.chapter.value!.manga.value != null,
+            )
+            .toList();
         if (entries.isNotEmpty) {
           return CustomScrollView(
             slivers: [

--- a/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
+++ b/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
@@ -89,12 +89,6 @@ Future<dynamic> updateMangaDetail(
         return num > 0 ? num : null;
       }
 
-      // Match by the domain-less URL (path + query), not the full URL. Sources
-      // (anime ones especially) migrate domains, so the stored URL keeps the old
-      // host while a fresh fetch returns the new one — matching on the full URL
-      // then misses and re-adds every chapter each update, which is how episodes
-      // ended up duplicated/tripled. Also fall back to a chapter-number +
-      // scanlator composite key, so a URL change alone doesn't create a dupe.
       final existingByUrl = <String, Chapter>{};
       final existingByComposite = <String, Chapter>{};
       final duplicateIds = <int>{};

--- a/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
+++ b/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
@@ -22,7 +22,6 @@ Future<dynamic> updateMangaDetail(
     final manga = isar.mangas.getSync(mangaId!);
     if (manga == null) return;
 
-    // loadSync() so .isNotEmpty is reliable (IsarLinks are lazy by default).
     manga.chapters.loadSync();
 
     if ((manga.isLocalArchive ?? false) ||
@@ -77,75 +76,86 @@ Future<dynamic> updateMangaDetail(
     final chaps = getManga.chapters;
 
     await isar.writeTxn(() async {
-      // Persist updated manga metadata.
       final savedMangaId = await isar.mangas.put(manga);
 
       if (chaps == null || chaps.isEmpty) return;
 
-      // loadSync() was called before the transaction; the set is still valid
-      // here because we haven't written to chapters yet.
       final existingChapters = manga.chapters.toList();
+      final recognition = ChapterRecognition();
+
+      int? numberOf(Chapter c) {
+        if (c.name == null) return null;
+        final num = recognition.parseChapterNumber(manga.name ?? '', c.name!);
+        return num > 0 ? num : null;
+      }
+
       // Match by the domain-less URL (path + query), not the full URL. Sources
       // (anime ones especially) migrate domains, so the stored URL keeps the old
       // host while a fresh fetch returns the new one — matching on the full URL
       // then misses and re-adds every chapter each update, which is how episodes
-      // ended up duplicated/tripled.
+      // ended up duplicated/tripled. Also fall back to a chapter-number +
+      // scanlator composite key, so a URL change alone doesn't create a dupe.
       final existingByUrl = <String, Chapter>{};
-      // IDs of pre-existing duplicates (same domain-less URL) to remove, so the
-      // list stops showing copies created before this fix. The read/started copy
-      // is the one kept.
-      final duplicateIds = <int>[];
+      final existingByComposite = <String, Chapter>{};
+      final duplicateIds = <int>{};
       for (final c in existingChapters) {
         final u = c.url?.trim();
-        if (u == null || u.isEmpty) continue;
-        final key = u.getUrlWithoutDomain;
-        final prior = existingByUrl[key];
+        final urlKey = (u == null || u.isEmpty) ? null : u.getUrlWithoutDomain;
+        final num = numberOf(c);
+        final compositeKey = num == null ? null : '$num::${c.scanlator ?? ''}';
+
+        final prior =
+            (urlKey != null ? existingByUrl[urlKey] : null) ??
+            (compositeKey != null ? existingByComposite[compositeKey] : null);
         if (prior == null) {
-          existingByUrl[key] = c;
+          if (urlKey != null) existingByUrl[urlKey] = c;
+          if (compositeKey != null) existingByComposite[compositeKey] = c;
         } else {
-          // Keep the copy with reading state; drop the other.
           final priorHasState =
               (prior.isRead ?? false) || (prior.lastPageRead ?? '').isNotEmpty;
           final keep = priorHasState ? prior : c;
           final drop = identical(keep, prior) ? c : prior;
-          existingByUrl[key] = keep;
+          if (urlKey != null) existingByUrl[urlKey] = keep;
+          if (compositeKey != null) existingByComposite[compositeKey] = keep;
           if (drop.id != null) duplicateIds.add(drop.id!);
         }
       }
 
-      // Build a chapterNumber -> isRead map so that when a new scanlator covers
-      // a chapter the user has already read, the new entry is pre-marked read.
-      // The value is true if ANY existing chapter at that number is read.
-      final recognition = ChapterRecognition();
       final readByNumber = <int, bool>{};
       for (final c in existingChapters) {
-        if (c.name == null) continue;
-        final num = recognition.parseChapterNumber(manga.name ?? '', c.name!);
-        if (num > 0) {
+        final num = numberOf(c);
+        if (num != null) {
           readByNumber[num] =
               (readByNumber[num] ?? false) || (c.isRead ?? false);
         }
       }
 
       final newChapters = <Chapter>[];
-      // Guards against a source repeating the same episode within one fetch.
       final seenKeys = <String>{};
-      // Existing chapters whose metadata changed — batch-updated at the end.
       final chaptersToUpdate = <Chapter>[];
 
       for (final chap in chaps) {
         final url = chap.url?.trim();
         if (url == null || url.isEmpty) continue;
         final key = url.getUrlWithoutDomain;
+
+        final chapNum = chap.name != null
+            ? recognition.parseChapterNumber(manga.name!, chap.name!)
+            : 0;
+        final compositeKey = chapNum > 0
+            ? '$chapNum::${chap.scanlator ?? ''}'
+            : null;
+
         if (!seenKeys.add(key)) continue;
-        final existing = existingByUrl[key];
+        if (compositeKey != null && !seenKeys.add('c:$compositeKey')) {
+          continue;
+        }
+
+        final existing =
+            existingByUrl[key] ??
+            (compositeKey != null ? existingByComposite[compositeKey] : null);
 
         if (existing == null) {
-          // Determine whether this chapter number has already been read under
-          // a different scanlator, so we don't show it as unread to the user.
-          final chapNum = chap.name != null
-              ? recognition.parseChapterNumber(manga.name!, chap.name!)
-              : 0;
           final alreadyRead = chapNum > 0 && (readByNumber[chapNum] ?? false);
 
           final newChapter = Chapter(
@@ -164,17 +174,21 @@ Future<dynamic> updateMangaDetail(
             duration: chap.duration,
           )..manga.value = manga;
 
-          // Carry over read state if another scanlator's version was read.
           if (alreadyRead) {
             newChapter.isRead = alreadyRead;
             newChapter.lastPageRead = "1";
           }
 
+          existingByUrl[key] = newChapter;
+          if (compositeKey != null) {
+            existingByComposite[compositeKey] = newChapter;
+          }
+
           newChapters.add(newChapter);
         } else {
-          // Existing chapter - refresh metadata only (collected for batch write).
           existing
             ..name = chap.name
+            ..url = url
             ..scanlator = chap.scanlator
             ..updatedAt = now
             ..isFiller = chap.isFiller
@@ -186,31 +200,24 @@ Future<dynamic> updateMangaDetail(
         }
       }
 
-      // ── Batch write existing chapters metadata ──────────────────────────
       if (chaptersToUpdate.isNotEmpty) {
         await isar.chapters.putAll(chaptersToUpdate);
       }
 
-      // ── Batch insert new chapters (oldest-first) + their Updates ────────
       if (newChapters.isNotEmpty) {
         final hasExisting = existingChapters.isNotEmpty;
 
-        // Reverse so oldest chapters get inserted first (API returns newest-first).
         final orderedNew = newChapters.reversed.toList();
 
-        // Set manga link on each chapter before batch insert.
         for (final chap in orderedNew) {
           chap.manga.value = manga;
         }
 
         await isar.chapters.putAll(orderedNew);
-        // Save the IsarLink for every chapter in one pass.
         for (final chap in orderedNew) {
           await chap.manga.save();
         }
 
-        // Build Update entries for genuinely new (unread) chapters only,
-        // so pre-read cross-scanlator chapters don't spam the updates feed.
         final updatesToInsert = <Update>[];
         for (final chap in orderedNew) {
           if (hasExisting && !(chap.isRead ?? false)) {
@@ -233,13 +240,10 @@ Future<dynamic> updateMangaDetail(
         }
       }
 
-      // ── Remove pre-existing duplicate chapters ───────────────────────────
       if (duplicateIds.isNotEmpty) {
-        await isar.chapters.deleteAll(duplicateIds);
+        await isar.chapters.deleteAll(duplicateIds.toList());
       }
 
-      // Calculate fetch interval:
-      // median of gaps between recent distinct chapter dates, clamped [1, 28].
       final dedupedExisting = duplicateIds.isEmpty
           ? existingChapters
           : existingChapters

--- a/lib/modules/manga/detail/providers/update_manga_detail_providers.g.dart
+++ b/lib/modules/manga/detail/providers/update_manga_detail_providers.g.dart
@@ -64,7 +64,7 @@ final class UpdateMangaDetailProvider
   }
 }
 
-String _$updateMangaDetailHash() => r'c721e34b369cfe19ef725b709a57ddd3ca42696a';
+String _$updateMangaDetailHash() => r'258074d17d1b07165d8d9af615ae276f9d1fa332';
 
 final class UpdateMangaDetailFamily extends $Family
     with

--- a/lib/modules/more/data_and_storage/data_and_storage.dart
+++ b/lib/modules/more/data_and_storage/data_and_storage.dart
@@ -190,7 +190,7 @@ class DataAndStorage extends ConsumerWidget {
             ),
             const RollbackLastChangeTile(),
             const DeleteSourceTile(),
-            const MergeDuplicateSourcesTile(),
+            const MergeDuplicateMangaTile(),
             ListTile(
               onTap: () {
                 showDialog(

--- a/lib/modules/more/data_and_storage/data_and_storage.dart
+++ b/lib/modules/more/data_and_storage/data_and_storage.dart
@@ -5,11 +5,12 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:mangayomi/eval/model/m_bridge.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/auto_backup.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/backup_compression.dart';
-import 'package:mangayomi/modules/more/data_and_storage/providers/restore.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/storage_usage.dart';
+import 'package:mangayomi/modules/more/data_and_storage/widgets/rollback_last_change_tile.dart';
+import 'package:mangayomi/modules/more/data_and_storage/widgets/source_management_tiles.dart';
+import 'package:mangayomi/modules/more/data_and_storage/widgets/unified_restore.dart';
 import 'package:mangayomi/modules/more/settings/downloads/providers/downloads_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
@@ -179,87 +180,7 @@ class DataAndStorage extends ConsumerWidget {
                         if (newSelection.contains('create')) {
                           context.push('/createBackup');
                         } else if (newSelection.contains('restore')) {
-                          showDialog(
-                            context: context,
-                            builder: (context) {
-                              return AlertDialog(
-                                title: Text(l10n.restore_backup),
-                                content: SizedBox(
-                                  width: context.width(0.8),
-                                  child: SuperListView(
-                                    shrinkWrap: true,
-                                    children: [
-                                      Row(
-                                        children: [
-                                          Icon(
-                                            Icons.info_outline_rounded,
-                                            color: context.secondaryColor,
-                                          ),
-                                        ],
-                                      ),
-                                      Padding(
-                                        padding: const EdgeInsets.symmetric(
-                                          vertical: 5,
-                                        ),
-                                        child: Text(
-                                          l10n.restore_backup_warning_title,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                                actions: [
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.end,
-                                    children: [
-                                      TextButton(
-                                        onPressed: () async {
-                                          Navigator.pop(context);
-                                        },
-                                        child: Text(
-                                          l10n.cancel,
-                                          style: TextStyle(
-                                            color: context.primaryColor,
-                                          ),
-                                        ),
-                                      ),
-                                      TextButton(
-                                        onPressed: () async {
-                                          try {
-                                            final file =
-                                                await FilePicker.pickFile();
-
-                                            if (file != null &&
-                                                context.mounted) {
-                                              ref.watch(
-                                                doRestoreProvider(
-                                                  path: file.path!,
-                                                  context: context,
-                                                ),
-                                              );
-                                            }
-                                            if (!context.mounted) return;
-                                            Navigator.pop(context);
-                                          } catch (e) {
-                                            botToast(
-                                              "Error restoring backup: $e",
-                                            );
-                                            Navigator.pop(context);
-                                          }
-                                        },
-                                        child: Text(
-                                          l10n.ok,
-                                          style: TextStyle(
-                                            color: context.primaryColor,
-                                          ),
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ],
-                              );
-                            },
-                          );
+                          performRestore(context, ref);
                         }
                       },
                     ),
@@ -267,6 +188,9 @@ class DataAndStorage extends ConsumerWidget {
                 ],
               ),
             ),
+            const RollbackLastChangeTile(),
+            const DeleteSourceTile(),
+            const MergeDuplicateSourcesTile(),
             ListTile(
               onTap: () {
                 showDialog(

--- a/lib/modules/more/data_and_storage/providers/backup.dart
+++ b/lib/modules/more/data_and_storage/providers/backup.dart
@@ -36,134 +36,11 @@ Future<void> doBackUp(
   final compression = ref.read(backupCompressionLevelProvider);
   final compressionLevel = compression.clamp(0, 9).toInt();
   try {
-    Map<String, dynamic> datas = {};
-    datas.addAll({"version": "2"});
-    if (list.contains(0)) {
-      final res = isar.mangas
-          .filter()
-          .idIsNotNull()
-          .favoriteEqualTo(true)
-          .isLocalArchiveEqualTo(false)
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"manga": res});
-    }
-    if (list.contains(1)) {
-      final res = isar.categorys
-          .filter()
-          .idIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"categories": res});
-    }
-    if (list.contains(2)) {
-      final res = isar.chapters
-          .filter()
-          .idIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"chapters": res});
-      final res_ = isar.downloads
-          .filter()
-          .idIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"downloads": res_});
-    }
-    if (list.contains(3)) {
-      final res = isar.tracks
-          .filter()
-          .idIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"tracks": res});
-    }
-    if (list.contains(4)) {
-      final res = isar.historys
-          .filter()
-          .idIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"history": res});
-    }
-    if (list.contains(5)) {
-      final res = isar.updates
-          .filter()
-          .idIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"updates": res});
-    }
-    if (list.contains(6)) {
-      final res = isar.settings
-          .filter()
-          .idIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"settings": res});
-    } else {
-      final setting = Settings()..themeIsDark = isTv;
-      datas.addAll({
-        "settings": [setting.toJson()],
-      });
-    }
-    if (list.contains(7)) {
-      final res = isar.sourcePreferences
-          .filter()
-          .idIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"extensions_preferences": res});
-    }
-    if (list.contains(8)) {
-      final res_ = isar.trackPreferences
-          .filter()
-          .syncIdIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"trackPreferences": res_});
-    }
-    if (list.contains(9)) {
-      final res = isar.sources
-          .filter()
-          .idIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"extensions": res});
-    }
-    if (list.contains(10)) {
-      final res = isar.customButtons
-          .filter()
-          .idIsNotNull()
-          .findAllSync()
-          .map((e) => e.toJson())
-          .toList();
-      datas.addAll({"customButtons": res});
-    }
-    final regExp = RegExp(r'[^a-zA-Z0-9 .()\-\s]');
-    final name =
-        'mangayomi_${DateTime.now().toString().replaceAll(regExp, '_').replaceAll(' ', '_')}';
-    final backupFilePath = p.join(path, "$name.backup.db");
-    final file = File(backupFilePath);
-
-    await file.writeAsString(jsonEncode(datas));
-    final zipPath = p.join(path, "$name.backup");
-    final zipEncoder = ZipFileEncoder();
-    zipEncoder.create(zipPath, level: compressionLevel);
-    await zipEncoder.addFile(file);
-    await zipEncoder.close();
-    file.delete();
+    final zipPath = await writeMangayomiBackupZip(
+      list: list,
+      directory: path,
+      compressionLevel: compressionLevel,
+    );
     final assets = [
       'assets/app_icons/icon-black.png',
       'assets/app_icons/icon-red.png',
@@ -191,8 +68,8 @@ Future<void> doBackUp(
                         context.findRenderObject() as RenderBox?;
                     SharePlus.instance.share(
                       ShareParams(
-                        files: [XFile(p.join(path, "$name.backup"))],
-                        subject: "$name.backup",
+                        files: [XFile(zipPath)],
+                        subject: p.basename(zipPath),
                         title: "Share Mangayomi backup file",
                         sharePositionOrigin: box == null
                             ? null
@@ -231,4 +108,140 @@ Future<void> doBackUp(
       );
     }
   }
+}
+
+Future<String> writeMangayomiBackupZip({
+  required List<int> list,
+  required String directory,
+  int compressionLevel = 6,
+}) async {
+  Map<String, dynamic> datas = {};
+  datas.addAll({"version": "2"});
+  if (list.contains(0)) {
+    final res = isar.mangas
+        .filter()
+        .idIsNotNull()
+        .favoriteEqualTo(true)
+        .isLocalArchiveEqualTo(false)
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"manga": res});
+  }
+  if (list.contains(1)) {
+    final res = isar.categorys
+        .filter()
+        .idIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"categories": res});
+  }
+  if (list.contains(2)) {
+    final res = isar.chapters
+        .filter()
+        .idIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"chapters": res});
+    final res_ = isar.downloads
+        .filter()
+        .idIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"downloads": res_});
+  }
+  if (list.contains(3)) {
+    final res = isar.tracks
+        .filter()
+        .idIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"tracks": res});
+  }
+  if (list.contains(4)) {
+    final res = isar.historys
+        .filter()
+        .idIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"history": res});
+  }
+  if (list.contains(5)) {
+    final res = isar.updates
+        .filter()
+        .idIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"updates": res});
+  }
+  if (list.contains(6)) {
+    final res = isar.settings
+        .filter()
+        .idIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"settings": res});
+  } else {
+    final setting = Settings()..themeIsDark = isTv;
+    datas.addAll({
+      "settings": [setting.toJson()],
+    });
+  }
+  if (list.contains(7)) {
+    final res = isar.sourcePreferences
+        .filter()
+        .idIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"extensions_preferences": res});
+  }
+  if (list.contains(8)) {
+    final res_ = isar.trackPreferences
+        .filter()
+        .syncIdIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"trackPreferences": res_});
+  }
+  if (list.contains(9)) {
+    final res = isar.sources
+        .filter()
+        .idIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"extensions": res});
+  }
+  if (list.contains(10)) {
+    final res = isar.customButtons
+        .filter()
+        .idIsNotNull()
+        .findAllSync()
+        .map((e) => e.toJson())
+        .toList();
+    datas.addAll({"customButtons": res});
+  }
+  final regExp = RegExp(r'[^a-zA-Z0-9 .()\-\s]');
+  final name =
+      'mangayomi_${DateTime.now().toString().replaceAll(regExp, '_').replaceAll(' ', '_')}';
+  final backupFilePath = p.join(directory, "$name.backup.db");
+  final file = File(backupFilePath);
+
+  await file.writeAsString(jsonEncode(datas));
+  final zipPath = p.join(directory, "$name.backup");
+  final zipEncoder = ZipFileEncoder();
+  zipEncoder.create(zipPath, level: compressionLevel);
+  await zipEncoder.addFile(file);
+  await zipEncoder.close();
+  file.delete();
+  return zipPath;
 }

--- a/lib/modules/more/data_and_storage/providers/backup.g.dart
+++ b/lib/modules/more/data_and_storage/providers/backup.g.dart
@@ -65,7 +65,7 @@ final class DoBackUpProvider
   }
 }
 
-String _$doBackUpHash() => r'af9942df46b3bc53945f1650f694812d31b6216e';
+String _$doBackUpHash() => r'4fb84ea501bd77fa5ecd04ebbacc8db31b44f09c';
 
 final class DoBackUpFamily extends $Family
     with

--- a/lib/modules/more/data_and_storage/providers/delete_source.dart
+++ b/lib/modules/more/data_and_storage/providers/delete_source.dart
@@ -1,0 +1,213 @@
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/models/download.dart';
+import 'package:mangayomi/models/history.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/models/source.dart';
+import 'package:mangayomi/models/track.dart';
+import 'package:mangayomi/models/update.dart';
+import 'package:mangayomi/utils/isar_txn_retry.dart';
+
+class LibrarySourceGroup {
+  LibrarySourceGroup({
+    required this.sourceId,
+    required this.sourceName,
+    required this.lang,
+    required this.itemType,
+    required this.mangaCount,
+  });
+
+  final int? sourceId;
+  final String sourceName;
+  final String? lang;
+  final ItemType itemType;
+  final int mangaCount;
+}
+
+List<LibrarySourceGroup> librarySourceGroups() {
+  final counts = <String, LibrarySourceGroup>{};
+  for (final m in isar.mangas.where().findAllSync()) {
+    final key = "${m.sourceId}|${m.source}|${m.lang}|${m.itemType.index}";
+    final existing = counts[key];
+    counts[key] = LibrarySourceGroup(
+      sourceId: m.sourceId,
+      sourceName: m.source ?? "Unknown",
+      lang: m.lang,
+      itemType: m.itemType,
+      mangaCount: (existing?.mangaCount ?? 0) + 1,
+    );
+  }
+  final list = counts.values.toList()
+    ..sort((a, b) => b.mangaCount.compareTo(a.mangaCount));
+  return list;
+}
+
+List<Manga> mangaForGroup(LibrarySourceGroup group) {
+  return isar.mangas.where().findAllSync().where((m) {
+    if (m.itemType != group.itemType) return false;
+    if (group.sourceId != null) return m.sourceId == group.sourceId;
+    return m.sourceId == null &&
+        m.source == group.sourceName &&
+        m.lang == group.lang;
+  }).toList();
+}
+
+class DeleteSourceCounts {
+  DeleteSourceCounts({
+    required this.mangaCount,
+    required this.chapterCount,
+    required this.historyCount,
+    required this.updateCount,
+    required this.trackCount,
+  });
+
+  final int mangaCount;
+  final int chapterCount;
+  final int historyCount;
+  final int updateCount;
+  final int trackCount;
+}
+
+DeleteSourceCounts previewDeleteSource(List<Manga> mangaList) {
+  final mangaIds = mangaList.map((m) => m.id!).toList();
+  final chapterCount = mangaIds.isEmpty
+      ? 0
+      : isar.chapters
+            .filter()
+            .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
+            .countSync();
+  final historyCount = mangaIds.isEmpty
+      ? 0
+      : isar.historys
+            .filter()
+            .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
+            .countSync();
+  final updateCount = mangaIds.isEmpty
+      ? 0
+      : isar.updates
+            .filter()
+            .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
+            .countSync();
+  final trackCount = mangaIds.isEmpty
+      ? 0
+      : isar.tracks
+            .filter()
+            .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
+            .countSync();
+  return DeleteSourceCounts(
+    mangaCount: mangaList.length,
+    chapterCount: chapterCount,
+    historyCount: historyCount,
+    updateCount: updateCount,
+    trackCount: trackCount,
+  );
+}
+
+Future<void> deleteSourceLibrary(
+  List<Manga> mangaList,
+  LibrarySourceGroup group, {
+  bool alsoRemoveExtension = false,
+}) async {
+  await writeTxnSyncWithRetry(() {
+    for (final manga in mangaList) {
+      final chapterIds = isar.chapters
+          .filter()
+          .mangaIdEqualTo(manga.id)
+          .findAllSync()
+          .map((c) => c.id!)
+          .toList();
+      if (chapterIds.isNotEmpty) {
+        isar.downloads.deleteAllSync(chapterIds);
+        isar.chapters.deleteAllSync(chapterIds);
+      }
+    }
+    final mangaIds = mangaList.map((m) => m.id!).toList();
+    if (mangaIds.isNotEmpty) {
+      isar.historys
+          .filter()
+          .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
+          .deleteAllSync();
+      isar.updates
+          .filter()
+          .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
+          .deleteAllSync();
+      isar.tracks
+          .filter()
+          .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
+          .deleteAllSync();
+      isar.mangas.deleteAllSync(mangaIds);
+    }
+    if (alsoRemoveExtension && group.sourceId != null) {
+      isar.sources.deleteSync(group.sourceId!);
+    }
+  });
+}
+
+class DuplicateSourceCluster {
+  DuplicateSourceCluster(this.groups);
+
+  final List<LibrarySourceGroup> groups;
+}
+
+String _normalizeSourceName(String name) =>
+    name.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
+
+bool _looksLikeSameSource(LibrarySourceGroup a, LibrarySourceGroup b) {
+  if (a.itemType != b.itemType) return false;
+  final na = _normalizeSourceName(a.sourceName);
+  final nb = _normalizeSourceName(b.sourceName);
+  if (na.isEmpty || nb.isEmpty) return false;
+  if (na == nb) return true;
+  if (na.length >= 4 && nb.contains(na)) return true;
+  if (nb.length >= 4 && na.contains(nb)) return true;
+  return false;
+}
+
+List<DuplicateSourceCluster> findDuplicateSourceClusters() {
+  final groups = librarySourceGroups();
+  final n = groups.length;
+  final parent = List.generate(n, (i) => i);
+  int find(int x) {
+    while (parent[x] != x) {
+      parent[x] = parent[parent[x]];
+      x = parent[x];
+    }
+    return x;
+  }
+
+  void union(int x, int y) {
+    final rx = find(x), ry = find(y);
+    if (rx != ry) parent[rx] = ry;
+  }
+
+  for (var i = 0; i < n; i++) {
+    for (var j = i + 1; j < n; j++) {
+      if (_looksLikeSameSource(groups[i], groups[j])) union(i, j);
+    }
+  }
+  final clusters = <int, List<LibrarySourceGroup>>{};
+  for (var i = 0; i < n; i++) {
+    clusters.putIfAbsent(find(i), () => []).add(groups[i]);
+  }
+  return clusters.values
+      .where((g) => g.length > 1)
+      .map(DuplicateSourceCluster.new)
+      .toList();
+}
+
+Future<void> mergeSourceGroups(
+  LibrarySourceGroup primary,
+  List<LibrarySourceGroup> others,
+) async {
+  await writeTxnSyncWithRetry(() {
+    for (final other in others) {
+      for (final manga in mangaForGroup(other)) {
+        manga.source = primary.sourceName;
+        manga.sourceId = primary.sourceId;
+        manga.lang = primary.lang;
+        isar.mangas.putSync(manga);
+      }
+    }
+  });
+}

--- a/lib/modules/more/data_and_storage/providers/delete_source.dart
+++ b/lib/modules/more/data_and_storage/providers/delete_source.dart
@@ -7,6 +7,8 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/models/track.dart';
 import 'package:mangayomi/models/update.dart';
+import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
+import 'package:mangayomi/utils/extensions/string_extensions.dart';
 import 'package:mangayomi/utils/isar_txn_retry.dart';
 
 class LibrarySourceGroup {
@@ -25,9 +27,12 @@ class LibrarySourceGroup {
   final int mangaCount;
 }
 
-List<LibrarySourceGroup> librarySourceGroups() {
+List<LibrarySourceGroup> librarySourceGroups({bool favoritesOnly = false}) {
   final counts = <String, LibrarySourceGroup>{};
-  for (final m in isar.mangas.where().findAllSync()) {
+  final mangas = favoritesOnly
+      ? isar.mangas.filter().favoriteEqualTo(true).findAllSync()
+      : isar.mangas.where().findAllSync();
+  for (final m in mangas) {
     final key = "${m.sourceId}|${m.source}|${m.lang}|${m.itemType.index}";
     final existing = counts[key];
     counts[key] = LibrarySourceGroup(
@@ -43,8 +48,9 @@ List<LibrarySourceGroup> librarySourceGroups() {
   return list;
 }
 
-List<Manga> mangaForGroup(LibrarySourceGroup group) {
+List<Manga> mangaForGroup(LibrarySourceGroup group, {bool favoritesOnly = false}) {
   return isar.mangas.where().findAllSync().where((m) {
+    if (favoritesOnly && !(m.favorite ?? false)) return false;
     if (m.itemType != group.itemType) return false;
     if (group.sourceId != null) return m.sourceId == group.sourceId;
     return m.sourceId == null &&
@@ -59,14 +65,12 @@ class DeleteSourceCounts {
     required this.chapterCount,
     required this.historyCount,
     required this.updateCount,
-    required this.trackCount,
   });
 
   final int mangaCount;
   final int chapterCount;
   final int historyCount;
   final int updateCount;
-  final int trackCount;
 }
 
 DeleteSourceCounts previewDeleteSource(List<Manga> mangaList) {
@@ -89,18 +93,11 @@ DeleteSourceCounts previewDeleteSource(List<Manga> mangaList) {
             .filter()
             .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
             .countSync();
-  final trackCount = mangaIds.isEmpty
-      ? 0
-      : isar.tracks
-            .filter()
-            .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
-            .countSync();
   return DeleteSourceCounts(
     mangaCount: mangaList.length,
     chapterCount: chapterCount,
     historyCount: historyCount,
     updateCount: updateCount,
-    trackCount: trackCount,
   );
 }
 
@@ -108,7 +105,21 @@ Future<void> deleteSourceLibrary(
   List<Manga> mangaList,
   LibrarySourceGroup group, {
   bool alsoRemoveExtension = false,
+  bool keepHistory = false,
+  bool keepDownloads = false,
 }) async {
+  if (!keepDownloads) {
+    for (final manga in mangaList) {
+      final chapters = isar.chapters
+          .filter()
+          .mangaIdEqualTo(manga.id)
+          .findAllSync();
+      for (final chapter in chapters) {
+        chapter.manga.value = manga;
+        await chapter.deleteDownloadedFiles();
+      }
+    }
+  }
   await writeTxnSyncWithRetry(() {
     for (final manga in mangaList) {
       final chapterIds = isar.chapters
@@ -118,21 +129,19 @@ Future<void> deleteSourceLibrary(
           .map((c) => c.id!)
           .toList();
       if (chapterIds.isNotEmpty) {
-        isar.downloads.deleteAllSync(chapterIds);
+        if (!keepDownloads) isar.downloads.deleteAllSync(chapterIds);
         isar.chapters.deleteAllSync(chapterIds);
       }
     }
     final mangaIds = mangaList.map((m) => m.id!).toList();
     if (mangaIds.isNotEmpty) {
-      isar.historys
-          .filter()
-          .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
-          .deleteAllSync();
+      if (!keepHistory) {
+        isar.historys
+            .filter()
+            .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
+            .deleteAllSync();
+      }
       isar.updates
-          .filter()
-          .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
-          .deleteAllSync();
-      isar.tracks
           .filter()
           .anyOf(mangaIds, (q, id) => q.mangaIdEqualTo(id))
           .deleteAllSync();
@@ -144,29 +153,15 @@ Future<void> deleteSourceLibrary(
   });
 }
 
-class DuplicateSourceCluster {
-  DuplicateSourceCluster(this.groups);
-
-  final List<LibrarySourceGroup> groups;
-}
-
-String _normalizeSourceName(String name) =>
-    name.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
-
-bool _looksLikeSameSource(LibrarySourceGroup a, LibrarySourceGroup b) {
-  if (a.itemType != b.itemType) return false;
-  final na = _normalizeSourceName(a.sourceName);
-  final nb = _normalizeSourceName(b.sourceName);
-  if (na.isEmpty || nb.isEmpty) return false;
-  if (na == nb) return true;
-  if (na.length >= 4 && nb.contains(na)) return true;
-  if (nb.length >= 4 && na.contains(nb)) return true;
-  return false;
-}
-
-List<DuplicateSourceCluster> findDuplicateSourceClusters() {
-  final groups = librarySourceGroups();
-  final n = groups.length;
+// Groups items into clusters of 2+ using union-find, joining any pair that
+// `matches` reports as equivalent (so equivalence doesn't need to be
+// transitive across the whole set — A~B and B~C is enough to cluster A,B,C
+// together even if A and C alone wouldn't match).
+List<List<T>> _clusterByPairwiseMatch<T>(
+  List<T> items,
+  bool Function(T a, T b) matches,
+) {
+  final n = items.length;
   final parent = List.generate(n, (i) => i);
   int find(int x) {
     while (parent[x] != x) {
@@ -183,31 +178,217 @@ List<DuplicateSourceCluster> findDuplicateSourceClusters() {
 
   for (var i = 0; i < n; i++) {
     for (var j = i + 1; j < n; j++) {
-      if (_looksLikeSameSource(groups[i], groups[j])) union(i, j);
+      if (matches(items[i], items[j])) union(i, j);
     }
   }
-  final clusters = <int, List<LibrarySourceGroup>>{};
+  final clusters = <int, List<T>>{};
   for (var i = 0; i < n; i++) {
-    clusters.putIfAbsent(find(i), () => []).add(groups[i]);
+    clusters.putIfAbsent(find(i), () => []).add(items[i]);
   }
-  return clusters.values
-      .where((g) => g.length > 1)
-      .map(DuplicateSourceCluster.new)
+  return clusters.values.where((g) => g.length > 1).toList();
+}
+
+class DuplicateMangaCluster {
+  DuplicateMangaCluster(this.mangaList);
+
+  final List<Manga> mangaList;
+}
+
+String _normalizeMangaTitle(String name) =>
+    name.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
+
+bool _looksLikeSameManga(Manga a, Manga b) {
+  final ta = _normalizeMangaTitle(a.name ?? '');
+  final tb = _normalizeMangaTitle(b.name ?? '');
+  return ta.isNotEmpty && ta == tb;
+}
+
+List<DuplicateMangaCluster> findDuplicateMangaClusters(List<Manga> mangaList) {
+  return _clusterByPairwiseMatch(mangaList, _looksLikeSameManga)
+      .map(DuplicateMangaCluster.new)
       .toList();
 }
 
-Future<void> mergeSourceGroups(
-  LibrarySourceGroup primary,
-  List<LibrarySourceGroup> others,
-) async {
-  await writeTxnSyncWithRetry(() {
-    for (final other in others) {
-      for (final manga in mangaForGroup(other)) {
-        manga.source = primary.sourceName;
-        manga.sourceId = primary.sourceId;
-        manga.lang = primary.lang;
-        isar.mangas.putSync(manga);
+class MergeMangaPreview {
+  MergeMangaPreview({
+    required this.totalChapters,
+    required this.duplicateChapters,
+    required this.duplicateTracks,
+  });
+
+  final int totalChapters;
+  final int duplicateChapters;
+  final int duplicateTracks;
+
+  int get keptChapters => totalChapters - duplicateChapters;
+}
+
+String? _chapterDedupKey(Chapter c) =>
+    (c.url ?? '').isNotEmpty ? c.url!.getUrlWithoutDomain : null;
+
+MergeMangaPreview previewMergeManga(Manga primary, List<Manga> others) {
+  final seenUrlKeys = <String>{
+    for (final c in isar.chapters.filter().mangaIdEqualTo(primary.id).findAllSync())
+      ?_chapterDedupKey(c),
+  };
+  var totalChapters = 0;
+  var duplicateChapters = 0;
+  for (final other in others) {
+    for (final c
+        in isar.chapters.filter().mangaIdEqualTo(other.id).findAllSync()) {
+      totalChapters++;
+      final key = _chapterDedupKey(c);
+      if (key == null) continue;
+      if (!seenUrlKeys.add(key)) duplicateChapters++;
+    }
+  }
+
+  final seenSyncIds = <int?>{
+    for (final t in isar.tracks.filter().mangaIdEqualTo(primary.id).findAllSync())
+      t.syncId,
+  };
+  var duplicateTracks = 0;
+  for (final other in others) {
+    for (final t
+        in isar.tracks.filter().mangaIdEqualTo(other.id).findAllSync()) {
+      if (t.syncId != null && !seenSyncIds.add(t.syncId)) duplicateTracks++;
+    }
+  }
+
+  return MergeMangaPreview(
+    totalChapters: totalChapters,
+    duplicateChapters: duplicateChapters,
+    duplicateTracks: duplicateTracks,
+  );
+}
+
+Future<void> mergeMangaGroup(Manga primary, List<Manga> others) async {
+  final primaryUrlKeys = <String>{
+    for (final c in isar.chapters.filter().mangaIdEqualTo(primary.id).findAllSync())
+      ?_chapterDedupKey(c),
+  };
+  for (final other in others) {
+    for (final chapter in isar.chapters
+        .filter()
+        .mangaIdEqualTo(other.id)
+        .findAllSync()) {
+      final key = _chapterDedupKey(chapter);
+      if (key != null && primaryUrlKeys.contains(key)) {
+        chapter.manga.value = other;
+        await chapter.deleteDownloadedFiles();
       }
+    }
+  }
+
+  await writeTxnSyncWithRetry(() {
+    final primaryByUrl = <String, Chapter>{
+      for (final c in isar.chapters
+          .filter()
+          .mangaIdEqualTo(primary.id)
+          .findAllSync())
+        ?_chapterDedupKey(c): c,
+    };
+
+    for (final other in others) {
+      final otherId = other.id!;
+      final otherChapters = isar.chapters
+          .filter()
+          .mangaIdEqualTo(otherId)
+          .findAllSync();
+
+      final remap = <int, Chapter>{};
+      final chaptersToDelete = <int>[];
+      final chaptersToUpdate = <Chapter>[];
+
+      for (final chapter in otherChapters) {
+        final key = _chapterDedupKey(chapter);
+        final existing = key != null ? primaryByUrl[key] : null;
+        if (existing != null) {
+          final otherHasState =
+              (chapter.isRead ?? false) ||
+              (chapter.lastPageRead ?? '').isNotEmpty;
+          final existingHasState =
+              (existing.isRead ?? false) ||
+              (existing.lastPageRead ?? '').isNotEmpty;
+          if (otherHasState && !existingHasState) {
+            existing.isRead = chapter.isRead;
+            existing.lastPageRead = chapter.lastPageRead;
+            chaptersToUpdate.add(existing);
+          }
+          remap[chapter.id!] = existing;
+          chaptersToDelete.add(chapter.id!);
+        } else {
+          chapter.mangaId = primary.id;
+          chapter.manga.value = primary;
+          isar.chapters.putSync(chapter);
+          chapter.manga.saveSync();
+          if (key != null) primaryByUrl[key] = chapter;
+          remap[chapter.id!] = chapter;
+        }
+      }
+      if (chaptersToUpdate.isNotEmpty) {
+        isar.chapters.putAllSync(chaptersToUpdate);
+      }
+
+      final historyEntries = isar.historys
+          .filter()
+          .mangaIdEqualTo(otherId)
+          .findAllSync();
+      for (final h in historyEntries) {
+        final kept = h.chapterId != null ? remap[h.chapterId] : null;
+        if (kept == null) {
+          isar.historys.deleteSync(h.id!);
+          continue;
+        }
+        h.mangaId = primary.id;
+        h.chapterId = kept.id;
+        h.chapter.value = kept;
+        isar.historys.putSync(h);
+        h.chapter.saveSync();
+      }
+
+      final updateEntries = isar.updates
+          .filter()
+          .mangaIdEqualTo(otherId)
+          .findAllSync();
+      for (final u in updateEntries) {
+        u.chapter.loadSync();
+        final oldChapter = u.chapter.value;
+        final kept = oldChapter != null ? remap[oldChapter.id] : null;
+        if (kept == null) {
+          isar.updates.deleteSync(u.id!);
+          continue;
+        }
+        u.mangaId = primary.id;
+        u.chapter.value = kept;
+        isar.updates.putSync(u);
+        u.chapter.saveSync();
+      }
+
+      final primarySyncIds = isar.tracks
+          .filter()
+          .mangaIdEqualTo(primary.id)
+          .findAllSync()
+          .map((t) => t.syncId)
+          .toSet();
+      for (final t in isar.tracks
+          .filter()
+          .mangaIdEqualTo(otherId)
+          .findAllSync()) {
+        if (t.syncId != null && primarySyncIds.contains(t.syncId)) {
+          isar.tracks.deleteSync(t.id!);
+        } else {
+          t.mangaId = primary.id;
+          isar.tracks.putSync(t);
+          primarySyncIds.add(t.syncId);
+        }
+      }
+
+      if (chaptersToDelete.isNotEmpty) {
+        isar.downloads.deleteAllSync(chaptersToDelete);
+        isar.chapters.deleteAllSync(chaptersToDelete);
+      }
+      isar.mangas.deleteSync(otherId);
     }
   });
 }

--- a/lib/modules/more/data_and_storage/providers/pre_import_backup.dart
+++ b/lib/modules/more/data_and_storage/providers/pre_import_backup.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:mangayomi/modules/more/data_and_storage/providers/backup.dart';
+import 'package:mangayomi/providers/storage_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:path/path.dart' as p;
+part 'pre_import_backup.g.dart';
+
+Future<String> createLibrarySafetyBackup() async {
+  final dir = await _snapshotDirectory();
+  return writeMangayomiBackupZip(
+    list: const [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    directory: dir.path,
+  );
+}
+
+class LibrarySafetySnapshot {
+  LibrarySafetySnapshot({
+    required this.backupPath,
+    required this.createdAt,
+    required this.description,
+  });
+
+  final String backupPath;
+  final int createdAt;
+  final String description;
+
+  Map<String, dynamic> toJson() => {
+    'backupPath': backupPath,
+    'createdAt': createdAt,
+    'description': description,
+  };
+
+  factory LibrarySafetySnapshot.fromJson(Map<String, dynamic> json) =>
+      LibrarySafetySnapshot(
+        backupPath: json['backupPath'] as String,
+        createdAt: json['createdAt'] as int,
+        description: json['description'] as String,
+      );
+}
+
+Future<void> writeLastLibrarySnapshot(LibrarySafetySnapshot snapshot) async {
+  final file = await _snapshotMetaFile();
+  await file.writeAsString(jsonEncode(snapshot.toJson()));
+}
+
+Future<void> clearLastLibrarySnapshot() async {
+  final file = await _snapshotMetaFile();
+  if (await file.exists()) await file.delete();
+}
+
+@riverpod
+Future<LibrarySafetySnapshot?> lastLibrarySnapshot(Ref ref) async {
+  final file = await _snapshotMetaFile();
+  if (!await file.exists()) return null;
+  try {
+    final snapshot = LibrarySafetySnapshot.fromJson(
+      jsonDecode(await file.readAsString()) as Map<String, dynamic>,
+    );
+    if (!await File(snapshot.backupPath).exists()) return null;
+    return snapshot;
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<Directory> _snapshotDirectory() =>
+    StorageProvider().createCacheDirectory('pre_import_backup');
+
+Future<File> _snapshotMetaFile() async {
+  final dir = await _snapshotDirectory();
+  return File(p.join(dir.path, 'last_library_snapshot.json'));
+}

--- a/lib/modules/more/data_and_storage/providers/pre_import_backup.dart
+++ b/lib/modules/more/data_and_storage/providers/pre_import_backup.dart
@@ -40,33 +40,67 @@ class LibrarySafetySnapshot {
       );
 }
 
+const maxLibrarySnapshots = 3;
+
 Future<void> writeLastLibrarySnapshot(LibrarySafetySnapshot snapshot) async {
   final file = await _snapshotMetaFile();
-  await file.writeAsString(jsonEncode(snapshot.toJson()));
+  final current = await _readSnapshots(file);
+  final updated = [snapshot, ...current];
+  final overflow = updated.length > maxLibrarySnapshots
+      ? updated.sublist(maxLibrarySnapshots)
+      : const <LibrarySafetySnapshot>[];
+  for (final old in overflow) {
+    final oldFile = File(old.backupPath);
+    if (await oldFile.exists()) await oldFile.delete();
+  }
+  final kept = updated.take(maxLibrarySnapshots).toList();
+  await file.writeAsString(
+    jsonEncode(kept.map((s) => s.toJson()).toList()),
+  );
 }
 
 Future<void> clearLastLibrarySnapshot() async {
   final file = await _snapshotMetaFile();
+  final current = await _readSnapshots(file);
+  for (final snapshot in current) {
+    final snapshotFile = File(snapshot.backupPath);
+    if (await snapshotFile.exists()) await snapshotFile.delete();
+  }
   if (await file.exists()) await file.delete();
 }
 
-@riverpod
-Future<LibrarySafetySnapshot?> lastLibrarySnapshot(Ref ref) async {
-  final file = await _snapshotMetaFile();
-  if (!await file.exists()) return null;
+Future<List<LibrarySafetySnapshot>> _readSnapshots(File file) async {
+  if (!await file.exists()) return const [];
   try {
-    final snapshot = LibrarySafetySnapshot.fromJson(
-      jsonDecode(await file.readAsString()) as Map<String, dynamic>,
-    );
-    if (!await File(snapshot.backupPath).exists()) return null;
-    return snapshot;
+    final decoded = jsonDecode(await file.readAsString());
+    if (decoded is! List) return const [];
+    return decoded
+        .cast<Map<String, dynamic>>()
+        .map(LibrarySafetySnapshot.fromJson)
+        .toList();
   } catch (_) {
-    return null;
+    return const [];
   }
 }
 
-Future<Directory> _snapshotDirectory() =>
-    StorageProvider().createCacheDirectory('pre_import_backup');
+@riverpod
+Future<List<LibrarySafetySnapshot>> lastLibrarySnapshot(Ref ref) async {
+  final file = await _snapshotMetaFile();
+  final snapshots = await _readSnapshots(file);
+  final valid = <LibrarySafetySnapshot>[];
+  for (final snapshot in snapshots) {
+    if (await File(snapshot.backupPath).exists()) valid.add(snapshot);
+  }
+  return valid;
+}
+
+Future<Directory> _snapshotDirectory() async {
+  final storageProvider = StorageProvider();
+  final defaultDirectory = await storageProvider.getDefaultDirectory();
+  final dirPath = p.join(defaultDirectory!.path, 'pre_import_backup');
+  await storageProvider.createDirectorySafely(dirPath);
+  return Directory(dirPath);
+}
 
 Future<File> _snapshotMetaFile() async {
   final dir = await _snapshotDirectory();

--- a/lib/modules/more/data_and_storage/providers/pre_import_backup.g.dart
+++ b/lib/modules/more/data_and_storage/providers/pre_import_backup.g.dart
@@ -15,13 +15,13 @@ final lastLibrarySnapshotProvider = LastLibrarySnapshotProvider._();
 final class LastLibrarySnapshotProvider
     extends
         $FunctionalProvider<
-          AsyncValue<LibrarySafetySnapshot?>,
-          LibrarySafetySnapshot?,
-          FutureOr<LibrarySafetySnapshot?>
+          AsyncValue<List<LibrarySafetySnapshot>>,
+          List<LibrarySafetySnapshot>,
+          FutureOr<List<LibrarySafetySnapshot>>
         >
     with
-        $FutureModifier<LibrarySafetySnapshot?>,
-        $FutureProvider<LibrarySafetySnapshot?> {
+        $FutureModifier<List<LibrarySafetySnapshot>>,
+        $FutureProvider<List<LibrarySafetySnapshot>> {
   LastLibrarySnapshotProvider._()
     : super(
         from: null,
@@ -38,15 +38,15 @@ final class LastLibrarySnapshotProvider
 
   @$internal
   @override
-  $FutureProviderElement<LibrarySafetySnapshot?> $createElement(
+  $FutureProviderElement<List<LibrarySafetySnapshot>> $createElement(
     $ProviderPointer pointer,
   ) => $FutureProviderElement(pointer);
 
   @override
-  FutureOr<LibrarySafetySnapshot?> create(Ref ref) {
+  FutureOr<List<LibrarySafetySnapshot>> create(Ref ref) {
     return lastLibrarySnapshot(ref);
   }
 }
 
 String _$lastLibrarySnapshotHash() =>
-    r'3250af4c54279cc95875f1dca1fa9d831fb828d8';
+    r'b662e85baeacf7074597f3b4533bcada028f2d66';

--- a/lib/modules/more/data_and_storage/providers/pre_import_backup.g.dart
+++ b/lib/modules/more/data_and_storage/providers/pre_import_backup.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pre_import_backup.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(lastLibrarySnapshot)
+final lastLibrarySnapshotProvider = LastLibrarySnapshotProvider._();
+
+final class LastLibrarySnapshotProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<LibrarySafetySnapshot?>,
+          LibrarySafetySnapshot?,
+          FutureOr<LibrarySafetySnapshot?>
+        >
+    with
+        $FutureModifier<LibrarySafetySnapshot?>,
+        $FutureProvider<LibrarySafetySnapshot?> {
+  LastLibrarySnapshotProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'lastLibrarySnapshotProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$lastLibrarySnapshotHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<LibrarySafetySnapshot?> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<LibrarySafetySnapshot?> create(Ref ref) {
+    return lastLibrarySnapshot(ref);
+  }
+}
+
+String _$lastLibrarySnapshotHash() =>
+    r'3250af4c54279cc95875f1dca1fa9d831fb828d8';

--- a/lib/modules/more/data_and_storage/providers/restore.dart
+++ b/lib/modules/more/data_and_storage/providers/restore.dart
@@ -44,8 +44,9 @@ Future<void> doRestore(
   Map<String, bool> categoryDecisions = const {},
   Map<String, int> sourceDecisions = const {},
 }) async {
-  final inputStream = InputFileStream(path);
+  InputFileStream? inputStream;
   try {
+    inputStream = InputFileStream(path);
     final archive = ZipDecoder().decodeStream(inputStream);
     final backupType = checkBackupType(path, archive);
     switch (backupType) {
@@ -81,7 +82,7 @@ Future<void> doRestore(
   } catch (e, s) {
     botToast('$e\n$s');
   } finally {
-    inputStream.close();
+    inputStream?.close();
   }
 }
 
@@ -607,7 +608,7 @@ Future<void> restoreTachiBkBackup(
     );
   }
 
-  List<Category> cats = [];
+  final categoryByOrder = <int, Category>{};
   await writeTxnSyncWithRetry(() {
     if (!merge) {
       isar.categorys.clearSync();
@@ -622,21 +623,22 @@ Future<void> restoreTachiBkBackup(
               .findAllSync()
         : <Category>[];
     for (var category in backup.backupCategories) {
+      final order = _protoInt(category.order);
       final existing = existingCategories.firstWhereOrNull(
         (c) => c.name == category.name,
       );
       if (existing != null) {
         if (categoryDecisions[category.name] == false) continue;
-        cats.add(existing);
+        categoryByOrder[order] = existing;
         continue;
       }
       final cat = Category(
         name: category.name,
         forItemType: ItemType.manga,
-        pos: _protoInt(category.order),
+        pos: order,
       );
       isar.categorys.putSync(cat);
-      cats.add(cat);
+      categoryByOrder[order] = cat;
     }
     final existingMangaByLink = merge
         ? {
@@ -651,9 +653,9 @@ Future<void> restoreTachiBkBackup(
     for (var tempManga in backup.backupManga) {
       final sourceId = _protoInt(tempManga.source);
       final categoryOrders = tempManga.categories.map(_protoInt).toSet();
-      final newCategoryIds = cats
-          .where((cat) => categoryOrders.contains(cat.pos))
-          .map((cat) => cat.id!)
+      final newCategoryIds = categoryOrders
+          .map((o) => categoryByOrder[o]?.id)
+          .whereType<int>()
           .toList();
       final existingManga = existingMangaByLink[tempManga.url];
       final Manga manga;
@@ -683,8 +685,8 @@ Future<void> restoreTachiBkBackup(
           categories: newCategoryIds,
           itemType: ItemType.manga,
           favorite: true,
-          dateAdded: _protoMillis(tempManga.dateAdded),
-          lastUpdate: _protoMillis(tempManga.lastModifiedAt),
+          dateAdded: _protoInt(tempManga.dateAdded),
+          lastUpdate: _protoInt(tempManga.lastModifiedAt),
           sourceId: boundSource?.id,
         );
         if (bkType == BackupType.neko && boundSource == null) {
@@ -709,7 +711,7 @@ Future<void> restoreTachiBkBackup(
           mangaId: manga.id!,
           name: tempChapter.name,
           dateUpload: bkType != BackupType.neko
-              ? "${_protoMillis(tempChapter.dateUpload)}"
+              ? "${_protoInt(tempChapter.dateUpload)}"
               : "${DateTime.now().millisecondsSinceEpoch - _protoInt(tempChapter.dateUpload).abs()}",
           isBookmarked: tempChapter.bookmark,
           isRead: tempChapter.read,
@@ -723,11 +725,11 @@ Future<void> restoreTachiBkBackup(
         chapter.manga.saveSync();
         if ((history == null ||
             int.parse(history.date ?? "0") <
-                _protoMillis(tempChapter.lastModifiedAt))) {
+                _protoInt(tempChapter.lastModifiedAt))) {
           history = History(
             mangaId: manga.id,
             date: bkType != BackupType.neko
-                ? "${_protoMillis(tempChapter.lastModifiedAt)}"
+                ? "${_protoInt(tempChapter.lastModifiedAt)}"
                 : "${DateTime.now().millisecondsSinceEpoch - _protoInt(tempChapter.dateUpload).abs()}",
             itemType: ItemType.manga,
             chapterId: chapter.id,
@@ -754,7 +756,7 @@ Future<void> restoreTachiBkBackup(
     final animeSources = backupAnime.backupAnimeSources.isNotEmpty
         ? backupAnime.backupAnimeSources
         : backupAnime.legacyBackupAnimeSources;
-    List<Category> cats = [];
+    final categoryByOrder = <int, Category>{};
     await writeTxnSyncWithRetry(() {
       final existingAnimeCategories = merge
           ? isar.categorys
@@ -763,21 +765,22 @@ Future<void> restoreTachiBkBackup(
                 .findAllSync()
           : <Category>[];
       for (var category in animeCategories) {
+        final order = _protoInt(category.order);
         final existing = existingAnimeCategories.firstWhereOrNull(
           (c) => c.name == category.name,
         );
         if (existing != null) {
           if (categoryDecisions[category.name] == false) continue;
-          cats.add(existing);
+          categoryByOrder[order] = existing;
           continue;
         }
         final cat = Category(
           name: category.name,
           forItemType: ItemType.anime,
-          pos: _protoInt(category.order),
+          pos: order,
         );
         isar.categorys.putSync(cat);
-        cats.add(cat);
+        categoryByOrder[order] = cat;
       }
       final existingAnimeByLink = merge
           ? {
@@ -792,9 +795,9 @@ Future<void> restoreTachiBkBackup(
       for (var tempAnime in animeEntries) {
         final sourceId = _protoInt(tempAnime.source);
         final categoryOrders = tempAnime.categories.map(_protoInt).toSet();
-        final newCategoryIds = cats
-            .where((cat) => categoryOrders.contains(cat.pos))
-            .map((cat) => cat.id!)
+        final newCategoryIds = categoryOrders
+            .map((o) => categoryByOrder[o]?.id)
+            .whereType<int>()
             .toList();
         final existingAnime = existingAnimeByLink[tempAnime.url];
         final Manga anime;
@@ -826,8 +829,8 @@ Future<void> restoreTachiBkBackup(
             categories: newCategoryIds,
             itemType: ItemType.anime,
             favorite: true,
-            dateAdded: _protoMillis(tempAnime.dateAdded),
-            lastUpdate: _protoMillis(tempAnime.lastModifiedAt),
+            dateAdded: _protoInt(tempAnime.dateAdded),
+            lastUpdate: _protoInt(tempAnime.lastModifiedAt),
             sourceId: boundSource?.id,
           );
         }
@@ -848,11 +851,11 @@ Future<void> restoreTachiBkBackup(
           final episode = Chapter(
             mangaId: anime.id!,
             name: tempEpisode.name,
-            dateUpload: "${_protoMillis(tempEpisode.dateUpload)}",
+            dateUpload: "${_protoInt(tempEpisode.dateUpload)}",
             isBookmarked: tempEpisode.bookmark,
             isRead: tempEpisode.seen,
             lastPageRead: _protoInt(tempEpisode.lastSecondSeen) != 0
-                ? "${_protoMillis(tempEpisode.lastSecondSeen)}"
+                ? "${_secondsToMillis(tempEpisode.lastSecondSeen)}"
                 : "1",
             scanlator: tempEpisode.scanlator,
             url: tempEpisode.url,
@@ -861,10 +864,10 @@ Future<void> restoreTachiBkBackup(
           episode.manga.saveSync();
           if ((history == null ||
               int.parse(history.date ?? "0") <
-                  _protoMillis(tempEpisode.lastModifiedAt))) {
+                  _protoInt(tempEpisode.lastModifiedAt))) {
             history = History(
               mangaId: anime.id,
-              date: "${_protoMillis(tempEpisode.lastModifiedAt)}",
+              date: "${_protoInt(tempEpisode.lastModifiedAt)}",
               itemType: ItemType.anime,
               chapterId: episode.id,
             )..chapter.value = episode;
@@ -901,7 +904,7 @@ int _protoInt(Object value) {
   return (value as dynamic).toInt() as int;
 }
 
-int _protoMillis(Object seconds) => _protoInt(seconds) * 1000;
+int _secondsToMillis(Object seconds) => _protoInt(seconds) * 1000;
 
 Settings _preserveDeviceLocalSettings(Settings incoming, Settings current) {
   return incoming

--- a/lib/modules/more/data_and_storage/providers/restore.dart
+++ b/lib/modules/more/data_and_storage/providers/restore.dart
@@ -30,12 +30,20 @@ import 'package:mangayomi/modules/more/settings/reader/providers/reader_state_pr
 import 'package:mangayomi/modules/more/settings/sync/providers/sync_providers.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/router/router.dart';
+import 'package:mangayomi/utils/isar_txn_retry.dart';
 import 'package:protobuf/protobuf.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'restore.g.dart';
 
 @riverpod
-void doRestore(Ref ref, {required String path, required BuildContext context}) {
+Future<void> doRestore(
+  Ref ref, {
+  required String path,
+  required BuildContext context,
+  bool merge = false,
+  Map<String, bool> categoryDecisions = const {},
+  Map<String, int> sourceDecisions = const {},
+}) async {
   final inputStream = InputFileStream(path);
   try {
     final archive = ZipDecoder().decodeStream(inputStream);
@@ -45,15 +53,23 @@ void doRestore(Ref ref, {required String path, required BuildContext context}) {
         final backup = jsonDecode(
           utf8.decode(archive.files.first.content),
         ) as Map<String, dynamic>;
-        ref.read(restoreBackupProvider(backup));
+        await ref.read(restoreBackupProvider(backup).future);
         break;
       case BackupType.kotatsu:
-        ref.read(restoreKotatsuBackupProvider(archive));
+        await ref.read(restoreKotatsuBackupProvider(archive).future);
         break;
       case BackupType.mihon:
       case BackupType.aniyomi:
       case BackupType.neko:
-        ref.read(restoreTachiBkBackupProvider(path, backupType));
+        await ref.read(
+          restoreTachiBkBackupProvider(
+            path,
+            backupType,
+            merge: merge,
+            categoryDecisions: categoryDecisions,
+            sourceDecisions: sourceDecisions,
+          ).future,
+        );
         break;
       default:
     }
@@ -105,7 +121,9 @@ BackupType checkBackupType(String path, Archive archive) {
       path.toLowerCase().endsWith(".proto.gz")) {
     return path.contains("xyz.jmir.tachiyomi.mi") || path.contains("aniyomi.mi")
         ? BackupType.aniyomi
-        : path.contains("tachiyomi") || path.contains("mihon")
+        : path.contains("tachiyomi") ||
+              path.contains("mihon") ||
+              path.contains("komikku")
         ? BackupType.mihon
         : path.contains("neko")
         ? BackupType.neko
@@ -114,8 +132,179 @@ BackupType checkBackupType(String path, Archive archive) {
   return BackupType.unknown;
 }
 
+BackupType peekBackupType(String path) {
+  final inputStream = InputFileStream(path);
+  try {
+    final archive = ZipDecoder().decodeStream(inputStream);
+    return checkBackupType(path, archive);
+  } finally {
+    inputStream.close();
+  }
+}
+
+class TachiBkImportPreview {
+  TachiBkImportPreview({
+    required this.conflictingCategories,
+    required this.unmatchedSourceNames,
+    required this.newSeriesCount,
+    required this.updatedSeriesCount,
+    required this.newChapterCount,
+  });
+
+  final List<String> conflictingCategories;
+
+  final Map<String, ItemType> unmatchedSourceNames;
+
+  final int newSeriesCount;
+  final int updatedSeriesCount;
+  final int newChapterCount;
+}
+
+TachiBkImportPreview? previewTachiBkImport(String path) {
+  final backupType = peekBackupType(path);
+  if (backupType != BackupType.mihon &&
+      backupType != BackupType.aniyomi &&
+      backupType != BackupType.neko) {
+    return null;
+  }
+  final inputStream = InputFileStream(path);
+  final content = GZipDecoder().decodeBytes(inputStream.toUint8List());
+  inputStream.close();
+  final backup = BackupMihon.create();
+  backup.mergeFromCodedBufferReader(
+    CodedBufferReader(content, sizeLimit: 250 << 20),
+  );
+
+  final existingCategoryNames = isar.categorys
+      .where()
+      .findAllSync()
+      .map((c) => c.name)
+      .whereType<String>()
+      .toSet();
+  final categoryNames = <String>{for (var c in backup.backupCategories) c.name};
+
+  final installedSourceNames = isar.sources
+      .where()
+      .findAllSync()
+      .where((s) => s.sourceCode != null)
+      .map((s) => (s.itemType, s.name?.toLowerCase()))
+      .toSet();
+  final unmatchedSources = <String, ItemType>{};
+
+  final existingMangaByLink = {
+    for (var m
+        in isar.mangas.filter().itemTypeEqualTo(ItemType.manga).findAllSync())
+      if (m.link != null) m.link!: m,
+  };
+  int newSeries = 0, updatedSeries = 0, newChapters = 0;
+  for (var m in backup.backupManga) {
+    final sourceId = _protoInt(m.source);
+    final srcName =
+        backup.backupSources
+            .firstWhereOrNull((s) => _protoInt(s.sourceId) == sourceId)
+            ?.name ??
+        "Unknown";
+    if (!installedSourceNames.contains((
+      ItemType.manga,
+      srcName.toLowerCase(),
+    ))) {
+      unmatchedSources[srcName] = ItemType.manga;
+    }
+    final existing = existingMangaByLink[m.url];
+    if (existing != null) {
+      updatedSeries++;
+      final existingUrls = isar.chapters
+          .filter()
+          .mangaIdEqualTo(existing.id)
+          .findAllSync()
+          .map((c) => c.url)
+          .whereType<String>()
+          .toSet();
+      newChapters += m.chapters
+          .where((c) => !existingUrls.contains(c.url))
+          .length;
+    } else {
+      newSeries++;
+      newChapters += m.chapters.length;
+    }
+  }
+
+  if (backupType == BackupType.aniyomi) {
+    final backupAnime = BackupAniyomi.fromBuffer(content);
+    final animeCategories = backupAnime.backupAnimeCategories.isNotEmpty
+        ? backupAnime.backupAnimeCategories
+        : backupAnime.legacyBackupAnimeCategories;
+    final animeEntries = backupAnime.backupAnime.isNotEmpty
+        ? backupAnime.backupAnime
+        : backupAnime.legacyBackupAnime;
+    final animeSources = backupAnime.backupAnimeSources.isNotEmpty
+        ? backupAnime.backupAnimeSources
+        : backupAnime.legacyBackupAnimeSources;
+    categoryNames.addAll(animeCategories.map((c) => c.name));
+    final existingAnimeByLink = {
+      for (var m
+          in isar.mangas.filter().itemTypeEqualTo(ItemType.anime).findAllSync())
+        if (m.link != null) m.link!: m,
+    };
+    for (var a in animeEntries) {
+      final sourceId = _protoInt(a.source);
+      final srcName =
+          animeSources
+              .firstWhereOrNull((s) => _protoInt(s.sourceId) == sourceId)
+              ?.name ??
+          "Unknown";
+      if (!installedSourceNames.contains((
+        ItemType.anime,
+        srcName.toLowerCase(),
+      ))) {
+        unmatchedSources[srcName] = ItemType.anime;
+      }
+      final existing = existingAnimeByLink[a.url];
+      if (existing != null) {
+        updatedSeries++;
+        final existingUrls = isar.chapters
+            .filter()
+            .mangaIdEqualTo(existing.id)
+            .findAllSync()
+            .map((c) => c.url)
+            .whereType<String>()
+            .toSet();
+        newChapters += a.episodes
+            .where((c) => !existingUrls.contains(c.url))
+            .length;
+      } else {
+        newSeries++;
+        newChapters += a.episodes.length;
+      }
+    }
+  }
+
+  return TachiBkImportPreview(
+    conflictingCategories: categoryNames
+        .where(existingCategoryNames.contains)
+        .toList(),
+    unmatchedSourceNames: unmatchedSources,
+    newSeriesCount: newSeries,
+    updatedSeriesCount: updatedSeries,
+    newChapterCount: newChapters,
+  );
+}
+
+List<Source> installedSourcesFor(ItemType itemType) => isar.sources
+    .where()
+    .findAllSync()
+    .where((s) => s.itemType == itemType && s.sourceCode != null)
+    .toList();
+
+int currentFavoriteMangaCount() =>
+    isar.mangas.filter().favoriteEqualTo(true).countSync();
+
 @riverpod
-void restoreBackup(Ref ref, Map<String, dynamic> backup, {bool full = true}) {
+Future<void> restoreBackup(
+  Ref ref,
+  Map<String, dynamic> backup, {
+  bool full = true,
+}) async {
   final version = backup['version'];
   if (["1", "2"].any((e) => e == version)) {
     try {
@@ -161,7 +350,7 @@ void restoreBackup(Ref ref, Map<String, dynamic> backup, {bool full = true}) {
           .toList();
 
       final currentSettings = isar.settings.getSync(227);
-      isar.writeTxnSync(() {
+      await writeTxnSyncWithRetry(() {
         isar.mangas.clearSync();
         if (manga != null) {
           isar.mangas.putAllSync(manga);
@@ -315,14 +504,14 @@ ItemType _convertToItemTypeCategory(Map<String, dynamic> backup) {
 }
 
 @riverpod
-void restoreKotatsuBackup(Ref ref, Archive archive) {
+Future<void> restoreKotatsuBackup(Ref ref, Archive archive) async {
   try {
     for (var f in archive.files) {
       List<Category> cats = [];
       switch (f.name) {
         case "categories":
           final categories = jsonDecode(utf8.decode(f.content)) as List? ?? [];
-          isar.writeTxnSync(() {
+          await writeTxnSyncWithRetry(() {
             isar.categorys.clearSync();
             for (var category in categories) {
               final cat = Category(
@@ -337,7 +526,7 @@ void restoreKotatsuBackup(Ref ref, Archive archive) {
           });
         case "favourites":
           final favourites = jsonDecode(utf8.decode(f.content)) as List? ?? [];
-          isar.writeTxnSync(() {
+          await writeTxnSyncWithRetry(() {
             isar.mangas.clearSync();
             for (var favourite in favourites) {
               final tempManga = favourite["manga"];
@@ -373,7 +562,7 @@ void restoreKotatsuBackup(Ref ref, Archive archive) {
           continue;
       }
     }
-    isar.writeTxnSync(() {
+    await writeTxnSyncWithRetry(() {
       isar.chapters.clearSync();
       isar.downloads.clearSync();
       isar.historys.clearSync();
@@ -388,7 +577,14 @@ void restoreKotatsuBackup(Ref ref, Archive archive) {
 }
 
 @riverpod
-void restoreTachiBkBackup(Ref ref, String path, BackupType bkType) {
+Future<void> restoreTachiBkBackup(
+  Ref ref,
+  String path,
+  BackupType bkType, {
+  bool merge = false,
+  Map<String, bool> categoryDecisions = const {},
+  Map<String, int> sourceDecisions = const {},
+}) async {
   final inputStream = InputFileStream(path);
   final content = GZipDecoder().decodeBytes(inputStream.toUint8List());
   inputStream.close();
@@ -396,13 +592,44 @@ void restoreTachiBkBackup(Ref ref, String path, BackupType bkType) {
   backup.mergeFromCodedBufferReader(
     CodedBufferReader(content, sizeLimit: 250 << 20),
   );
+  final installedSources = isar.sources
+      .where()
+      .findAllSync()
+      .where((s) => s.sourceCode != null)
+      .toList();
+  Source? resolveSource(String originalName, ItemType itemType) {
+    final decision = sourceDecisions[originalName];
+    if (decision != null) return isar.sources.getSync(decision);
+    return installedSources.firstWhereOrNull(
+      (s) =>
+          s.itemType == itemType &&
+          s.name?.toLowerCase() == originalName.toLowerCase(),
+    );
+  }
+
   List<Category> cats = [];
-  isar.writeTxnSync(() {
-    isar.categorys.clearSync();
-    isar.mangas.clearSync();
-    isar.chapters.clearSync();
-    isar.historys.clearSync();
+  await writeTxnSyncWithRetry(() {
+    if (!merge) {
+      isar.categorys.clearSync();
+      isar.mangas.clearSync();
+      isar.chapters.clearSync();
+      isar.historys.clearSync();
+    }
+    final existingCategories = merge
+        ? isar.categorys
+              .filter()
+              .forItemTypeEqualTo(ItemType.manga)
+              .findAllSync()
+        : <Category>[];
     for (var category in backup.backupCategories) {
+      final existing = existingCategories.firstWhereOrNull(
+        (c) => c.name == category.name,
+      );
+      if (existing != null) {
+        if (categoryDecisions[category.name] == false) continue;
+        cats.add(existing);
+        continue;
+      }
       final cat = Category(
         name: category.name,
         forItemType: ItemType.manga,
@@ -411,40 +638,73 @@ void restoreTachiBkBackup(Ref ref, String path, BackupType bkType) {
       isar.categorys.putSync(cat);
       cats.add(cat);
     }
+    final existingMangaByLink = merge
+        ? {
+            for (var m
+                in isar.mangas
+                    .filter()
+                    .itemTypeEqualTo(ItemType.manga)
+                    .findAllSync())
+              if (m.link != null) m.link!: m,
+          }
+        : <String, Manga>{};
     for (var tempManga in backup.backupManga) {
       final sourceId = _protoInt(tempManga.source);
       final categoryOrders = tempManga.categories.map(_protoInt).toSet();
-      final manga = Manga(
-        source:
+      final newCategoryIds = cats
+          .where((cat) => categoryOrders.contains(cat.pos))
+          .map((cat) => cat.id!)
+          .toList();
+      final existingManga = existingMangaByLink[tempManga.url];
+      final Manga manga;
+      final bool isNewManga = existingManga == null;
+      if (existingManga != null) {
+        manga = existingManga;
+        manga.favorite = true;
+        manga.categories = {...?manga.categories, ...newCategoryIds}.toList();
+      } else {
+        final originalSourceName =
             backup.backupSources
                 .firstWhereOrNull((src) => _protoInt(src.sourceId) == sourceId)
                 ?.name ??
-            "Unknown",
-        author: tempManga.author,
-        artist: tempManga.artist,
-        genre: tempManga.genre,
-        imageUrl: tempManga.thumbnailUrl,
-        lang: 'en',
-        link: tempManga.url,
-        name: tempManga.title,
-        status: _convertStatusFromTachiBk(tempManga.status),
-        description: tempManga.description,
-        categories: cats
-            .where((cat) => categoryOrders.contains(cat.pos))
-            .map((cat) => cat.id!)
-            .toList(),
-        itemType: ItemType.manga,
-        favorite: true,
-        dateAdded: _protoMillis(tempManga.dateAdded),
-        lastUpdate: _protoMillis(tempManga.lastModifiedAt),
-        sourceId: null,
-      );
-      if (bkType == BackupType.neko) {
-        manga.source = "MangaDex";
+            "Unknown";
+        final boundSource = resolveSource(originalSourceName, ItemType.manga);
+        manga = Manga(
+          source: boundSource?.name ?? originalSourceName,
+          author: tempManga.author,
+          artist: tempManga.artist,
+          genre: tempManga.genre,
+          imageUrl: tempManga.thumbnailUrl,
+          lang: boundSource?.lang ?? 'en',
+          link: tempManga.url,
+          name: tempManga.title,
+          status: _convertStatusFromTachiBk(tempManga.status),
+          description: tempManga.description,
+          categories: newCategoryIds,
+          itemType: ItemType.manga,
+          favorite: true,
+          dateAdded: _protoMillis(tempManga.dateAdded),
+          lastUpdate: _protoMillis(tempManga.lastModifiedAt),
+          sourceId: boundSource?.id,
+        );
+        if (bkType == BackupType.neko && boundSource == null) {
+          manga.source = "MangaDex";
+        }
       }
       isar.mangas.putSync(manga);
+      final existingChaptersByUrl = merge && !isNewManga
+          ? {
+              for (var c
+                  in isar.chapters
+                      .filter()
+                      .mangaIdEqualTo(manga.id)
+                      .findAllSync())
+                if (c.url != null) c.url!: c,
+            }
+          : <String, Chapter>{};
       History? history;
       for (var tempChapter in tempManga.chapters) {
+        if (existingChaptersByUrl.containsKey(tempChapter.url)) continue;
         final chapter = Chapter(
           mangaId: manga.id!,
           name: tempChapter.name,
@@ -474,7 +734,10 @@ void restoreTachiBkBackup(Ref ref, String path, BackupType bkType) {
           )..chapter.value = chapter;
         }
       }
-      if (history != null) {
+      if (history != null &&
+          (!merge ||
+              isar.historys.filter().mangaIdEqualTo(manga.id).findFirstSync() ==
+                  null)) {
         isar.historys.putSync(history);
         history.chapter.saveSync();
       }
@@ -492,8 +755,22 @@ void restoreTachiBkBackup(Ref ref, String path, BackupType bkType) {
         ? backupAnime.backupAnimeSources
         : backupAnime.legacyBackupAnimeSources;
     List<Category> cats = [];
-    isar.writeTxnSync(() {
+    await writeTxnSyncWithRetry(() {
+      final existingAnimeCategories = merge
+          ? isar.categorys
+                .filter()
+                .forItemTypeEqualTo(ItemType.anime)
+                .findAllSync()
+          : <Category>[];
       for (var category in animeCategories) {
+        final existing = existingAnimeCategories.firstWhereOrNull(
+          (c) => c.name == category.name,
+        );
+        if (existing != null) {
+          if (categoryDecisions[category.name] == false) continue;
+          cats.add(existing);
+          continue;
+        }
         final cat = Category(
           name: category.name,
           forItemType: ItemType.anime,
@@ -502,39 +779,72 @@ void restoreTachiBkBackup(Ref ref, String path, BackupType bkType) {
         isar.categorys.putSync(cat);
         cats.add(cat);
       }
+      final existingAnimeByLink = merge
+          ? {
+              for (var m
+                  in isar.mangas
+                      .filter()
+                      .itemTypeEqualTo(ItemType.anime)
+                      .findAllSync())
+                if (m.link != null) m.link!: m,
+            }
+          : <String, Manga>{};
       for (var tempAnime in animeEntries) {
         final sourceId = _protoInt(tempAnime.source);
         final categoryOrders = tempAnime.categories.map(_protoInt).toSet();
-        final anime = Manga(
-          source:
+        final newCategoryIds = cats
+            .where((cat) => categoryOrders.contains(cat.pos))
+            .map((cat) => cat.id!)
+            .toList();
+        final existingAnime = existingAnimeByLink[tempAnime.url];
+        final Manga anime;
+        final bool isNewAnime = existingAnime == null;
+        if (existingAnime != null) {
+          anime = existingAnime;
+          anime.favorite = true;
+          anime.categories = {...?anime.categories, ...newCategoryIds}.toList();
+        } else {
+          final originalSourceName =
               animeSources
                   .firstWhereOrNull(
                     (src) => _protoInt(src.sourceId) == sourceId,
                   )
                   ?.name ??
-              "Unknown",
-          author: tempAnime.author,
-          artist: tempAnime.artist,
-          genre: tempAnime.genre,
-          imageUrl: tempAnime.thumbnailUrl,
-          lang: 'en',
-          link: tempAnime.url,
-          name: tempAnime.title,
-          status: _convertStatusFromTachiBk(tempAnime.status),
-          description: tempAnime.description,
-          categories: cats
-              .where((cat) => categoryOrders.contains(cat.pos))
-              .map((cat) => cat.id!)
-              .toList(),
-          itemType: ItemType.anime,
-          favorite: true,
-          dateAdded: _protoMillis(tempAnime.dateAdded),
-          lastUpdate: _protoMillis(tempAnime.lastModifiedAt),
-          sourceId: null,
-        );
+              "Unknown";
+          final boundSource = resolveSource(originalSourceName, ItemType.anime);
+          anime = Manga(
+            source: boundSource?.name ?? originalSourceName,
+            author: tempAnime.author,
+            artist: tempAnime.artist,
+            genre: tempAnime.genre,
+            imageUrl: tempAnime.thumbnailUrl,
+            lang: boundSource?.lang ?? 'en',
+            link: tempAnime.url,
+            name: tempAnime.title,
+            status: _convertStatusFromTachiBk(tempAnime.status),
+            description: tempAnime.description,
+            categories: newCategoryIds,
+            itemType: ItemType.anime,
+            favorite: true,
+            dateAdded: _protoMillis(tempAnime.dateAdded),
+            lastUpdate: _protoMillis(tempAnime.lastModifiedAt),
+            sourceId: boundSource?.id,
+          );
+        }
         isar.mangas.putSync(anime);
+        final existingEpisodesByUrl = merge && !isNewAnime
+            ? {
+                for (var c
+                    in isar.chapters
+                        .filter()
+                        .mangaIdEqualTo(anime.id)
+                        .findAllSync())
+                  if (c.url != null) c.url!: c,
+              }
+            : <String, Chapter>{};
         History? history;
         for (var tempEpisode in tempAnime.episodes) {
+          if (existingEpisodesByUrl.containsKey(tempEpisode.url)) continue;
           final episode = Chapter(
             mangaId: anime.id!,
             name: tempEpisode.name,
@@ -560,18 +870,26 @@ void restoreTachiBkBackup(Ref ref, String path, BackupType bkType) {
             )..chapter.value = episode;
           }
         }
-        if (history != null) {
+        if (history != null &&
+            (!merge ||
+                isar.historys
+                        .filter()
+                        .mangaIdEqualTo(anime.id)
+                        .findFirstSync() ==
+                    null)) {
           isar.historys.putSync(history);
           history.chapter.saveSync();
         }
       }
     });
   }
-  isar.writeTxnSync(() {
-    isar.downloads.clearSync();
-    isar.updates.clearSync();
-    isar.tracks.clearSync();
-    isar.trackPreferences.clearSync();
+  await writeTxnSyncWithRetry(() {
+    if (!merge) {
+      isar.downloads.clearSync();
+      isar.updates.clearSync();
+      isar.tracks.clearSync();
+      isar.trackPreferences.clearSync();
+    }
     _invalidateCommonState(ref);
   });
 }
@@ -596,6 +914,7 @@ Settings _preserveDeviceLocalSettings(Settings incoming, Settings current) {
     ..jrePath = current.jrePath
     ..extensionServerPath = current.extensionServerPath;
 }
+
 void _invalidateCommonState(Ref ref) {
   ref.read(synchingProvider(syncId: 1).notifier).clearAllChangedParts(false);
   ref.invalidate(followSystemThemeStateProvider);

--- a/lib/modules/more/data_and_storage/providers/restore.g.dart
+++ b/lib/modules/more/data_and_storage/providers/restore.g.dart
@@ -80,7 +80,7 @@ final class DoRestoreProvider
   }
 }
 
-String _$doRestoreHash() => r'6b158fd7fa9285914ff4c7f0f7a93f4494925d06';
+String _$doRestoreHash() => r'e9a6e18d390cde83ce3721016e2c8fd104fca3f4';
 
 final class DoRestoreFamily extends $Family
     with
@@ -339,7 +339,7 @@ final class RestoreTachiBkBackupProvider
 }
 
 String _$restoreTachiBkBackupHash() =>
-    r'4dfa04c20f01f96d2f17c9efaabbcfade222d54f';
+    r'20c74e7c12682bd61d4df5ab0ae6ac79cbac0e8b';
 
 final class RestoreTachiBkBackupFamily extends $Family
     with

--- a/lib/modules/more/data_and_storage/providers/restore.g.dart
+++ b/lib/modules/more/data_and_storage/providers/restore.g.dart
@@ -12,11 +12,19 @@ part of 'restore.dart';
 @ProviderFor(doRestore)
 final doRestoreProvider = DoRestoreFamily._();
 
-final class DoRestoreProvider extends $FunctionalProvider<void, void, void>
-    with $Provider<void> {
+final class DoRestoreProvider
+    extends $FunctionalProvider<AsyncValue<void>, void, FutureOr<void>>
+    with $FutureModifier<void>, $FutureProvider<void> {
   DoRestoreProvider._({
     required DoRestoreFamily super.from,
-    required ({String path, BuildContext context}) super.argument,
+    required ({
+      String path,
+      BuildContext context,
+      bool merge,
+      Map<String, bool> categoryDecisions,
+      Map<String, int> sourceDecisions,
+    })
+    super.argument,
   }) : super(
          retry: null,
          name: r'doRestoreProvider',
@@ -37,20 +45,27 @@ final class DoRestoreProvider extends $FunctionalProvider<void, void, void>
 
   @$internal
   @override
-  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
+  $FutureProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
-  void create(Ref ref) {
-    final argument = this.argument as ({String path, BuildContext context});
-    return doRestore(ref, path: argument.path, context: argument.context);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(void value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<void>(value),
+  FutureOr<void> create(Ref ref) {
+    final argument =
+        this.argument
+            as ({
+              String path,
+              BuildContext context,
+              bool merge,
+              Map<String, bool> categoryDecisions,
+              Map<String, int> sourceDecisions,
+            });
+    return doRestore(
+      ref,
+      path: argument.path,
+      context: argument.context,
+      merge: argument.merge,
+      categoryDecisions: argument.categoryDecisions,
+      sourceDecisions: argument.sourceDecisions,
     );
   }
 
@@ -65,11 +80,20 @@ final class DoRestoreProvider extends $FunctionalProvider<void, void, void>
   }
 }
 
-String _$doRestoreHash() => r'4e556ae822d1f48ef3519fd65393c178de14b73d';
+String _$doRestoreHash() => r'6b158fd7fa9285914ff4c7f0f7a93f4494925d06';
 
 final class DoRestoreFamily extends $Family
     with
-        $FunctionalFamilyOverride<void, ({String path, BuildContext context})> {
+        $FunctionalFamilyOverride<
+          FutureOr<void>,
+          ({
+            String path,
+            BuildContext context,
+            bool merge,
+            Map<String, bool> categoryDecisions,
+            Map<String, int> sourceDecisions,
+          })
+        > {
   DoRestoreFamily._()
     : super(
         retry: null,
@@ -82,8 +106,19 @@ final class DoRestoreFamily extends $Family
   DoRestoreProvider call({
     required String path,
     required BuildContext context,
-  }) =>
-      DoRestoreProvider._(argument: (path: path, context: context), from: this);
+    bool merge = false,
+    Map<String, bool> categoryDecisions = const {},
+    Map<String, int> sourceDecisions = const {},
+  }) => DoRestoreProvider._(
+    argument: (
+      path: path,
+      context: context,
+      merge: merge,
+      categoryDecisions: categoryDecisions,
+      sourceDecisions: sourceDecisions,
+    ),
+    from: this,
+  );
 
   @override
   String toString() => r'doRestoreProvider';
@@ -92,8 +127,9 @@ final class DoRestoreFamily extends $Family
 @ProviderFor(restoreBackup)
 final restoreBackupProvider = RestoreBackupFamily._();
 
-final class RestoreBackupProvider extends $FunctionalProvider<void, void, void>
-    with $Provider<void> {
+final class RestoreBackupProvider
+    extends $FunctionalProvider<AsyncValue<void>, void, FutureOr<void>>
+    with $FutureModifier<void>, $FutureProvider<void> {
   RestoreBackupProvider._({
     required RestoreBackupFamily super.from,
     required (Map<String, dynamic>, {bool full}) super.argument,
@@ -117,21 +153,13 @@ final class RestoreBackupProvider extends $FunctionalProvider<void, void, void>
 
   @$internal
   @override
-  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
+  $FutureProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
-  void create(Ref ref) {
+  FutureOr<void> create(Ref ref) {
     final argument = this.argument as (Map<String, dynamic>, {bool full});
     return restoreBackup(ref, argument.$1, full: argument.full);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(void value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<void>(value),
-    );
   }
 
   @override
@@ -145,10 +173,14 @@ final class RestoreBackupProvider extends $FunctionalProvider<void, void, void>
   }
 }
 
-String _$restoreBackupHash() => r'942d8e7548daeb3138b3b4c26565fdee2d4c4aa1';
+String _$restoreBackupHash() => r'02e1e607cf60fc3e0784deef5bdc27debe8d847e';
 
 final class RestoreBackupFamily extends $Family
-    with $FunctionalFamilyOverride<void, (Map<String, dynamic>, {bool full})> {
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<void>,
+          (Map<String, dynamic>, {bool full})
+        > {
   RestoreBackupFamily._()
     : super(
         retry: null,
@@ -169,8 +201,8 @@ final class RestoreBackupFamily extends $Family
 final restoreKotatsuBackupProvider = RestoreKotatsuBackupFamily._();
 
 final class RestoreKotatsuBackupProvider
-    extends $FunctionalProvider<void, void, void>
-    with $Provider<void> {
+    extends $FunctionalProvider<AsyncValue<void>, void, FutureOr<void>>
+    with $FutureModifier<void>, $FutureProvider<void> {
   RestoreKotatsuBackupProvider._({
     required RestoreKotatsuBackupFamily super.from,
     required Archive super.argument,
@@ -194,21 +226,13 @@ final class RestoreKotatsuBackupProvider
 
   @$internal
   @override
-  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
+  $FutureProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
-  void create(Ref ref) {
+  FutureOr<void> create(Ref ref) {
     final argument = this.argument as Archive;
     return restoreKotatsuBackup(ref, argument);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(void value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<void>(value),
-    );
   }
 
   @override
@@ -223,10 +247,10 @@ final class RestoreKotatsuBackupProvider
 }
 
 String _$restoreKotatsuBackupHash() =>
-    r'4b43cb1719527b3030b9966e5ef662c29435425d';
+    r'e63edd7e3260920b9ced279927cae3902701f8a3';
 
 final class RestoreKotatsuBackupFamily extends $Family
-    with $FunctionalFamilyOverride<void, Archive> {
+    with $FunctionalFamilyOverride<FutureOr<void>, Archive> {
   RestoreKotatsuBackupFamily._()
     : super(
         retry: null,
@@ -247,11 +271,18 @@ final class RestoreKotatsuBackupFamily extends $Family
 final restoreTachiBkBackupProvider = RestoreTachiBkBackupFamily._();
 
 final class RestoreTachiBkBackupProvider
-    extends $FunctionalProvider<void, void, void>
-    with $Provider<void> {
+    extends $FunctionalProvider<AsyncValue<void>, void, FutureOr<void>>
+    with $FutureModifier<void>, $FutureProvider<void> {
   RestoreTachiBkBackupProvider._({
     required RestoreTachiBkBackupFamily super.from,
-    required (String, BackupType) super.argument,
+    required (
+      String,
+      BackupType, {
+      bool merge,
+      Map<String, bool> categoryDecisions,
+      Map<String, int> sourceDecisions,
+    })
+    super.argument,
   }) : super(
          retry: null,
          name: r'restoreTachiBkBackupProvider',
@@ -272,20 +303,27 @@ final class RestoreTachiBkBackupProvider
 
   @$internal
   @override
-  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
+  $FutureProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
-  void create(Ref ref) {
-    final argument = this.argument as (String, BackupType);
-    return restoreTachiBkBackup(ref, argument.$1, argument.$2);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(void value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<void>(value),
+  FutureOr<void> create(Ref ref) {
+    final argument =
+        this.argument
+            as (
+              String,
+              BackupType, {
+              bool merge,
+              Map<String, bool> categoryDecisions,
+              Map<String, int> sourceDecisions,
+            });
+    return restoreTachiBkBackup(
+      ref,
+      argument.$1,
+      argument.$2,
+      merge: argument.merge,
+      categoryDecisions: argument.categoryDecisions,
+      sourceDecisions: argument.sourceDecisions,
     );
   }
 
@@ -301,10 +339,20 @@ final class RestoreTachiBkBackupProvider
 }
 
 String _$restoreTachiBkBackupHash() =>
-    r'0f121d94021eb9a56d0689240dbcefd49f5a2a79';
+    r'4dfa04c20f01f96d2f17c9efaabbcfade222d54f';
 
 final class RestoreTachiBkBackupFamily extends $Family
-    with $FunctionalFamilyOverride<void, (String, BackupType)> {
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<void>,
+          (
+            String,
+            BackupType, {
+            bool merge,
+            Map<String, bool> categoryDecisions,
+            Map<String, int> sourceDecisions,
+          })
+        > {
   RestoreTachiBkBackupFamily._()
     : super(
         retry: null,
@@ -314,8 +362,22 @@ final class RestoreTachiBkBackupFamily extends $Family
         isAutoDispose: true,
       );
 
-  RestoreTachiBkBackupProvider call(String path, BackupType bkType) =>
-      RestoreTachiBkBackupProvider._(argument: (path, bkType), from: this);
+  RestoreTachiBkBackupProvider call(
+    String path,
+    BackupType bkType, {
+    bool merge = false,
+    Map<String, bool> categoryDecisions = const {},
+    Map<String, int> sourceDecisions = const {},
+  }) => RestoreTachiBkBackupProvider._(
+    argument: (
+      path,
+      bkType,
+      merge: merge,
+      categoryDecisions: categoryDecisions,
+      sourceDecisions: sourceDecisions,
+    ),
+    from: this,
+  );
 
   @override
   String toString() => r'restoreTachiBkBackupProvider';

--- a/lib/modules/more/data_and_storage/widgets/rollback_last_change_tile.dart
+++ b/lib/modules/more/data_and_storage/widgets/rollback_last_change_tile.dart
@@ -12,10 +12,33 @@ class RollbackLastChangeTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final snapshot = ref.watch(lastLibrarySnapshotProvider).asData?.value;
-    if (snapshot == null) return const SizedBox.shrink();
+    final snapshots = ref.watch(lastLibrarySnapshotProvider).asData?.value;
+    if (snapshots == null || snapshots.isEmpty) return const SizedBox.shrink();
     final l10n = context.l10n;
-    return ListTile(
+
+    if (snapshots.length == 1) {
+      final snapshot = snapshots.first;
+      return ListTile(
+        leading: const Icon(
+          Icons.settings_backup_restore_rounded,
+          color: Colors.red,
+        ),
+        title: Text(
+          l10n.roll_back_last_change,
+          style: const TextStyle(color: Colors.red),
+        ),
+        subtitle: Text(
+          l10n.roll_back_last_change_subtitle(
+            DateTime.fromMillisecondsSinceEpoch(snapshot.createdAt).toString(),
+            snapshot.description,
+          ),
+          style: TextStyle(fontSize: 11, color: context.secondaryColor),
+        ),
+        onTap: () => offerLibraryRollback(context, ref, snapshot.backupPath),
+      );
+    }
+
+    return ExpansionTile(
       leading: const Icon(
         Icons.settings_backup_restore_rounded,
         color: Colors.red,
@@ -25,13 +48,27 @@ class RollbackLastChangeTile extends ConsumerWidget {
         style: const TextStyle(color: Colors.red),
       ),
       subtitle: Text(
-        l10n.roll_back_last_change_subtitle(
-          DateTime.fromMillisecondsSinceEpoch(snapshot.createdAt).toString(),
-          snapshot.description,
-        ),
+        l10n.roll_back_available_count(snapshots.length),
         style: TextStyle(fontSize: 11, color: context.secondaryColor),
       ),
-      onTap: () => offerLibraryRollback(context, ref, snapshot.backupPath),
+      children: [
+        for (final snapshot in snapshots)
+          ListTile(
+            contentPadding: const EdgeInsets.fromLTRB(32, 0, 16, 0),
+            title: Text(
+              snapshot.description,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Text(
+              DateTime.fromMillisecondsSinceEpoch(
+                snapshot.createdAt,
+              ).toString(),
+              style: TextStyle(fontSize: 11, color: context.secondaryColor),
+            ),
+            onTap: () => offerLibraryRollback(context, ref, snapshot.backupPath),
+          ),
+      ],
     );
   }
 }

--- a/lib/modules/more/data_and_storage/widgets/rollback_last_change_tile.dart
+++ b/lib/modules/more/data_and_storage/widgets/rollback_last_change_tile.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/eval/model/m_bridge.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/pre_import_backup.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/restore.dart';
+import 'package:mangayomi/modules/more/widgets/dialog_actions.dart';
+import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+
+class RollbackLastChangeTile extends ConsumerWidget {
+  const RollbackLastChangeTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final snapshot = ref.watch(lastLibrarySnapshotProvider).asData?.value;
+    if (snapshot == null) return const SizedBox.shrink();
+    final l10n = context.l10n;
+    return ListTile(
+      leading: const Icon(
+        Icons.settings_backup_restore_rounded,
+        color: Colors.red,
+      ),
+      title: Text(
+        l10n.roll_back_last_change,
+        style: const TextStyle(color: Colors.red),
+      ),
+      subtitle: Text(
+        l10n.roll_back_last_change_subtitle(
+          DateTime.fromMillisecondsSinceEpoch(snapshot.createdAt).toString(),
+          snapshot.description,
+        ),
+        style: TextStyle(fontSize: 11, color: context.secondaryColor),
+      ),
+      onTap: () => offerLibraryRollback(context, ref, snapshot.backupPath),
+    );
+  }
+}
+
+Future<void> offerLibraryRollback(
+  BuildContext context,
+  WidgetRef ref,
+  String safetyBackupPath,
+) async {
+  final l10n = context.l10n;
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(l10n.roll_back),
+        content: Text(l10n.roll_back_confirm_message),
+        actions: dialogCancelConfirmActions(
+          dialogContext: dialogContext,
+          confirmLabel: l10n.roll_back,
+          confirmColor: Colors.red,
+        ),
+      );
+    },
+  );
+  if (confirmed != true || !context.mounted) return;
+  showBusyDialog(context, l10n.restoring_backup);
+  try {
+    await ref.read(
+      doRestoreProvider(
+        path: safetyBackupPath,
+        context: context,
+        merge: false,
+      ).future,
+    );
+  } finally {
+    if (context.mounted) hideBusyDialog(context);
+  }
+  await clearLastLibrarySnapshot();
+  if (!context.mounted) return;
+  ref.invalidate(lastLibrarySnapshotProvider);
+  botToast(l10n.roll_back_done);
+}

--- a/lib/modules/more/data_and_storage/widgets/source_management_tiles.dart
+++ b/lib/modules/more/data_and_storage/widgets/source_management_tiles.dart
@@ -1,12 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:isar_community/isar.dart';
 import 'package:mangayomi/eval/model/m_bridge.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/delete_source.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/pre_import_backup.dart';
 import 'package:mangayomi/modules/more/widgets/beta_badge.dart';
 import 'package:mangayomi/modules/more/widgets/dialog_actions.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+
+String _itemTypeLabel(BuildContext context, ItemType itemType) {
+  final l10n = context.l10n;
+  return switch (itemType) {
+    ItemType.manga => l10n.manga,
+    ItemType.anime => l10n.anime,
+    ItemType.novel => l10n.novel,
+  };
+}
 
 class DeleteSourceTile extends ConsumerWidget {
   const DeleteSourceTile({super.key});
@@ -30,21 +43,21 @@ class DeleteSourceTile extends ConsumerWidget {
   }
 }
 
-class MergeDuplicateSourcesTile extends ConsumerWidget {
-  const MergeDuplicateSourcesTile({super.key});
+class MergeDuplicateMangaTile extends ConsumerWidget {
+  const MergeDuplicateMangaTile({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     return ListTile(
-      leading: const Icon(Icons.merge_type_rounded),
-      title: Text(l10n.merge_sources_title),
+      leading: const Icon(Icons.join_full_rounded),
+      title: Text(l10n.merge_manga_title),
       subtitle: Text(
-        l10n.merge_sources_subtitle,
+        l10n.merge_manga_subtitle,
         style: TextStyle(fontSize: 11, color: context.secondaryColor),
       ),
       trailing: const BetaBadge(),
-      onTap: () => _mergeDuplicateSources(context, ref),
+      onTap: () => _mergeDuplicateManga(context, ref),
     );
   }
 }
@@ -74,7 +87,9 @@ Future<void> _deleteSource(BuildContext context, WidgetRef ref) async {
                 title: Text(
                   g.lang != null ? "${g.sourceName} (${g.lang})" : g.sourceName,
                 ),
-                subtitle: Text("${g.mangaCount} manga"),
+                subtitle: Text(
+                  "${_itemTypeLabel(context, g.itemType)} • ${g.mangaCount}",
+                ),
                 onTap: () => Navigator.pop(dialogContext, g),
               );
             },
@@ -89,13 +104,19 @@ Future<void> _deleteSource(BuildContext context, WidgetRef ref) async {
   final mangaList = mangaForGroup(group);
   final counts = previewDeleteSource(mangaList);
   var removeExtension = group.sourceId != null;
+  var keepHistory = false;
+  var keepDownloads = false;
   final confirmed = await showDialog<bool>(
     context: context,
     builder: (dialogContext) {
       return StatefulBuilder(
         builder: (dialogContext, setState) {
           return AlertDialog(
-            title: Text(l10n.delete_source_confirm_title(group.sourceName)),
+            title: Text(
+              l10n.delete_source_confirm_title(
+                "${group.sourceName} (${_itemTypeLabel(context, group.itemType)})",
+              ),
+            ),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -106,8 +127,27 @@ Future<void> _deleteSource(BuildContext context, WidgetRef ref) async {
                     counts.chapterCount,
                     counts.historyCount,
                     counts.updateCount,
-                    counts.trackCount,
                   ),
+                ),
+                CheckboxListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: Text(
+                    l10n.delete_source_keep_history,
+                    style: const TextStyle(fontSize: 13),
+                  ),
+                  value: keepHistory,
+                  onChanged: (value) =>
+                      setState(() => keepHistory = value ?? false),
+                ),
+                CheckboxListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: Text(
+                    l10n.delete_source_keep_downloads,
+                    style: const TextStyle(fontSize: 13),
+                  ),
+                  value: keepDownloads,
+                  onChanged: (value) =>
+                      setState(() => keepDownloads = value ?? false),
                 ),
                 if (group.sourceId != null)
                   CheckboxListTile(
@@ -149,6 +189,8 @@ Future<void> _deleteSource(BuildContext context, WidgetRef ref) async {
     await deleteSourceLibrary(
       mangaList,
       group,
+      keepHistory: keepHistory,
+      keepDownloads: keepDownloads,
       alsoRemoveExtension: removeExtension,
     );
     if (!context.mounted) return;
@@ -161,78 +203,99 @@ Future<void> _deleteSource(BuildContext context, WidgetRef ref) async {
   }
 }
 
-Future<void> _mergeDuplicateSources(BuildContext context, WidgetRef ref) async {
+class _TaggedMangaCluster {
+  _TaggedMangaCluster(this.group, this.cluster);
+
+  final LibrarySourceGroup group;
+  final DuplicateMangaCluster cluster;
+}
+
+Future<void> _mergeDuplicateManga(BuildContext context, WidgetRef ref) async {
   final l10n = context.l10n;
-  final clusters = findDuplicateSourceClusters();
-  if (clusters.isEmpty) {
-    botToast(l10n.merge_sources_none_found);
+  final taggedClusters = <_TaggedMangaCluster>[];
+  for (final group in librarySourceGroups(favoritesOnly: true)) {
+    final mangaList = mangaForGroup(group, favoritesOnly: true);
+    for (final cluster in findDuplicateMangaClusters(mangaList)) {
+      taggedClusters.add(_TaggedMangaCluster(group, cluster));
+    }
+  }
+  if (taggedClusters.isEmpty) {
+    botToast(l10n.merge_manga_none_found);
     return;
   }
 
-  final cluster = await showDialog<DuplicateSourceCluster>(
+  final picked = await showDialog<_TaggedMangaCluster>(
     context: context,
     builder: (dialogContext) {
       return AlertDialog(
-        title: Text(l10n.merge_sources_pick_title),
+        title: Text(l10n.merge_manga_pick_title),
         content: SizedBox(
           width: double.maxFinite,
-          child: ListView(
+          child: ListView.separated(
             shrinkWrap: true,
-            children: clusters
-                .map(
-                  (c) => ListTile(
-                    title: Text(c.groups.map((g) => g.sourceName).join(' / ')),
-                    subtitle: Text(
-                      "${c.groups.fold<int>(0, (s, g) => s + g.mangaCount)} manga total",
-                    ),
-                    onTap: () => Navigator.pop(dialogContext, c),
-                  ),
-                )
-                .toList(),
+            itemCount: taggedClusters.length,
+            separatorBuilder: (context, index) => const SizedBox(height: 8),
+            itemBuilder: (context, index) {
+              final t = taggedClusters[index];
+              return ListTile(
+                title: Text(t.cluster.mangaList.first.name ?? ''),
+                subtitle: Text(
+                  "${_itemTypeLabel(context, t.group.itemType)} • ${t.group.sourceName} • "
+                  "${t.cluster.mangaList.length}",
+                ),
+                onTap: () => Navigator.pop(dialogContext, t),
+              );
+            },
           ),
         ),
         actions: dialogCancelOnlyAction(dialogContext),
       );
     },
   );
-  if (cluster == null || !context.mounted) return;
+  if (picked == null || !context.mounted) return;
 
-  final sortedGroups = [...cluster.groups]
-    ..sort((a, b) => b.mangaCount.compareTo(a.mangaCount));
+  final mangaList = [...picked.cluster.mangaList];
+  final chapterCounts = <int, int>{
+    for (final m in mangaList)
+      m.id!: isar.chapters.filter().mangaIdEqualTo(m.id).countSync(),
+  };
+  mangaList.sort(
+    (a, b) => (chapterCounts[b.id!] ?? 0).compareTo(chapterCounts[a.id!] ?? 0),
+  );
 
-  final primary = await showDialog<LibrarySourceGroup>(
+  final primary = await showDialog<Manga>(
     context: context,
     builder: (dialogContext) {
-      var selected = sortedGroups.first;
+      var selected = mangaList.first;
       return StatefulBuilder(
         builder: (dialogContext, setState) {
           return AlertDialog(
-            title: Text(l10n.merge_sources_choose_primary_title),
+            title: Text(l10n.merge_manga_choose_primary_title),
             content: SizedBox(
               width: double.maxFinite,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Text(
-                    l10n.merge_sources_choose_primary_message,
+                    l10n.merge_manga_choose_primary_message,
                     style: TextStyle(
                       fontSize: 12,
                       color: context.secondaryColor,
                     ),
                   ),
-                  ...sortedGroups.map(
-                    (g) => RadioListTile<LibrarySourceGroup>(
-                      value: g,
+                  ...mangaList.map(
+                    (m) => RadioListTile<Manga>(
+                      value: m,
                       // ignore: deprecated_member_use
                       groupValue: selected,
                       // ignore: deprecated_member_use
                       onChanged: (v) => setState(() => selected = v!),
-                      title: Text(
-                        g.lang != null
-                            ? "${g.sourceName} (${g.lang})"
-                            : g.sourceName,
+                      title: Text(m.name ?? ''),
+                      subtitle: Text(
+                        l10n.merge_manga_chapters_subtitle(
+                          chapterCounts[m.id!] ?? 0,
+                        ),
                       ),
-                      subtitle: Text("${g.mangaCount} manga"),
                     ),
                   ),
                 ],
@@ -240,7 +303,7 @@ Future<void> _mergeDuplicateSources(BuildContext context, WidgetRef ref) async {
             ),
             actions: dialogCancelConfirmActions(
               dialogContext: dialogContext,
-              confirmLabel: l10n.merge_sources_button,
+              confirmLabel: l10n.merge_manga_button,
               onCancel: () => Navigator.pop(dialogContext, null),
               onConfirm: () => Navigator.pop(dialogContext, selected),
             ),
@@ -251,8 +314,30 @@ Future<void> _mergeDuplicateSources(BuildContext context, WidgetRef ref) async {
   );
   if (primary == null || !context.mounted) return;
 
-  final others = sortedGroups.where((g) => g != primary).toList();
-  final mergedCount = others.fold<int>(0, (s, g) => s + g.mangaCount);
+  final others = mangaList.where((m) => m.id != primary.id).toList();
+  final preview = previewMergeManga(primary, others);
+
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(l10n.merge_preview_title),
+        content: Text(
+          l10n.merge_manga_preview_message(
+            preview.totalChapters,
+            preview.duplicateChapters,
+            preview.keptChapters,
+            preview.duplicateTracks,
+          ),
+        ),
+        actions: dialogCancelConfirmActions(
+          dialogContext: dialogContext,
+          confirmLabel: l10n.merge_manga_button,
+        ),
+      );
+    },
+  );
+  if (confirmed != true || !context.mounted) return;
 
   try {
     final safetyBackupPath = await createLibrarySafetyBackup();
@@ -260,19 +345,19 @@ Future<void> _mergeDuplicateSources(BuildContext context, WidgetRef ref) async {
       LibrarySafetySnapshot(
         backupPath: safetyBackupPath,
         createdAt: DateTime.now().millisecondsSinceEpoch,
-        description: l10n.merge_sources_result_message(
-          mergedCount,
-          primary.sourceName,
+        description: l10n.merge_manga_result_message(
+          others.length,
+          primary.name ?? '',
         ),
       ),
     );
-    await mergeSourceGroups(primary, others);
+    await mergeMangaGroup(primary, others);
     if (!context.mounted) return;
     ref.invalidate(lastLibrarySnapshotProvider);
     botToast(
-      l10n.merge_sources_result_message(mergedCount, primary.sourceName),
+      l10n.merge_manga_result_message(others.length, primary.name ?? ''),
     );
   } catch (e) {
-    botToast("Error merging sources: $e");
+    botToast("Error merging manga: $e");
   }
 }

--- a/lib/modules/more/data_and_storage/widgets/source_management_tiles.dart
+++ b/lib/modules/more/data_and_storage/widgets/source_management_tiles.dart
@@ -1,0 +1,278 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/eval/model/m_bridge.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/delete_source.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/pre_import_backup.dart';
+import 'package:mangayomi/modules/more/widgets/beta_badge.dart';
+import 'package:mangayomi/modules/more/widgets/dialog_actions.dart';
+import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+
+class DeleteSourceTile extends ConsumerWidget {
+  const DeleteSourceTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    return ListTile(
+      leading: const Icon(Icons.delete_sweep_outlined, color: Colors.red),
+      title: Text(
+        l10n.delete_source_title,
+        style: const TextStyle(color: Colors.red),
+      ),
+      subtitle: Text(
+        l10n.delete_source_subtitle,
+        style: TextStyle(fontSize: 11, color: context.secondaryColor),
+      ),
+      trailing: const BetaBadge(),
+      onTap: () => _deleteSource(context, ref),
+    );
+  }
+}
+
+class MergeDuplicateSourcesTile extends ConsumerWidget {
+  const MergeDuplicateSourcesTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    return ListTile(
+      leading: const Icon(Icons.merge_type_rounded),
+      title: Text(l10n.merge_sources_title),
+      subtitle: Text(
+        l10n.merge_sources_subtitle,
+        style: TextStyle(fontSize: 11, color: context.secondaryColor),
+      ),
+      trailing: const BetaBadge(),
+      onTap: () => _mergeDuplicateSources(context, ref),
+    );
+  }
+}
+
+Future<void> _deleteSource(BuildContext context, WidgetRef ref) async {
+  final l10n = context.l10n;
+  final groups = librarySourceGroups();
+  if (groups.isEmpty) {
+    botToast(l10n.delete_source_empty);
+    return;
+  }
+
+  final group = await showDialog<LibrarySourceGroup>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(l10n.delete_source_pick_title),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ListView.separated(
+            shrinkWrap: true,
+            itemCount: groups.length,
+            separatorBuilder: (context, index) => const SizedBox(height: 8),
+            itemBuilder: (context, index) {
+              final g = groups[index];
+              return ListTile(
+                title: Text(
+                  g.lang != null ? "${g.sourceName} (${g.lang})" : g.sourceName,
+                ),
+                subtitle: Text("${g.mangaCount} manga"),
+                onTap: () => Navigator.pop(dialogContext, g),
+              );
+            },
+          ),
+        ),
+        actions: dialogCancelOnlyAction(dialogContext),
+      );
+    },
+  );
+  if (group == null || !context.mounted) return;
+
+  final mangaList = mangaForGroup(group);
+  final counts = previewDeleteSource(mangaList);
+  var removeExtension = group.sourceId != null;
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) {
+      return StatefulBuilder(
+        builder: (dialogContext, setState) {
+          return AlertDialog(
+            title: Text(l10n.delete_source_confirm_title(group.sourceName)),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.delete_source_confirm_message(
+                    counts.mangaCount,
+                    counts.chapterCount,
+                    counts.historyCount,
+                    counts.updateCount,
+                    counts.trackCount,
+                  ),
+                ),
+                if (group.sourceId != null)
+                  CheckboxListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(
+                      l10n.delete_source_also_remove_extension,
+                      style: const TextStyle(fontSize: 13),
+                    ),
+                    value: removeExtension,
+                    onChanged: (value) =>
+                        setState(() => removeExtension = value ?? true),
+                  ),
+              ],
+            ),
+            actions: dialogCancelConfirmActions(
+              dialogContext: dialogContext,
+              confirmLabel: l10n.delete_source_button,
+              confirmColor: Colors.red,
+            ),
+          );
+        },
+      );
+    },
+  );
+  if (confirmed != true || !context.mounted) return;
+
+  try {
+    final safetyBackupPath = await createLibrarySafetyBackup();
+    await writeLastLibrarySnapshot(
+      LibrarySafetySnapshot(
+        backupPath: safetyBackupPath,
+        createdAt: DateTime.now().millisecondsSinceEpoch,
+        description: l10n.delete_source_result_message(
+          counts.mangaCount,
+          group.sourceName,
+        ),
+      ),
+    );
+    await deleteSourceLibrary(
+      mangaList,
+      group,
+      alsoRemoveExtension: removeExtension,
+    );
+    if (!context.mounted) return;
+    ref.invalidate(lastLibrarySnapshotProvider);
+    botToast(
+      l10n.delete_source_result_message(counts.mangaCount, group.sourceName),
+    );
+  } catch (e) {
+    botToast("Error deleting source: $e");
+  }
+}
+
+Future<void> _mergeDuplicateSources(BuildContext context, WidgetRef ref) async {
+  final l10n = context.l10n;
+  final clusters = findDuplicateSourceClusters();
+  if (clusters.isEmpty) {
+    botToast(l10n.merge_sources_none_found);
+    return;
+  }
+
+  final cluster = await showDialog<DuplicateSourceCluster>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(l10n.merge_sources_pick_title),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ListView(
+            shrinkWrap: true,
+            children: clusters
+                .map(
+                  (c) => ListTile(
+                    title: Text(c.groups.map((g) => g.sourceName).join(' / ')),
+                    subtitle: Text(
+                      "${c.groups.fold<int>(0, (s, g) => s + g.mangaCount)} manga total",
+                    ),
+                    onTap: () => Navigator.pop(dialogContext, c),
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+        actions: dialogCancelOnlyAction(dialogContext),
+      );
+    },
+  );
+  if (cluster == null || !context.mounted) return;
+
+  final sortedGroups = [...cluster.groups]
+    ..sort((a, b) => b.mangaCount.compareTo(a.mangaCount));
+
+  final primary = await showDialog<LibrarySourceGroup>(
+    context: context,
+    builder: (dialogContext) {
+      var selected = sortedGroups.first;
+      return StatefulBuilder(
+        builder: (dialogContext, setState) {
+          return AlertDialog(
+            title: Text(l10n.merge_sources_choose_primary_title),
+            content: SizedBox(
+              width: double.maxFinite,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    l10n.merge_sources_choose_primary_message,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: context.secondaryColor,
+                    ),
+                  ),
+                  ...sortedGroups.map(
+                    (g) => RadioListTile<LibrarySourceGroup>(
+                      value: g,
+                      // ignore: deprecated_member_use
+                      groupValue: selected,
+                      // ignore: deprecated_member_use
+                      onChanged: (v) => setState(() => selected = v!),
+                      title: Text(
+                        g.lang != null
+                            ? "${g.sourceName} (${g.lang})"
+                            : g.sourceName,
+                      ),
+                      subtitle: Text("${g.mangaCount} manga"),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            actions: dialogCancelConfirmActions(
+              dialogContext: dialogContext,
+              confirmLabel: l10n.merge_sources_button,
+              onCancel: () => Navigator.pop(dialogContext, null),
+              onConfirm: () => Navigator.pop(dialogContext, selected),
+            ),
+          );
+        },
+      );
+    },
+  );
+  if (primary == null || !context.mounted) return;
+
+  final others = sortedGroups.where((g) => g != primary).toList();
+  final mergedCount = others.fold<int>(0, (s, g) => s + g.mangaCount);
+
+  try {
+    final safetyBackupPath = await createLibrarySafetyBackup();
+    await writeLastLibrarySnapshot(
+      LibrarySafetySnapshot(
+        backupPath: safetyBackupPath,
+        createdAt: DateTime.now().millisecondsSinceEpoch,
+        description: l10n.merge_sources_result_message(
+          mergedCount,
+          primary.sourceName,
+        ),
+      ),
+    );
+    await mergeSourceGroups(primary, others);
+    if (!context.mounted) return;
+    ref.invalidate(lastLibrarySnapshotProvider);
+    botToast(
+      l10n.merge_sources_result_message(mergedCount, primary.sourceName),
+    );
+  } catch (e) {
+    botToast("Error merging sources: $e");
+  }
+}

--- a/lib/modules/more/data_and_storage/widgets/unified_restore.dart
+++ b/lib/modules/more/data_and_storage/widgets/unified_restore.dart
@@ -1,0 +1,480 @@
+import 'package:bot_toast/bot_toast.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/eval/model/m_bridge.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/pre_import_backup.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/restore.dart';
+import 'package:mangayomi/modules/more/data_and_storage/widgets/rollback_last_change_tile.dart';
+import 'package:mangayomi/modules/more/widgets/dialog_actions.dart';
+import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+
+Future<void> performRestore(BuildContext context, WidgetRef ref) async {
+  String? safetyBackupPath;
+  try {
+    final file = await FilePicker.pickFile();
+    if (file?.path == null || !context.mounted) return;
+    final path = file!.path!;
+
+    final backupType = peekBackupType(path);
+    final isMihonFamily =
+        backupType == BackupType.mihon ||
+        backupType == BackupType.aniyomi ||
+        backupType == BackupType.neko;
+
+    if (!isMihonFamily) {
+      if (!context.mounted) return;
+      final confirmed = await _confirmPlainRestore(context);
+      if (confirmed != true || !context.mounted) return;
+      showBusyDialog(context, context.l10n.restoring_backup);
+      try {
+        await ref.read(doRestoreProvider(path: path, context: context).future);
+      } finally {
+        if (context.mounted) hideBusyDialog(context);
+      }
+      return;
+    }
+
+    final l10n = context.l10n;
+    final preview = previewTachiBkImport(path);
+    if (preview == null) {
+      botToast("Unsupported or unrecognized backup file.");
+      return;
+    }
+
+    if (!context.mounted) return;
+    final keepExisting = await _chooseImportMode(context);
+    if (keepExisting == null || !context.mounted) return;
+
+    var categoryDecisions = const <String, bool>{};
+    var sourceDecisions = const <String, int>{};
+
+    if (keepExisting && preview.conflictingCategories.isNotEmpty) {
+      if (!context.mounted) return;
+      final decisions = await _resolveCategoryConflicts(
+        context,
+        preview.conflictingCategories,
+      );
+      if (decisions == null || !context.mounted) return;
+      categoryDecisions = decisions;
+    }
+
+    if (preview.unmatchedSourceNames.isNotEmpty) {
+      if (!context.mounted) return;
+      final decisions = await _resolveSourceConflicts(
+        context,
+        preview.unmatchedSourceNames,
+      );
+      if (decisions == null || !context.mounted) return;
+      sourceDecisions = decisions;
+    }
+
+    if (!context.mounted) return;
+    final proceed = keepExisting
+        ? await _confirmImportSummary(context, preview)
+        : await _confirmReplaceSummary(context, preview);
+    if (proceed != true || !context.mounted) return;
+
+    final resultDescription = keepExisting
+        ? l10n.import_result_message(
+            preview.newSeriesCount,
+            preview.updatedSeriesCount,
+            preview.newChapterCount,
+          )
+        : l10n.replace_result_message(
+            preview.newSeriesCount + preview.updatedSeriesCount,
+          );
+
+    if (!context.mounted) return;
+    showBusyDialog(context, l10n.restoring_backup);
+    try {
+      try {
+        safetyBackupPath = await createLibrarySafetyBackup();
+        await writeLastLibrarySnapshot(
+          LibrarySafetySnapshot(
+            backupPath: safetyBackupPath,
+            createdAt: DateTime.now().millisecondsSinceEpoch,
+            description: resultDescription,
+          ),
+        );
+      } catch (_) {
+        safetyBackupPath = null;
+      }
+
+      if (!context.mounted) return;
+      await ref.read(
+        doRestoreProvider(
+          path: path,
+          context: context,
+          merge: keepExisting,
+          categoryDecisions: categoryDecisions,
+          sourceDecisions: sourceDecisions,
+        ).future,
+      );
+    } finally {
+      if (context.mounted) hideBusyDialog(context);
+    }
+    if (!context.mounted) return;
+    ref.invalidate(lastLibrarySnapshotProvider);
+
+    _showImportResultToast(context, ref, resultDescription, safetyBackupPath);
+  } catch (e) {
+    botToast("Error restoring backup: $e");
+    if (safetyBackupPath != null && context.mounted) {
+      offerLibraryRollback(context, ref, safetyBackupPath);
+    }
+  }
+}
+
+Future<bool?> _confirmPlainRestore(BuildContext context) {
+  final l10n = context.l10n;
+  return showDialog<bool>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(l10n.restore_backup),
+        content: Row(
+          children: [
+            Icon(Icons.info_outline_rounded, color: context.secondaryColor),
+            const SizedBox(width: 8),
+            Expanded(child: Text(l10n.restore_backup_warning_title)),
+          ],
+        ),
+        actions: dialogCancelConfirmActions(
+          dialogContext: dialogContext,
+          confirmLabel: l10n.ok,
+        ),
+      );
+    },
+  );
+}
+
+Future<bool?> _chooseImportMode(BuildContext context) {
+  final l10n = context.l10n;
+  return showDialog<bool>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(l10n.import_mode_title),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 8,
+          children: [
+            Text(
+              l10n.import_mode_message,
+              style: TextStyle(fontSize: 12, color: context.secondaryColor),
+            ),
+            const SizedBox(height: 4),
+            ListTile(
+              leading: const Icon(Icons.merge_type_rounded),
+              title: Text(l10n.import_mode_keep_existing),
+              subtitle: Text(
+                l10n.import_mode_keep_existing_subtitle,
+                style: TextStyle(fontSize: 11, color: context.secondaryColor),
+              ),
+              onTap: () => Navigator.pop(dialogContext, true),
+            ),
+            ListTile(
+              leading: const Icon(
+                Icons.delete_sweep_outlined,
+                color: Colors.red,
+              ),
+              title: Text(
+                l10n.import_mode_replace,
+                style: const TextStyle(color: Colors.red),
+              ),
+              subtitle: Text(
+                l10n.import_mode_replace_subtitle,
+                style: TextStyle(fontSize: 11, color: context.secondaryColor),
+              ),
+              onTap: () => Navigator.pop(dialogContext, false),
+            ),
+          ],
+        ),
+        actions: dialogCancelOnlyAction(dialogContext),
+      );
+    },
+  );
+}
+
+Future<Map<String, bool>?> _resolveCategoryConflicts(
+  BuildContext context,
+  List<String> conflicts,
+) async {
+  final l10n = context.l10n;
+  final decisions = {for (final name in conflicts) name: true};
+  return showDialog<Map<String, bool>>(
+    context: context,
+    builder: (dialogContext) {
+      return StatefulBuilder(
+        builder: (dialogContext, setState) {
+          return AlertDialog(
+            title: Text(l10n.category_conflict_title),
+            content: SizedBox(
+              width: double.maxFinite,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    l10n.category_conflict_message,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: context.secondaryColor,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Flexible(
+                    child: ListView(
+                      shrinkWrap: true,
+                      children: conflicts
+                          .map(
+                            (name) => CheckboxListTile(
+                              contentPadding: EdgeInsets.zero,
+                              title: Text(name),
+                              subtitle: Text(
+                                decisions[name]!
+                                    ? l10n.category_conflict_keep
+                                    : l10n.category_conflict_delete,
+                                style: TextStyle(
+                                  fontSize: 11,
+                                  color: context.secondaryColor,
+                                ),
+                              ),
+                              value: decisions[name],
+                              onChanged: (value) => setState(
+                                () => decisions[name] = value ?? true,
+                              ),
+                            ),
+                          )
+                          .toList(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            actions: dialogCancelConfirmActions(
+              dialogContext: dialogContext,
+              confirmLabel: l10n.ok,
+              onCancel: () => Navigator.pop(dialogContext, null),
+              onConfirm: () => Navigator.pop(dialogContext, decisions),
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+
+Future<Map<String, int>?> _resolveSourceConflicts(
+  BuildContext context,
+  Map<String, ItemType> unmatched,
+) async {
+  final l10n = context.l10n;
+  final selections = <String, int?>{
+    for (final name in unmatched.keys) name: null,
+  };
+  return showDialog<Map<String, int>>(
+    context: context,
+    builder: (dialogContext) {
+      return StatefulBuilder(
+        builder: (dialogContext, setState) {
+          return AlertDialog(
+            title: Text(l10n.source_conflict_title),
+            content: SizedBox(
+              width: double.maxFinite,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    l10n.source_conflict_message,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: context.secondaryColor,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Flexible(
+                    child: ListView(
+                      shrinkWrap: true,
+                      children: unmatched.entries.map((entry) {
+                        final name = entry.key;
+                        final itemType = entry.value;
+                        final options = installedSourcesFor(itemType);
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 6),
+                          child: DropdownButtonFormField<int?>(
+                            initialValue: selections[name],
+                            isExpanded: true,
+                            decoration: InputDecoration(
+                              label: Text(
+                                name,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              isDense: true,
+                              filled: true,
+                              fillColor: Color.alphaBlend(
+                                context.primaryColor.withValues(alpha: 0.05),
+                                Theme.of(context).scaffoldBackgroundColor,
+                              ),
+                              contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 12,
+                              ),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide(
+                                  color: context.primaryColor.withValues(
+                                    alpha: 0.2,
+                                  ),
+                                ),
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide(
+                                  color: context.primaryColor.withValues(
+                                    alpha: 0.2,
+                                  ),
+                                ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide(
+                                  color: context.primaryColor,
+                                  width: 2,
+                                ),
+                              ),
+                            ),
+                            items: [
+                              DropdownMenuItem<int?>(
+                                value: null,
+                                child: Text(
+                                  l10n.source_conflict_keep,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                              ...options.map(
+                                (s) => DropdownMenuItem<int?>(
+                                  value: s.id,
+                                  child: Text(
+                                    "${s.name} (${s.lang})",
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ),
+                            ],
+                            onChanged: (value) =>
+                                setState(() => selections[name] = value),
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            actions: dialogCancelConfirmActions(
+              dialogContext: dialogContext,
+              confirmLabel: l10n.ok,
+              onCancel: () => Navigator.pop(dialogContext, null),
+              onConfirm: () => Navigator.pop(dialogContext, {
+                for (final e in selections.entries)
+                  if (e.value != null) e.key: e.value!,
+              }),
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+
+Future<bool?> _confirmImportSummary(
+  BuildContext context,
+  TachiBkImportPreview preview,
+) {
+  final l10n = context.l10n;
+  return showDialog<bool>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(l10n.import_summary_title),
+        content: Text(
+          l10n.import_summary_message(
+            preview.newSeriesCount,
+            preview.updatedSeriesCount,
+            preview.newChapterCount,
+          ),
+        ),
+        actions: dialogCancelConfirmActions(
+          dialogContext: dialogContext,
+          confirmLabel: l10n.import_summary_confirm,
+        ),
+      );
+    },
+  );
+}
+
+Future<bool?> _confirmReplaceSummary(
+  BuildContext context,
+  TachiBkImportPreview preview,
+) {
+  final l10n = context.l10n;
+  final currentCount = currentFavoriteMangaCount();
+  final backupCount = preview.newSeriesCount + preview.updatedSeriesCount;
+  return showDialog<bool>(
+    context: context,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(l10n.replace_summary_title),
+        content: Text(l10n.replace_summary_message(currentCount, backupCount)),
+        actions: dialogCancelConfirmActions(
+          dialogContext: dialogContext,
+          confirmLabel: l10n.replace_summary_confirm,
+          confirmColor: Colors.red,
+        ),
+      );
+    },
+  );
+}
+
+void _showImportResultToast(
+  BuildContext context,
+  WidgetRef ref,
+  String resultDescription,
+  String? safetyBackupPath,
+) {
+  final l10n = context.l10n;
+  BotToast.showNotification(
+    animationDuration: const Duration(milliseconds: 200),
+    animationReverseDuration: const Duration(milliseconds: 200),
+    duration: const Duration(seconds: 8),
+    backButtonBehavior: BackButtonBehavior.none,
+    leading: (_) => Image.asset('assets/app_icons/icon-red.png', height: 32),
+    title: (_) => Text(
+      resultDescription,
+      style: const TextStyle(fontWeight: FontWeight.bold),
+    ),
+    trailing: safetyBackupPath == null
+        ? null
+        : (_) => UnconstrainedBox(
+            alignment: Alignment.topLeft,
+            child: TextButton(
+              onPressed: () =>
+                  offerLibraryRollback(context, ref, safetyBackupPath),
+              child: Text(
+                l10n.roll_back,
+                style: const TextStyle(color: Colors.red),
+              ),
+            ),
+          ),
+    enableSlideOff: true,
+    onlyOne: true,
+    crossPage: true,
+  );
+}

--- a/lib/modules/more/settings/browse/providers/browse_state_provider.g.dart
+++ b/lib/modules/more/settings/browse/providers/browse_state_provider.g.dart
@@ -98,7 +98,7 @@ final class AutoStartExtensionServerOnLaunchStateProvider
 }
 
 String _$autoStartExtensionServerOnLaunchStateHash() =>
-    r'e2137ed3c05a099db7c2a9b3d16bd1877ad8fac3';
+    r'be04fc2923244e09d51c699d411e692c7d139ac6';
 
 abstract class _$AutoStartExtensionServerOnLaunchState extends $Notifier<bool> {
   bool build();

--- a/lib/modules/more/widgets/beta_badge.dart
+++ b/lib/modules/more/widgets/beta_badge.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+
+class BetaBadge extends StatelessWidget {
+  const BetaBadge({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final accent = context.primaryColor;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.18),
+        borderRadius: BorderRadius.circular(5),
+      ),
+      child: Text(
+        l10n.beta.toUpperCase(),
+        style: TextStyle(
+          color: accent,
+          fontSize: 9,
+          fontWeight: FontWeight.bold,
+          letterSpacing: 1.0,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/more/widgets/dialog_actions.dart
+++ b/lib/modules/more/widgets/dialog_actions.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+
+List<Widget> dialogCancelConfirmActions({
+  required BuildContext dialogContext,
+  required String confirmLabel,
+  Color? confirmColor,
+  VoidCallback? onCancel,
+  VoidCallback? onConfirm,
+}) {
+  final l10n = dialogContext.l10n;
+  return [
+    Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        TextButton(
+          onPressed: onCancel ?? () => Navigator.pop(dialogContext, false),
+          child: Text(
+            l10n.cancel,
+            style: TextStyle(color: dialogContext.primaryColor),
+          ),
+        ),
+        TextButton(
+          onPressed: onConfirm ?? () => Navigator.pop(dialogContext, true),
+          child: Text(
+            confirmLabel,
+            style: TextStyle(color: confirmColor ?? dialogContext.primaryColor),
+          ),
+        ),
+      ],
+    ),
+  ];
+}
+
+List<Widget> dialogCancelOnlyAction(BuildContext dialogContext) {
+  final l10n = dialogContext.l10n;
+  return [
+    TextButton(
+      onPressed: () => Navigator.pop(dialogContext, null),
+      child: Text(
+        l10n.cancel,
+        style: TextStyle(color: dialogContext.primaryColor),
+      ),
+    ),
+  ];
+}
+
+void showBusyDialog(BuildContext context, String message) {
+  showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (dialogContext) => PopScope(
+      canPop: false,
+      child: AlertDialog(
+        content: Row(
+          children: [
+            const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2.5),
+            ),
+            const SizedBox(width: 16),
+            Expanded(child: Text(message)),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+void hideBusyDialog(BuildContext context) {
+  final navigator = Navigator.of(context, rootNavigator: true);
+  if (navigator.canPop()) navigator.pop();
+}

--- a/lib/services/aniskip.g.dart
+++ b/lib/services/aniskip.g.dart
@@ -40,7 +40,7 @@ final class AniSkipProvider extends $NotifierProvider<AniSkip, void> {
   }
 }
 
-String _$aniSkipHash() => r'887869b54e2e151633efd46da83bde845e14f421';
+String _$aniSkipHash() => r'2e5d19b025a2207ff64da7bf7908450ea9e5ff8c';
 
 abstract class _$AniSkip extends $Notifier<void> {
   void build();

--- a/lib/services/trackers/anilist.g.dart
+++ b/lib/services/trackers/anilist.g.dart
@@ -58,7 +58,7 @@ final class AnilistProvider extends $NotifierProvider<Anilist, void> {
   }
 }
 
-String _$anilistHash() => r'bc3f5e2aba14274074c73f7848dec713c77b9e23';
+String _$anilistHash() => r'eaf42b8330154cddd4c0cfaf34c64d3a022db501';
 
 final class AnilistFamily extends $Family
     with

--- a/lib/utils/isar_txn_retry.dart
+++ b/lib/utils/isar_txn_retry.dart
@@ -1,0 +1,19 @@
+import 'package:mangayomi/main.dart';
+
+Future<T> writeTxnSyncWithRetry<T>(
+  T Function() body, {
+  int maxAttempts = 6,
+}) async {
+  for (var attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return isar.writeTxnSync<T>(body);
+    } catch (e) {
+      final isAsyncTxnConflict = e.toString().contains(
+        'async write transaction is already in progress',
+      );
+      if (!isAsyncTxnConflict || attempt == maxAttempts - 1) rethrow;
+      await Future.delayed(Duration(milliseconds: 100 * (attempt + 1)));
+    }
+  }
+  throw StateError('writeTxnSyncWithRetry: exhausted retries');
+}


### PR DESCRIPTION
## Database QoL

- **Rollback System**
  - Every database operation (delete a source, merge duplicate sources, merge duplicate manga, restore a backup) takes a snapshot of library right before it runs.
  - A Rollback last change option appears whenever a snapshot exist letting you undo the most recent operation and return your library to exactly how it was before.
  - Only keeps the latest snapshot on disk

- **Delete a source and its manga**
  - Lets you pick a source (labeled by item type manga, anime, novel) and remove every manga tied to it. along with their chapters, downloads, history
  - Options as Keep history and Download so you can wipe source library entries without losing data.

- **Merge duplicate manga**
  - Finds manga with matching titles under the same source
  - Chapters are combined and deduplicated, keeping whichever copy has actual reading progress.

- **Restore QoL**
  - **Merge or Replace**: When restoring a any type of database such as Mihon, Komikku, Aniyomi, Neko, backup, choose to merge into your current library or replace your entire library with it, with a preview of new/updated series and new chapter counts before you commit.
  - **Category Conflict((: If the backup has categories that already exist locally, choose per category whether to fold into them or leave those uncategorized.
  - **Missing source detection**: If the backup reference a source that you don't have installed, choose to keep the original source name or bind those series to one of your installed.
  

- **Bug Fixed**:
  - Komikku backup weren't being recognized as part of the Mihon family and would fail to import (Was requested by user to me)
  - When Mihon, Aniyomi, Neko, etc backup would return the issues with showing last update "200000 days ago" in certain screens.