### PR TITLE
fix: read downloaded chapters from disk instead of the source

### DIFF
--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -300,6 +300,10 @@ Future<void> downloadChapter(
 
     setProgress(DownloadProgress(0, 0, itemType));
     void savePageUrls() {
+      // Re-downloading a chapter that is already on disk reads it locally, and
+      // local pages carry no url. Storing those placeholders would leave the
+      // chapter unreadable from its source once the download is deleted.
+      if (pageUrls.every((pageUrl) => pageUrl.url.isEmpty)) return;
       final settings = isar.settings.getSync(227)!;
       List<ChapterPageurls>? chapterPageUrls = [];
       for (var chapterPageUrl in settings.chapterPageUrlsList ?? []) {

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
 import 'package:photo_view/photo_view.dart';
 import 'package:mangayomi/modules/widgets/error_state.dart';
-import 'package:mangayomi/providers/storage_provider.dart';
+import 'package:mangayomi/services/downloaded_chapter.dart';
 import 'package:mangayomi/modules/manga/archive_reader/providers/archive_reader_providers.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/modules/manga/reader/subsampling_scale_image_view/subsampling_scale_image_view.dart'
@@ -1349,15 +1348,9 @@ class _MangaChapterPageGalleryState
 
     if (needsReload) {
       final isLocalArchive = (currentChapter.archivePath ?? '').isNotEmpty;
-      final storageProvider = StorageProvider();
-      final mangaDirectory = await storageProvider.getMangaMainDirectory(
-        currentChapter,
-      );
       final archivePath = isLocalArchive
           ? currentChapter.archivePath
-          : (mangaDirectory != null
-                ? p.join(mangaDirectory.path, "${currentChapter.name}.cbz")
-                : null);
+          : (await findDownloadedChapter(currentChapter))?.archive?.path;
 
       if (archivePath != null && await File(archivePath).exists()) {
         try {

--- a/lib/services/downloaded_chapter.dart
+++ b/lib/services/downloaded_chapter.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/models/download.dart';
+import 'package:mangayomi/modules/library/providers/file_scanner.dart';
+import 'package:mangayomi/providers/storage_provider.dart';
+import 'package:mangayomi/utils/extensions/string_extensions.dart';
+import 'package:mangayomi/utils/reg_exp_matcher.dart';
+import 'package:path/path.dart' as p;
+
+/// Where a downloaded chapter's pages actually sit on disk.
+///
+/// Exactly one of [archive] and [pagesDirectory] is set: the downloader writes
+/// a single `.cbz` when "save as CBZ archive" is on and deletes the page folder
+/// afterwards, and leaves the folder of `001.jpg`, `002.jpg`, … when it is off.
+class DownloadedChapter {
+  /// The `.cbz` holding every page of the chapter.
+  final File? archive;
+
+  /// The folder holding one `padIndex(i).jpg` per page.
+  final Directory? pagesDirectory;
+
+  /// How many pages [pagesDirectory] holds. Zero for an [archive], whose page
+  /// count is only known once it is unpacked.
+  final int pageCount;
+
+  const DownloadedChapter.fromArchive(File this.archive)
+    : pagesDirectory = null,
+      pageCount = 0;
+
+  const DownloadedChapter.fromPages(
+    Directory this.pagesDirectory, {
+    required this.pageCount,
+  }) : archive = null;
+}
+
+/// Every directory a download of [chapter] could live in, most likely first.
+///
+/// The default is `<downloads>/<ItemType>/<source> (LANG)/<manga>/`. Versions
+/// 0.8.6 and 0.8.7 sent downloads to a local folder instead, so anything the
+/// user downloaded on those builds is under `<local folder>/<manga>/` and stays
+/// there. The location was restored upstream but the files were not moved.
+Future<List<Directory>> downloadedMangaDirectories(Chapter chapter) async {
+  final directories = <Directory>[];
+  final defaultDirectory = await StorageProvider().getMangaMainDirectory(
+    chapter,
+  );
+  if (defaultDirectory != null) directories.add(defaultDirectory);
+
+  final mangaName = chapter.manga.value?.name;
+  if (mangaName == null) return directories;
+  for (final folder in await getAllLocalFolders()) {
+    final folderPath = folder.path;
+    if (folderPath == null || folderPath.isEmpty) continue;
+    directories.add(
+      Directory(p.join(folderPath, mangaName.replaceForbiddenCharacters('_'))),
+    );
+  }
+  return directories;
+}
+
+/// Finds the local copy of [chapter], or null when there is nothing complete on
+/// disk to read.
+///
+/// Callers use this before reaching for the source so that a downloaded chapter
+/// opens with the extension uninstalled, the site down, or no connection at
+/// all.
+Future<DownloadedChapter?> findDownloadedChapter(Chapter chapter) async {
+  final chapterId = chapter.id;
+  if (chapterId == null || chapter.name == null) return null;
+
+  final storageProvider = StorageProvider();
+  // The folder is written page by page, so a download still in flight has a
+  // partial one; only the Isar record knows it is finished. An archive needs no
+  // such check, since it is written once, at the end, from the complete folder.
+  final isComplete = isar.downloads.getSync(chapterId)?.isDownload ?? false;
+
+  for (final mangaDirectory in await downloadedMangaDirectories(chapter)) {
+    final archive = findChapterArchive(mangaDirectory, chapter.name!);
+    if (archive != null) return DownloadedChapter.fromArchive(archive);
+
+    if (!isComplete) continue;
+    final pagesDirectory = await storageProvider.getMangaChapterDirectory(
+      chapter,
+      mangaMainDirectory: mangaDirectory,
+    );
+    if (pagesDirectory == null) continue;
+    final pageCount = countDownloadedPages(pagesDirectory);
+    if (pageCount > 0) {
+      return DownloadedChapter.fromPages(pagesDirectory, pageCount: pageCount);
+    }
+  }
+  return null;
+}
+
+/// The `.cbz` for [chapterName] in [mangaDirectory], under either name it may
+/// carry.
+///
+/// The downloader names it after the chapter with forbidden characters replaced
+/// by spaces, while the reader used to rebuild the raw name. That is why a
+/// chapter whose title holds a colon never resolved locally and fell through to
+/// the network.
+File? findChapterArchive(Directory mangaDirectory, String chapterName) {
+  for (final name in {
+    chapterName,
+    chapterName.replaceForbiddenCharacters(' '),
+  }) {
+    final file = File(p.join(mangaDirectory.path, '$name.cbz'));
+    if (file.existsSync()) return file;
+  }
+  return null;
+}
+
+/// How many pages of [directory] the reader can actually address.
+///
+/// The reader asks for page `i` by rebuilding `padIndex(i).jpg`, so the run has
+/// to be counted from the first page and stop at the first gap. A folder
+/// missing `003.jpg` can only serve two pages however many files it holds.
+int countDownloadedPages(Directory directory) {
+  if (!directory.existsSync()) return 0;
+  var count = 0;
+  while (File(p.join(directory.path, '${padIndex(count)}.jpg')).existsSync()) {
+    count++;
+  }
+  return count;
+}

--- a/lib/services/downloaded_chapter.dart
+++ b/lib/services/downloaded_chapter.dart
@@ -70,22 +70,43 @@ Future<DownloadedChapter?> findDownloadedChapter(Chapter chapter) async {
   final chapterId = chapter.id;
   if (chapterId == null || chapter.name == null) return null;
 
-  final storageProvider = StorageProvider();
   // The folder is written page by page, so a download still in flight has a
   // partial one; only the Isar record knows it is finished. An archive needs no
   // such check, since it is written once, at the end, from the complete folder.
   final isComplete = isar.downloads.getSync(chapterId)?.isDownload ?? false;
+  final chapterDirectory = await StorageProvider().getMangaChapterDirectory(
+    chapter,
+  );
+  if (chapterDirectory == null) return null;
 
-  for (final mangaDirectory in await downloadedMangaDirectories(chapter)) {
-    final archive = findChapterArchive(mangaDirectory, chapter.name!);
+  return findDownloadedChapterIn(
+    await downloadedMangaDirectories(chapter),
+    chapterName: chapter.name!,
+    chapterDirectoryName: p.basename(chapterDirectory.path),
+    isComplete: isComplete,
+  );
+}
+
+/// The local copy in the first of [mangaDirectories] that holds one.
+///
+/// The chapter's own folder carries the same name under every manga directory,
+/// so [chapterDirectoryName] is the basename the downloader gave it and only
+/// the parent changes. [isComplete] gates that folder and not the archive, for
+/// the reason given in [findDownloadedChapter].
+DownloadedChapter? findDownloadedChapterIn(
+  Iterable<Directory> mangaDirectories, {
+  required String chapterName,
+  required String chapterDirectoryName,
+  required bool isComplete,
+}) {
+  for (final mangaDirectory in mangaDirectories) {
+    final archive = findChapterArchive(mangaDirectory, chapterName);
     if (archive != null) return DownloadedChapter.fromArchive(archive);
 
     if (!isComplete) continue;
-    final pagesDirectory = await storageProvider.getMangaChapterDirectory(
-      chapter,
-      mangaMainDirectory: mangaDirectory,
+    final pagesDirectory = Directory(
+      p.join(mangaDirectory.path, chapterDirectoryName),
     );
-    if (pagesDirectory == null) continue;
     final pageCount = countDownloadedPages(pagesDirectory);
     if (pageCount > 0) {
       return DownloadedChapter.fromPages(pagesDirectory, pageCount: pageCount);

--- a/lib/services/get_chapter_pages.dart
+++ b/lib/services/get_chapter_pages.dart
@@ -14,6 +14,7 @@ import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/library/providers/file_scanner.dart';
 import 'package:mangayomi/modules/manga/archive_reader/providers/archive_reader_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
+import 'package:mangayomi/services/downloaded_chapter.dart';
 import 'package:mangayomi/utils/utils.dart';
 import 'package:mangayomi/utils/reg_exp_matcher.dart';
 import 'package:mangayomi/modules/more/providers/incognito_mode_state_provider.dart';
@@ -65,12 +66,18 @@ Future<GetChapterPagesModel> getChapterPages(
     final resolvedArchivePath = isLocalArchive
         ? await resolveLocalArchivePath(chapter.archivePath!)
         : null;
+
+    // A downloaded chapter has to open from disk, not from its source. Finding
+    // the local copy before any network call is what lets it open with the
+    // extension uninstalled, the site down, or no connection at all: getPageList
+    // used to run first and its failure took the whole chapter down even though
+    // every page was already on disk.
+    final downloaded = isLocalArchive
+        ? null
+        : await findDownloadedChapter(chapter);
+    if (downloaded?.pagesDirectory != null) path = downloaded!.pagesDirectory;
+
     if (!chapter.manga.value!.isLocalArchive!) {
-      final source = getSource(
-        chapter.manga.value!.lang!,
-        chapter.manga.value!.source!,
-        chapter.manga.value!.sourceId,
-      )!;
       if ((isarPageUrls?.urls?.isNotEmpty ?? false) &&
           (isarPageUrls?.chapterUrl ?? chapter.url) == chapter.url) {
         pagesFromCache = true;
@@ -83,7 +90,15 @@ Future<GetChapterPagesModel> getChapterPages(
           }
           pageUrls.add(PageUrl(isarPageUrls.urls![i], headers: headers));
         }
-      } else {
+      } else if (downloaded == null) {
+        // Only ask the source when there is nothing on disk to read. The
+        // extension is also resolved here rather than above, so a missing one
+        // can't take down a chapter that never needed it.
+        final source = getSource(
+          chapter.manga.value!.lang!,
+          chapter.manga.value!.source!,
+          chapter.manga.value!.sourceId,
+        )!;
         pageUrls = await getIsolateService.get<List<PageUrl>>(
           url: chapter.url!,
           source: source,
@@ -101,22 +116,26 @@ Future<GetChapterPagesModel> getChapterPages(
       uChapDataPreload: [],
     );
 
-    if (pageUrls.isNotEmpty || isLocalArchive) {
-      if (await File(p.join(mangaDirectory!.path, "${chapter.name}.cbz"))
-              .exists() ||
-          isLocalArchive) {
-        final path = isLocalArchive
-            ? resolvedArchivePath
-            : p.join(mangaDirectory.path, "${chapter.name}.cbz");
+    final archivePath = isLocalArchive
+        ? resolvedArchivePath
+        : downloaded?.archive?.path;
+
+    if (pageUrls.isNotEmpty || archivePath != null || downloaded != null) {
+      if (archivePath != null) {
         final local = await ref.read(
-          getArchiveDataFromFileProvider(path!).future,
+          getArchiveDataFromFileProvider(archivePath).future,
         );
         for (var image in local.images!) {
           archiveImages.add(image.image!);
           isLocaleList.add(true);
         }
       } else {
-        for (var i = 0; i < pageUrls.length; i++) {
+        // With no urls from the cache and none from the source, the folder on
+        // disk is the only thing that knows how many pages there are.
+        final pageCount = pageUrls.isNotEmpty
+            ? pageUrls.length
+            : downloaded!.pageCount;
+        for (var i = 0; i < pageCount; i++) {
           archiveImages.add(null);
           if (await File(p.join(path!.path, '${padIndex(i)}.jpg')).exists()) {
             isLocaleList.add(true);
@@ -125,10 +144,17 @@ Future<GetChapterPagesModel> getChapterPages(
           }
         }
       }
-      if (isLocalArchive) {
-        for (var i = 0; i < archiveImages.length; i++) {
+      // The reader indexes pageUrls, isLocaleList and archiveImages together,
+      // so the three have to agree: local pages carry no url, and an archive
+      // is the authority on how many pages the chapter actually has.
+      if (pageUrls.length > isLocaleList.length) {
+        pageUrls.removeRange(isLocaleList.length, pageUrls.length);
+      } else {
+        for (var i = pageUrls.length; i < isLocaleList.length; i++) {
           pageUrls.add(PageUrl(""));
         }
+      }
+      if (isLocalArchive) {
         // Archives store placeholder urls only for the page count; skip the
         // write when the stored entry already matches.
         if ((isarPageUrls?.urls?.length ?? -1) == pageUrls.length &&
@@ -140,7 +166,9 @@ Future<GetChapterPagesModel> getChapterPages(
       // row, so only do it when there is something new to store — never when
       // the pages came from that cache. The cache is also capped to the most
       // recent chapters so the row doesn't grow with reading history.
-      if (!incognitoMode && !pagesFromCache) {
+      // A downloaded chapter's urls are placeholders; storing them would make
+      // it unreadable online once the download is deleted.
+      if (!incognitoMode && !pagesFromCache && downloaded == null) {
         const maxCachedChapters = 40;
         List<ChapterPageurls>? chapterPageUrls = [];
         for (var chapterPageUrl in settings.chapterPageUrlsList ?? []) {

--- a/lib/services/get_video_list.dart
+++ b/lib/services/get_video_list.dart
@@ -7,6 +7,7 @@ import 'package:mangayomi/modules/library/providers/file_scanner.dart';
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/player/providers/player_state_provider.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
+import 'package:mangayomi/services/downloaded_chapter.dart';
 import 'package:mangayomi/services/isolate_service.dart';
 import 'package:mangayomi/services/torrent_server.dart';
 import 'package:mangayomi/utils/utils.dart';
@@ -34,14 +35,20 @@ Future<(List<Video>, bool, List<String>, Directory?)> getVideoList(
     final mpvDirectory = useMpvConfig
         ? await storageProvider.getMpvDirectory()
         : null;
-    final mangaDirectory = await storageProvider.getMangaMainDirectory(episode);
     final isLocalArchive =
         episode.manga.value!.isLocalArchive! &&
         episode.manga.value!.source != "torrent";
-    final mp4animePath = p.join(
-      mangaDirectory!.path,
-      "${episode.name!.replaceForbiddenCharacters(' ')}.mp4",
+    // Episodes downloaded on the builds that sent downloads to a local folder
+    // are still in that folder, so look there as well as in the downloads
+    // directory rather than only where new downloads land.
+    final episodeFileName =
+        "${episode.name!.replaceForbiddenCharacters(' ')}.mp4";
+    final candidateDirectories = await downloadedMangaDirectories(episode);
+    final downloadedDirectory = candidateDirectories.firstWhere(
+      (directory) => File(p.join(directory.path, episodeFileName)).existsSync(),
+      orElse: () => candidateDirectories.first,
     );
+    final mp4animePath = p.join(downloadedDirectory.path, episodeFileName);
     final resolvedArchivePath = episode.archivePath?.isNotEmpty ?? false
         ? await resolveLocalArchivePath(episode.archivePath!)
         : null;
@@ -53,7 +60,7 @@ Future<(List<Video>, bool, List<String>, Directory?)> getVideoList(
           : null;
       final chapterDirectory = (await storageProvider.getMangaChapterDirectory(
         episode,
-        mangaMainDirectory: animeDir ?? mangaDirectory,
+        mangaMainDirectory: animeDir ?? downloadedDirectory,
       ))!;
       final path = isLocalArchive ? resolvedArchivePath : mp4animePath;
       final subtitlesDir = Directory(

--- a/test/services/downloaded_chapter_test.dart
+++ b/test/services/downloaded_chapter_test.dart
@@ -51,6 +51,87 @@ void main() {
     });
   });
 
+  group('findDownloadedChapterIn', () {
+    late Directory downloads;
+    late Directory localFolder;
+
+    setUp(() {
+      downloads = Directory(p.join(directory.path, 'downloads', 'Manga'))
+        ..createSync(recursive: true);
+      localFolder = Directory(p.join(directory.path, 'local', 'Manga'))
+        ..createSync(recursive: true);
+    });
+
+    DownloadedChapter? find({bool isComplete = true}) =>
+        findDownloadedChapterIn(
+          [downloads, localFolder],
+          chapterName: 'Chapter 1',
+          chapterDirectoryName: 'Chapter 1',
+          isComplete: isComplete,
+        );
+
+    void writeArchive(Directory into) =>
+        File(p.join(into.path, 'Chapter 1.cbz')).writeAsStringSync('');
+
+    void writePages(Directory into, int count) {
+      final pages = Directory(p.join(into.path, 'Chapter 1'))..createSync();
+      for (var i = 1; i <= count; i++) {
+        File(p.join(pages.path, '${i.toString().padLeft(3, '0')}.jpg'))
+            .writeAsStringSync('');
+      }
+    }
+
+    test('is null when nothing was downloaded anywhere', () {
+      expect(find(), isNull);
+    });
+
+    test('finds an archive in the downloads directory', () {
+      writeArchive(downloads);
+      expect(find()?.archive?.path, startsWith(downloads.path));
+    });
+
+    test('falls back to a local folder, where older builds put it', () {
+      writeArchive(localFolder);
+      expect(find()?.archive?.path, startsWith(localFolder.path));
+    });
+
+    test('prefers the downloads directory when both hold a copy', () {
+      writeArchive(downloads);
+      writeArchive(localFolder);
+      expect(find()?.archive?.path, startsWith(downloads.path));
+    });
+
+    test('finds a page folder and counts it', () {
+      writePages(downloads, 3);
+      final found = find();
+      expect(found?.pagesDirectory?.path, startsWith(downloads.path));
+      expect(found?.pageCount, 3);
+    });
+
+    test('finds a page folder in a local folder too', () {
+      writePages(localFolder, 2);
+      expect(find()?.pagesDirectory?.path, startsWith(localFolder.path));
+    });
+
+    test('ignores a page folder while the download is still running', () {
+      writePages(downloads, 3);
+      expect(find(isComplete: false), isNull);
+    });
+
+    test('still takes an archive while a download is running, since an archive '
+        'is only written once the download finished', () {
+      writeArchive(downloads);
+      expect(find(isComplete: false)?.archive, isNotNull);
+    });
+
+    test('prefers the archive over a page folder beside it', () {
+      writeArchive(downloads);
+      writePages(downloads, 3);
+      expect(find()?.archive, isNotNull);
+      expect(find()?.pagesDirectory, isNull);
+    });
+  });
+
   group('countDownloadedPages', () {
     test('counts a complete chapter', () {
       for (final name in ['001.jpg', '002.jpg', '003.jpg']) {

--- a/test/services/downloaded_chapter_test.dart
+++ b/test/services/downloaded_chapter_test.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/downloaded_chapter.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory directory;
+
+  setUp(() => directory = Directory.systemTemp.createTempSync('downloaded'));
+  tearDown(() => directory.deleteSync(recursive: true));
+
+  void write(String name) =>
+      File(p.join(directory.path, name)).writeAsStringSync('');
+
+  group('findChapterArchive', () {
+    test('finds the archive the downloader writes', () {
+      write('Chapter 1.cbz');
+      expect(
+        findChapterArchive(directory, 'Chapter 1')?.path,
+        endsWith('Chapter 1.cbz'),
+      );
+    });
+
+    test('finds it when the title held a colon the downloader stripped', () {
+      // The downloader replaces forbidden characters with spaces, so this is
+      // the name on disk for a chapter called "Chapter 1: Beginnings". The
+      // reader used to rebuild the raw name and never match it.
+      write('Chapter 1  Beginnings.cbz');
+      expect(
+        findChapterArchive(directory, 'Chapter 1: Beginnings')?.path,
+        endsWith('Chapter 1  Beginnings.cbz'),
+      );
+    });
+
+    test('finds it under a name with nothing to sanitise', () {
+      write('Chapter 1 - 1_2.cbz');
+      expect(
+        findChapterArchive(directory, 'Chapter 1 - 1_2')?.path,
+        endsWith('Chapter 1 - 1_2.cbz'),
+      );
+    });
+
+    test('is null when nothing was downloaded', () {
+      expect(findChapterArchive(directory, 'Chapter 1'), isNull);
+    });
+
+    test('does not match another chapter in the same manga folder', () {
+      write('Chapter 2.cbz');
+      expect(findChapterArchive(directory, 'Chapter 1'), isNull);
+    });
+  });
+
+  group('countDownloadedPages', () {
+    test('counts a complete chapter', () {
+      for (final name in ['001.jpg', '002.jpg', '003.jpg']) {
+        write(name);
+      }
+      expect(countDownloadedPages(directory), 3);
+    });
+
+    test('stops at the first gap, since the reader asks by page index', () {
+      write('001.jpg');
+      write('002.jpg');
+      write('004.jpg');
+      expect(countDownloadedPages(directory), 2);
+    });
+
+    test('is zero for a folder holding no first page', () {
+      write('cover.jpg');
+      expect(countDownloadedPages(directory), 0);
+    });
+
+    test('is zero for a folder that was never created', () {
+      expect(
+        countDownloadedPages(Directory(p.join(directory.path, 'missing'))),
+        0,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes the error people are hitting when they open a downloaded chapter.

The read path asked the source before it looked on disk, so a failure there took down a chapter whose pages were already stored. `getPageList` ran unconditionally and the extension handle above it was a bare null assertion, so a missing extension, a dead source or no connection all ended at the reader's error screen.

Three things also kept the local copy from being found when it was reached:

1. The `.cbz` lookup rebuilt the raw chapter name, but the downloader writes it through `replaceForbiddenCharacters(' ')`. Any title holding a colon never matched. Same mismatch as #817, which was fixed for novels and left in place for manga.
2. Offline reading leant on `settings.chapterPageUrlsList`, which is capped at 40 entries, while downloading writes one entry per chapter. Anything past 40 quietly loses its urls and falls back to the source.
3. Downloads made while downloads went to a local folder are still in that folder. 265531f3 restored the location but did not move the files, and only `deleteDownloadedFiles` got a fallback.

## What I changed

* New `lib/services/downloaded_chapter.dart` resolves a downloaded chapter across the downloads directory and any local folder, under either name the archive can carry.
* `getChapterPages` resolves that first and asks the source only when there is nothing on disk. Cached urls are still preferred when present, so a chapter with a gap in its page folder behaves as it does today.
* The page folder is only trusted when the download record says it finished, since it is written page by page. An archive needs no such check, being written once at the end.
* A downloaded chapter no longer writes placeholder urls into the page-url cache, which would leave it unreadable from its source after the download is deleted.
* Reconciled the three per-page lists the reader indexes together. An archive with fewer images than the url list used to run `pageUrls` off the end of `isLocaleList`.
* Same lookup for anime, where an episode downloaded to a local folder was invisible to the player and it streamed instead.

## Testing

Eighteen new tests. The leaf helpers cover the archive name under both spellings and a page count that stops at the first gap, since the reader addresses pages by index. The resolution around them covers the local folder fallback, the downloads directory winning when both hold a copy, an archive beating a page folder beside it, and a page folder ignored while a download is still running while an archive is still taken.

Full suite passes (33), `dart analyze lib/` is clean.

Also verified on device, a release build on an iPhone 14, where reading downloaded chapters works.
