### PR TITLE
Fix History screen scroll lag

### DIFF
--- a/lib/modules/history/history_screen.dart
+++ b/lib/modules/history/history_screen.dart
@@ -126,12 +126,32 @@ class _HistoryTabState extends ConsumerState<HistoryTab>
     );
     return history.when(
       data: (allEntries) {
-        final entries = allEntries
-            .where(
-              (e) =>
-                  e.chapter.value != null && e.chapter.value!.manga.value != null,
-            )
+        // Batch-resolve chapter/manga for every entry in one multi-get each,
+        // instead of each row's IsarLink.value doing its own blocking sync
+        // DB read — that was firing per row as it scrolled into view (every
+        // unloaded IsarLink.value synchronously calls loadSync()).
+        final chapterIds = allEntries
+            .map((e) => e.chapterId)
+            .whereType<int>()
+            .toSet()
             .toList();
+        final chapterById = {
+          for (final c in isar.chapters.getAllSync(chapterIds))
+            if (c != null) c.id!: c,
+        };
+        final mangaIds = chapterById.values
+            .map((c) => c.mangaId)
+            .whereType<int>()
+            .toSet()
+            .toList();
+        final mangaById = {
+          for (final m in isar.mangas.getAllSync(mangaIds))
+            if (m != null) m.id!: m,
+        };
+        final entries = allEntries.where((e) {
+          final c = chapterById[e.chapterId];
+          return c != null && mangaById[c.mangaId] != null;
+        }).toList();
         if (entries.isNotEmpty) {
           return CustomScrollView(
             slivers: [
@@ -160,8 +180,8 @@ class _HistoryTabState extends ConsumerState<HistoryTab>
                   ),
                 ),
                 itemBuilder: (context, History element) {
-                  final chapter = element.chapter.value!;
-                  final manga = chapter.manga.value!;
+                  final chapter = chapterById[element.chapterId]!;
+                  final manga = mangaById[chapter.mangaId]!;
                   // Two focusable targets on TV, matching the Browse source
                   // rows: the entry itself, and remove. The cover's own
                   // tap-to-detail folds into the entry rather than becoming a
@@ -397,23 +417,27 @@ class _HistoryTabState extends ConsumerState<HistoryTab>
   }
 
   Widget _getCoverImage(Manga manga) {
-    return manga.customCoverImage != null
-        ? Image.memory(manga.customCoverImage as Uint8List)
-        : cachedCompressedNetworkImage(
-            headers: ref.watch(
-              headersProvider(
-                source: manga.source!,
-                lang: manga.lang!,
-                sourceId: manga.sourceId,
+    return _DeferredCoverImage(
+      width: 60,
+      height: 90,
+      builder: (context) => manga.customCoverImage != null
+          ? Image.memory(manga.customCoverImage as Uint8List)
+          : cachedCompressedNetworkImage(
+              headers: ref.watch(
+                headersProvider(
+                  source: manga.source!,
+                  lang: manga.lang!,
+                  sourceId: manga.sourceId,
+                ),
               ),
+              imageUrl: toImgUrl(
+                manga.customCoverFromTracker ?? manga.imageUrl ?? "",
+              ),
+              width: 60,
+              height: 90,
+              fit: BoxFit.cover,
             ),
-            imageUrl: toImgUrl(
-              manga.customCoverFromTracker ?? manga.imageUrl ?? "",
-            ),
-            width: 60,
-            height: 90,
-            fit: BoxFit.cover,
-          );
+    );
   }
 
   void _openDeleteDialog(AppLocalizations l10n, Manga manga, int? deleteId) {
@@ -460,5 +484,57 @@ class _HistoryTabState extends ConsumerState<HistoryTab>
     if (context.mounted) {
       Navigator.pop(context);
     }
+  }
+}
+
+/// Skips building the real cover — a network fetch + decode — while the
+/// nearest Scrollable is flinging fast, showing an empty box of the same
+/// size instead. Swaps in the real image once scrolling settles, using
+/// ScrollerNotif to know when to re-check.
+class _DeferredCoverImage extends StatefulWidget {
+  final Widget Function(BuildContext context) builder;
+  final double width;
+  final double height;
+
+  const _DeferredCoverImage({
+    required this.builder,
+    required this.width,
+    required this.height,
+  });
+
+  @override
+  State<_DeferredCoverImage> createState() => _DeferredCoverImageState();
+}
+
+class _DeferredCoverImageState extends State<_DeferredCoverImage> {
+  ScrollPosition? _scrollPosition;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final position = Scrollable.maybeOf(context)?.position;
+    if (!identical(position, _scrollPosition)) {
+      _scrollPosition?.isScrollingNotifier.removeListener(_onScrollingChanged);
+      _scrollPosition = position;
+      _scrollPosition?.isScrollingNotifier.addListener(_onScrollingChanged);
+    }
+  }
+
+  void _onScrollingChanged() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _scrollPosition?.isScrollingNotifier.removeListener(_onScrollingChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (Scrollable.recommendDeferredLoadingForContext(context)) {
+      return SizedBox(width: widget.width, height: widget.height);
+    }
+    return widget.builder(context);
   }
 }

--- a/lib/modules/more/settings/appearance/providers/date_format_state_provider.dart
+++ b/lib/modules/more/settings/appearance/providers/date_format_state_provider.dart
@@ -3,11 +3,25 @@ import 'package:mangayomi/models/settings.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'date_format_state_provider.g.dart';
 
-@riverpod
+/// Live view of the single Settings row (id 227), shared by every provider
+/// that only needs one field off it. Settings is a large row (several list
+/// fields, some unbounded), so this exists to make sure it only gets
+/// deserialized when it actually changes — once — instead of every reader
+/// doing its own isar.settings.getSync() on every single read.
+@Riverpod(keepAlive: true)
+Stream<Settings> settingsStream(Ref ref) {
+  return isar.settings
+      .watchObject(227, fireImmediately: true)
+      .where((s) => s != null)
+      .map((s) => s!);
+}
+
+@Riverpod(keepAlive: true)
 class DateFormatState extends _$DateFormatState {
   @override
   String build() {
-    return isar.settings.getSync(227)!.dateFormat!;
+    return ref.watch(settingsStreamProvider).value?.dateFormat ??
+        isar.settings.getSync(227)!.dateFormat!;
   }
 
   void set(String dateFormat) {
@@ -23,11 +37,12 @@ class DateFormatState extends _$DateFormatState {
   }
 }
 
-@riverpod
+@Riverpod(keepAlive: true)
 class RelativeTimesTampsState extends _$RelativeTimesTampsState {
   @override
   int build() {
-    return isar.settings.getSync(227)!.relativeTimesTamps!;
+    return ref.watch(settingsStreamProvider).value?.relativeTimesTamps ??
+        isar.settings.getSync(227)!.relativeTimesTamps!;
   }
 
   void set(int type) {

--- a/lib/modules/more/settings/appearance/providers/date_format_state_provider.g.dart
+++ b/lib/modules/more/settings/appearance/providers/date_format_state_provider.g.dart
@@ -8,6 +8,56 @@ part of 'date_format_state_provider.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// Live view of the single Settings row (id 227), shared by every provider
+/// that only needs one field off it. Settings is a large row (several list
+/// fields, some unbounded), so this exists to make sure it only gets
+/// deserialized when it actually changes — once — instead of every reader
+/// doing its own isar.settings.getSync() on every single read.
+
+@ProviderFor(settingsStream)
+final settingsStreamProvider = SettingsStreamProvider._();
+
+/// Live view of the single Settings row (id 227), shared by every provider
+/// that only needs one field off it. Settings is a large row (several list
+/// fields, some unbounded), so this exists to make sure it only gets
+/// deserialized when it actually changes — once — instead of every reader
+/// doing its own isar.settings.getSync() on every single read.
+
+final class SettingsStreamProvider
+    extends
+        $FunctionalProvider<AsyncValue<Settings>, Settings, Stream<Settings>>
+    with $FutureModifier<Settings>, $StreamProvider<Settings> {
+  /// Live view of the single Settings row (id 227), shared by every provider
+  /// that only needs one field off it. Settings is a large row (several list
+  /// fields, some unbounded), so this exists to make sure it only gets
+  /// deserialized when it actually changes — once — instead of every reader
+  /// doing its own isar.settings.getSync() on every single read.
+  SettingsStreamProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'settingsStreamProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$settingsStreamHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<Settings> $createElement($ProviderPointer pointer) =>
+      $StreamProviderElement(pointer);
+
+  @override
+  Stream<Settings> create(Ref ref) {
+    return settingsStream(ref);
+  }
+}
+
+String _$settingsStreamHash() => r'c868936fe474c9c77cd4709f4963526da39b625a';
 
 @ProviderFor(DateFormatState)
 final dateFormatStateProvider = DateFormatStateProvider._();
@@ -20,7 +70,7 @@ final class DateFormatStateProvider
         argument: null,
         retry: null,
         name: r'dateFormatStateProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -41,7 +91,7 @@ final class DateFormatStateProvider
   }
 }
 
-String _$dateFormatStateHash() => r'9b11f72b8fa535b74873365618089dfca957e445';
+String _$dateFormatStateHash() => r'8e18a6bdf0858544ab2532aa3980a456c742da69';
 
 abstract class _$DateFormatState extends $Notifier<String> {
   String build();
@@ -72,7 +122,7 @@ final class RelativeTimesTampsStateProvider
         argument: null,
         retry: null,
         name: r'relativeTimesTampsStateProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -94,7 +144,7 @@ final class RelativeTimesTampsStateProvider
 }
 
 String _$relativeTimesTampsStateHash() =>
-    r'fc39b88871e857dcd363c01df59de9ca174cb1d6';
+    r'f0b503eed4c0e574a5d0e4c95b3227f9f7504d01';
 
 abstract class _$RelativeTimesTampsState extends $Notifier<int> {
   int build();


### PR DESCRIPTION
History screen lag, root cause was date format settings weren't cached so every date label re-read the whole settings row from the database every scroll. also cleaned up the per row database reads slow down image loading during fast scroll. 

And i checked the update screen codes. it has same bug but worse. not fixed. just waiting on on approval.