### PR TITLE
Fix chapter sort incorrectly and Added Missing Chapter Header

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -407,6 +407,7 @@
   "episode_number": "Episode number",
   "share": "Share",
   "n_chapters": "{n} chapters",
+  "missing_chapters": "Missing {count} chapters",
   "no_description": "No description",
   "resume": "Resume",
   "read": "Read",
@@ -492,6 +493,7 @@
   "full_screen_player_info": "Automatically use fullscreen when playing a video.",
   "episode_progress": "Progress: {n}",
   "n_episodes": "{n} episodes",
+  "missing_episodes": "Missing {count} episodes",
   "manga_sources": "Manga Sources",
   "anime_sources": "Anime Sources",
   "novel_sources": "Novel Sources",
@@ -847,6 +849,12 @@
   "@failed_to_export_metadata": {
     "placeholders": {
       "error": {}
+    }
+  },
+  "unrecognized_chapter_numbers": "{count} chapter(s) couldn't be auto-numbered and may be out of order or missing from the reader.",
+  "@unrecognized_chapter_numbers": {
+    "placeholders": {
+      "count": {}
     }
   },
   "cloudflare_resolution_webview_server_start_failed": "Couldn't start Cloudflare Resolution Webview Server.",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1637,6 +1637,12 @@ abstract class AppLocalizations {
   /// **'{n} chapters'**
   String n_chapters(Object n);
 
+  /// No description provided for @missing_chapters.
+  ///
+  /// In en, this message translates to:
+  /// **'Missing {count} chapters'**
+  String missing_chapters(Object count);
+
   /// No description provided for @no_description.
   ///
   /// In en, this message translates to:
@@ -2146,6 +2152,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{n} episodes'**
   String n_episodes(Object n);
+
+  /// No description provided for @missing_episodes.
+  ///
+  /// In en, this message translates to:
+  /// **'Missing {count} episodes'**
+  String missing_episodes(Object count);
 
   /// No description provided for @manga_sources.
   ///
@@ -4042,6 +4054,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Failed to export metadata: {error}'**
   String failed_to_export_metadata(Object error);
+
+  /// No description provided for @unrecognized_chapter_numbers.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.'**
+  String unrecognized_chapter_numbers(Object count);
 
   /// No description provided for @cloudflare_resolution_webview_server_start_failed.
   ///

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -889,6 +889,11 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'لا يوجد وصف';
 
   @override
@@ -1163,6 +1168,11 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n حلقات';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2199,6 +2209,11 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -879,6 +879,11 @@ class AppLocalizationsAs extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'কোনো বিৱৰণ নাই';
 
   @override
@@ -1154,6 +1159,11 @@ class AppLocalizationsAs extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n খণ্ড';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2193,6 +2203,11 @@ class AppLocalizationsAs extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -879,6 +879,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'Keine Beschreibung';
 
   @override
@@ -1154,6 +1159,11 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n Episoden';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2206,6 +2216,11 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -878,6 +878,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'No description';
 
   @override
@@ -1153,6 +1158,11 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n episodes';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2187,6 +2197,11 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -882,6 +882,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'Sin descripción';
 
   @override
@@ -1157,6 +1162,11 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n episodios';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2215,6 +2225,11 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -884,6 +884,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'Aucune description';
 
   @override
@@ -1160,6 +1165,11 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n épisodes';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2215,6 +2225,11 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -877,6 +877,11 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'कोई विवरण नहीं';
 
   @override
@@ -1152,6 +1157,11 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n एपिसोड';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2191,6 +2201,11 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -881,6 +881,11 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'Tidak ada deskripsi';
 
   @override
@@ -1156,6 +1161,11 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n episode';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2198,6 +2208,11 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -884,6 +884,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'Nessuna descrizione';
 
   @override
@@ -1159,6 +1164,11 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n episodi';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2214,6 +2224,11 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -871,6 +871,11 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => '説明なし';
 
   @override
@@ -1141,6 +1146,11 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n エピソード';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2158,6 +2168,11 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -882,6 +882,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'Sem descrição';
 
   @override
@@ -1157,6 +1162,11 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n episódios';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2210,6 +2220,11 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -893,6 +893,11 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'Нет описания';
 
   @override
@@ -1169,6 +1174,11 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n эпизодов';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2225,6 +2235,11 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -878,6 +878,11 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'ไม่มีคำอธิบาย';
 
   @override
@@ -1152,6 +1157,11 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n ตอน';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2187,6 +2197,11 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -876,6 +876,11 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => 'Açıklama Yok';
 
   @override
@@ -1151,6 +1156,11 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n bölüm';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2196,6 +2206,11 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -860,6 +860,11 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String missing_chapters(Object count) {
+    return 'Missing $count chapters';
+  }
+
+  @override
   String get no_description => '无描述';
 
   @override
@@ -1129,6 +1134,11 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String n_episodes(Object n) {
     return '$n集';
+  }
+
+  @override
+  String missing_episodes(Object count) {
+    return 'Missing $count episodes';
   }
 
   @override
@@ -2133,6 +2143,11 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String failed_to_export_metadata(Object error) {
     return 'Failed to export metadata: $error';
+  }
+
+  @override
+  String unrecognized_chapter_numbers(Object count) {
+    return '$count chapter(s) couldn\'t be auto-numbered and may be out of order or missing from the reader.';
   }
 
   @override

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -104,8 +104,23 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
     super.dispose();
   }
 
+  /// One-time notice (per screen open) when some chapters have no
+  /// detectable number — sort/dedup can't place them reliably.
+  void _notifyUnrecognizedChapterNumbers() {
+    if (_shownUnrecognizedNotice) return;
+    final count = widget.manga!.unrecognizedChapterNumberCount();
+    if (count == 0) return;
+    _shownUnrecognizedNotice = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final l10n = l10nLocalizations(context)!;
+      botToast(l10n.unrecognized_chapter_numbers(count), second: 5);
+    });
+  }
+
   final offetProvider = StateProvider(() => 0.0);
   bool _expanded = false;
+  bool _shownUnrecognizedNotice = false;
   late final ScrollController _scrollController;
   late final isLocalArchive = widget.manga!.isLocalArchive ?? false;
 
@@ -225,6 +240,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
           data: (_) {
             List<Chapter> chapters = widget.manga!.getSortedFilteredChapters();
             ref.read(chaptersListttStateProvider.notifier).set(chapters);
+            _notifyUnrecognizedChapterNumbers();
             return _buildWidget(chapters: chapters);
           },
           error: (Object error, StackTrace stackTrace) {
@@ -689,19 +705,60 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                                         const EdgeInsets.symmetric(
                                                           horizontal: 8,
                                                         ),
-                                                    child: Text(
-                                                      widget.manga!.itemType !=
-                                                              ItemType.anime
-                                                          ? l10n.n_chapters(
-                                                              chapters.length,
-                                                            )
-                                                          : l10n.n_episodes(
-                                                              chapters.length,
-                                                            ),
-                                                      style: const TextStyle(
-                                                        fontWeight:
-                                                            FontWeight.bold,
-                                                      ),
+                                                    child: Column(
+                                                      crossAxisAlignment:
+                                                          CrossAxisAlignment
+                                                              .start,
+                                                      mainAxisSize:
+                                                          MainAxisSize.min,
+                                                      children: [
+                                                        Text(
+                                                          widget
+                                                                      .manga!
+                                                                      .itemType !=
+                                                                  ItemType.anime
+                                                              ? l10n.n_chapters(
+                                                                  chapters
+                                                                      .length,
+                                                                )
+                                                              : l10n.n_episodes(
+                                                                  chapters
+                                                                      .length,
+                                                                ),
+                                                          style:
+                                                              const TextStyle(
+                                                                fontWeight:
+                                                                    FontWeight
+                                                                        .bold,
+                                                              ),
+                                                        ),
+                                                        Builder(
+                                                          builder: (context) {
+                                                            final missing = widget
+                                                                .manga!
+                                                                .missingChapterCount();
+                                                            if (missing <= 0) {
+                                                              return const SizedBox.shrink();
+                                                            }
+                                                            return Text(
+                                                              widget.manga!.itemType !=
+                                                                      ItemType
+                                                                          .anime
+                                                                  ? l10n.missing_chapters(
+                                                                      missing,
+                                                                    )
+                                                                  : l10n.missing_episodes(
+                                                                      missing,
+                                                                    ),
+                                                              style: TextStyle(
+                                                                fontSize: 12,
+                                                                color: Colors
+                                                                    .red[400],
+                                                              ),
+                                                            );
+                                                          },
+                                                        ),
+                                                      ],
                                                     ),
                                                   ),
                                                 ),
@@ -1710,13 +1767,38 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                 padding: const EdgeInsets.symmetric(
                                   horizontal: 8,
                                 ),
-                                child: Text(
-                                  widget.manga!.itemType != ItemType.anime
-                                      ? l10n.n_chapters(chapterLength)
-                                      : l10n.n_episodes(chapterLength),
-                                  style: const TextStyle(
-                                    fontWeight: FontWeight.bold,
-                                  ),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Text(
+                                      widget.manga!.itemType != ItemType.anime
+                                          ? l10n.n_chapters(chapterLength)
+                                          : l10n.n_episodes(chapterLength),
+                                      style: const TextStyle(
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                    Builder(
+                                      builder: (context) {
+                                        final missing = widget.manga!
+                                            .missingChapterCount();
+                                        if (missing <= 0) {
+                                          return const SizedBox.shrink();
+                                        }
+                                        return Text(
+                                          widget.manga!.itemType !=
+                                                  ItemType.anime
+                                              ? l10n.missing_chapters(missing)
+                                              : l10n.missing_episodes(missing),
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            color: Colors.red[400],
+                                          ),
+                                        );
+                                      },
+                                    ),
+                                  ],
                                 ),
                               ),
                               if (isLocalArchive)

--- a/lib/utils/chapter_recognition.dart
+++ b/lib/utils/chapter_recognition.dart
@@ -19,7 +19,7 @@ class ChapterRecognition {
   /// season when present: key = season * 100000 + episode.
   int parseChapterNumber(String mangaTitle, String chapterName) {
     final (season, ep) = rawSeasonAndNumber(mangaTitle, chapterName);
-    return _withSeason(season, ep);
+    return _withSeason(season, ep).toInt();
   }
 
   /// Episode number within a season, for tracker updates (MAL/AniList/Kitsu)
@@ -27,11 +27,14 @@ class ChapterRecognition {
   /// so season is never applied.
   int parseEpisodeNumber(String mangaTitle, String chapterName) {
     final (_, ep) = rawSeasonAndNumber(mangaTitle, chapterName);
-    return ep;
+    return ep.toInt();
   }
 
   /// Raw (season, episode) pair, unbucketed — season is 0 if none matched.
-  (int, int) rawSeasonAndNumber(String mangaTitle, String chapterName) {
+  /// Episode keeps its fractional part (e.g. 12.5) so callers needing exact
+  /// chapter identity (dedup, stable sort of split chapters) don't collide
+  /// at the same truncated integer.
+  (int, double) rawSeasonAndNumber(String mangaTitle, String chapterName) {
     final name = chapterName
         .toLowerCase()
         .replaceAll(mangaTitle.toLowerCase(), '')
@@ -45,22 +48,23 @@ class ChapterRecognition {
 
     final epMatch = _episodeKeyword.firstMatch(name);
     if (epMatch != null) {
-      return (season, double.parse(epMatch.group(1)!).toInt());
+      return (season, double.parse(epMatch.group(1)!));
     }
 
     final stripped = name.replaceAll(_unwanted, '');
     return (season, _extractNumber(stripped) ?? 0);
   }
 
-  // Combines season + episode into a sortable integer.
-  int _withSeason(int season, int ep) => season > 0 ? season * 100000 + ep : ep;
+  // Combines season + episode into a sortable number.
+  double _withSeason(int season, double ep) =>
+      season > 0 ? season * 100000 + ep : ep;
 
-  int? _extractNumber(String name) {
+  double? _extractNumber(String name) {
     final chMatch = _chNotation.firstMatch(name);
-    if (chMatch != null) return _fromMatch(chMatch).toInt();
+    if (chMatch != null) return _fromMatch(chMatch);
 
     final numMatch = _bareNumber.firstMatch(name);
-    if (numMatch != null) return _fromMatch(numMatch).toInt();
+    if (numMatch != null) return _fromMatch(numMatch);
 
     return null;
   }

--- a/lib/utils/chapter_recognition.dart
+++ b/lib/utils/chapter_recognition.dart
@@ -1,3 +1,5 @@
+import 'package:mangayomi/utils/log/logger.dart';
+
 class ChapterRecognition {
   static final _unwanted = RegExp(
     r"\b(?:v|ver|vol|version|volume|season|staffel|saison|temporada|s)[^a-z]?[0-9]+",
@@ -14,6 +16,10 @@ class ChapterRecognition {
     r"(?<=ch\.) *([0-9]+)(\.[0-9]+)?(\.?[a-z]+)?",
   );
   static final _bareNumber = RegExp(r"([0-9]+)(\.[0-9]+)?(\.?[a-z]+)?");
+
+  // Dedup so a repeatedly-rebuilt chapter list doesn't spam the log file
+  // with the same unrecognized name on every rebuild.
+  static final Set<String> _loggedUnrecognized = {};
 
   /// Sort key for a single chapter with no list context. Always buckets by
   /// season when present: key = season * 100000 + episode.
@@ -55,7 +61,14 @@ class ChapterRecognition {
     }
 
     final stripped = name.replaceAll(_unwanted, '');
-    return (season, _extractNumber(stripped));
+    final ep = _extractNumber(stripped);
+    if (ep == null && _loggedUnrecognized.add('$mangaTitle|$chapterName')) {
+      AppLogger.log(
+        'ChapterRecognition: no number detected in "$chapterName" (manga: "$mangaTitle")',
+        logLevel: LogLevel.warning,
+      );
+    }
+    return (season, ep);
   }
 
   // Combines season + episode into a sortable number.

--- a/lib/utils/chapter_recognition.dart
+++ b/lib/utils/chapter_recognition.dart
@@ -15,23 +15,23 @@ class ChapterRecognition {
   );
   static final _bareNumber = RegExp(r"([0-9]+)(\.[0-9]+)?(\.?[a-z]+)?");
 
-  /// Sort key for the UI list. Encodes season into the key so multi-season
-  /// anime sort correctly: key = season * 100000 + episode.
-  int parseChapterNumber(String mangaTitle, String chapterName) =>
-      _parse(mangaTitle, chapterName, applySeason: true);
+  /// Sort key for a single chapter with no list context. Always buckets by
+  /// season when present: key = season * 100000 + episode.
+  int parseChapterNumber(String mangaTitle, String chapterName) {
+    final (season, ep) = rawSeasonAndNumber(mangaTitle, chapterName);
+    return _withSeason(season, ep);
+  }
 
   /// Episode number within a season, for tracker updates (MAL/AniList/Kitsu)
   /// and AniSkip results. The tracker entry is already season-specific,
-  /// so season is stripped.
-  int parseEpisodeNumber(String mangaTitle, String chapterName) =>
-      _parse(mangaTitle, chapterName, applySeason: false);
+  /// so season is never applied.
+  int parseEpisodeNumber(String mangaTitle, String chapterName) {
+    final (_, ep) = rawSeasonAndNumber(mangaTitle, chapterName);
+    return ep;
+  }
 
-  int _parse(
-    String mangaTitle,
-    String chapterName, {
-    required bool applySeason,
-  }) {
-    // Normalize the chapter name by removing title, punctuation noise, etc.
+  /// Raw (season, episode) pair, unbucketed — season is 0 if none matched.
+  (int, int) rawSeasonAndNumber(String mangaTitle, String chapterName) {
     final name = chapterName
         .toLowerCase()
         .replaceAll(mangaTitle.toLowerCase(), '')
@@ -40,20 +40,16 @@ class ChapterRecognition {
         .replaceAll('-', '.')
         .replaceAll(_unwantedWhiteSpace, '');
 
-    final season = applySeason
-        ? int.tryParse(_seasonKeyword.firstMatch(name)?.group(1) ?? '') ?? 0
-        : 0;
+    final season =
+        int.tryParse(_seasonKeyword.firstMatch(name)?.group(1) ?? '') ?? 0;
 
     final epMatch = _episodeKeyword.firstMatch(name);
     if (epMatch != null) {
-      final ep = double.parse(epMatch.group(1)!).toInt();
-      return _withSeason(season, ep);
+      return (season, double.parse(epMatch.group(1)!).toInt());
     }
 
-    // strip season/volume noise, then look for ch. or bare number.
     final stripped = name.replaceAll(_unwanted, '');
-    final ep = _extractNumber(stripped);
-    return ep != null ? _withSeason(season, ep) : 0;
+    return (season, _extractNumber(stripped) ?? 0);
   }
 
   // Combines season + episode into a sortable integer.

--- a/lib/utils/chapter_recognition.dart
+++ b/lib/utils/chapter_recognition.dart
@@ -19,7 +19,7 @@ class ChapterRecognition {
   /// season when present: key = season * 100000 + episode.
   int parseChapterNumber(String mangaTitle, String chapterName) {
     final (season, ep) = rawSeasonAndNumber(mangaTitle, chapterName);
-    return _withSeason(season, ep).toInt();
+    return _withSeason(season, ep ?? 0).toInt();
   }
 
   /// Episode number within a season, for tracker updates (MAL/AniList/Kitsu)
@@ -27,14 +27,17 @@ class ChapterRecognition {
   /// so season is never applied.
   int parseEpisodeNumber(String mangaTitle, String chapterName) {
     final (_, ep) = rawSeasonAndNumber(mangaTitle, chapterName);
-    return ep.toInt();
+    return (ep ?? 0).toInt();
   }
 
   /// Raw (season, episode) pair, unbucketed — season is 0 if none matched.
   /// Episode keeps its fractional part (e.g. 12.5) so callers needing exact
   /// chapter identity (dedup, stable sort of split chapters) don't collide
-  /// at the same truncated integer.
-  (int, double) rawSeasonAndNumber(String mangaTitle, String chapterName) {
+  /// at the same truncated integer. Episode is null when the name has no
+  /// detectable number at all (e.g. "Special", "Prologue") — distinct from
+  /// a genuine chapter 0, so callers can avoid treating every such chapter
+  /// as a duplicate of every other one.
+  (int, double?) rawSeasonAndNumber(String mangaTitle, String chapterName) {
     final name = chapterName
         .toLowerCase()
         .replaceAll(mangaTitle.toLowerCase(), '')
@@ -52,7 +55,7 @@ class ChapterRecognition {
     }
 
     final stripped = name.replaceAll(_unwanted, '');
-    return (season, _extractNumber(stripped) ?? 0);
+    return (season, _extractNumber(stripped));
   }
 
   // Combines season + episode into a sortable number.

--- a/lib/utils/extensions/manga_extensions.dart
+++ b/lib/utils/extensions/manga_extensions.dart
@@ -6,15 +6,20 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/utils/chapter_recognition.dart';
 
-/// Sort keys that only bucket by season if numbering actually repeats
-/// across seasons (a real reset) — otherwise chapters sort by raw number.
-Map<int?, int> _chapterSortKeys(String mangaTitle, List<Chapter> chapterList) {
+/// Sort/identity keys that only bucket by season if numbering actually
+/// repeats across seasons (a real reset) — otherwise chapters key by raw
+/// number. Precise (not truncated) so split chapters (12, 12.1, 12.5, ...)
+/// sort and dedup correctly instead of colliding at the same integer.
+Map<int?, double> _chapterSortKeys(
+  String mangaTitle,
+  List<Chapter> chapterList,
+) {
   final recognition = ChapterRecognition();
-  final raw = <int?, (int, int)>{
+  final raw = <int?, (int, double)>{
     for (final c in chapterList)
       c.id: recognition.rawSeasonAndNumber(mangaTitle, c.name ?? ''),
   };
-  final episodeToSeasons = <int, Set<int>>{};
+  final episodeToSeasons = <double, Set<int>>{};
   for (final pair in raw.values) {
     episodeToSeasons.putIfAbsent(pair.$2, () => {}).add(pair.$1);
   }
@@ -180,15 +185,8 @@ extension MangaExtensions on Manga {
   /// another scanlator's copy of the same one.
   List<Chapter> getChapterListForReading() {
     final list = getFilteredChapters();
-    final mangaTitle = name ?? '';
-    final recognition = ChapterRecognition();
-    final seen = <int>{};
-    return list
-        .where(
-          (c) => seen.add(
-            recognition.parseChapterNumber(mangaTitle, c.name ?? ''),
-          ),
-        )
-        .toList();
+    final sortKeys = _chapterSortKeys(name ?? '', list);
+    final seen = <double>{};
+    return list.where((c) => seen.add(sortKeys[c.id] ?? 0)).toList();
   }
 }

--- a/lib/utils/extensions/manga_extensions.dart
+++ b/lib/utils/extensions/manga_extensions.dart
@@ -9,19 +9,23 @@ import 'package:mangayomi/utils/chapter_recognition.dart';
 /// Sort/identity keys that only bucket by season if numbering actually
 /// repeats across seasons (a real reset) — otherwise chapters key by raw
 /// number. Precise (not truncated) so split chapters (12, 12.1, 12.5, ...)
-/// sort and dedup correctly instead of colliding at the same integer.
-Map<int?, double> _chapterSortKeys(
+/// sort and dedup correctly instead of colliding at the same integer. A
+/// null value means the name had no detectable number at all (e.g.
+/// "Special") — distinct from a genuine chapter 0, so callers know not to
+/// treat every such chapter as a duplicate of every other one.
+Map<int?, double?> _chapterSortKeys(
   String mangaTitle,
   List<Chapter> chapterList,
 ) {
   final recognition = ChapterRecognition();
-  final raw = <int?, (int, double)>{
+  final raw = <int?, (int, double?)>{
     for (final c in chapterList)
       c.id: recognition.rawSeasonAndNumber(mangaTitle, c.name ?? ''),
   };
   final episodeToSeasons = <double, Set<int>>{};
   for (final pair in raw.values) {
-    episodeToSeasons.putIfAbsent(pair.$2, () => {}).add(pair.$1);
+    if (pair.$2 == null) continue;
+    episodeToSeasons.putIfAbsent(pair.$2!, () => {}).add(pair.$1);
   }
   // A single collision is more likely a stray "S1-5 Recap"-style title
   // falsely matching the season regex than a real reset — require several
@@ -33,11 +37,12 @@ Map<int?, double> _chapterSortKeys(
   final resets = collisions >= 3;
   return {
     for (final entry in raw.entries)
-      entry.key: resets
-          ? (entry.value.$1 > 0
-                ? entry.value.$1 * 100000 + entry.value.$2
-                : entry.value.$2)
-          : entry.value.$2,
+      entry.key: switch (entry.value.$2) {
+        null => null,
+        final ep => resets
+            ? (entry.value.$1 > 0 ? entry.value.$1 * 100000 + ep : ep)
+            : ep,
+      },
   };
 }
 
@@ -182,11 +187,17 @@ extension MangaExtensions on Manga {
   /// Filtered chapters ready for sequential reading: same filters as
   /// [getFilteredChapters] but with duplicate chapter numbers collapsed to a
   /// single entry so the reader advances to the next story chapter rather than
-  /// another scanlator's copy of the same one.
+  /// another scanlator's copy of the same one. Chapters with no detectable
+  /// number (key is null — e.g. "Special") are never collapsed: there is no
+  /// reliable way to tell them apart, so treating them all as duplicates
+  /// would silently drop real chapters instead of just scanlator copies.
   List<Chapter> getChapterListForReading() {
     final list = getFilteredChapters();
     final sortKeys = _chapterSortKeys(name ?? '', list);
     final seen = <double>{};
-    return list.where((c) => seen.add(sortKeys[c.id] ?? 0)).toList();
+    return list.where((c) {
+      final key = sortKeys[c.id];
+      return key == null || seen.add(key);
+    }).toList();
   }
 }

--- a/lib/utils/extensions/manga_extensions.dart
+++ b/lib/utils/extensions/manga_extensions.dart
@@ -6,6 +6,36 @@ import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/utils/chapter_recognition.dart';
 
+/// Sort keys that only bucket by season if numbering actually repeats
+/// across seasons (a real reset) — otherwise chapters sort by raw number.
+Map<int?, int> _chapterSortKeys(String mangaTitle, List<Chapter> chapterList) {
+  final recognition = ChapterRecognition();
+  final raw = <int?, (int, int)>{
+    for (final c in chapterList)
+      c.id: recognition.rawSeasonAndNumber(mangaTitle, c.name ?? ''),
+  };
+  final episodeToSeasons = <int, Set<int>>{};
+  for (final pair in raw.values) {
+    episodeToSeasons.putIfAbsent(pair.$2, () => {}).add(pair.$1);
+  }
+  // A single collision is more likely a stray "S1-5 Recap"-style title
+  // falsely matching the season regex than a real reset — require several
+  // before trusting it, since a genuine per-season reset repeats numbers
+  // across many chapters, not just one.
+  final collisions = episodeToSeasons.values
+      .where((seasons) => seasons.length > 1)
+      .length;
+  final resets = collisions >= 3;
+  return {
+    for (final entry in raw.entries)
+      entry.key: resets
+          ? (entry.value.$1 > 0
+                ? entry.value.$1 * 100000 + entry.value.$2
+                : entry.value.$2)
+          : entry.value.$2,
+  };
+}
+
 extension MangaExtensions on Manga {
   /// Number of unread chapters, excluding chapters from scanlators the user has
   /// filtered out for this manga. Mirrors the chapter list's scanlator filter,
@@ -55,19 +85,12 @@ extension MangaExtensions on Manga {
     final scanlators = settings.filterScanlatorList ?? [];
     final filter = scanlators.where((e) => e.mangaId == id);
     final filterScanlator = filter.firstOrNull?.scanlators ?? [];
-    final recognition = ChapterRecognition();
-    final mangaTitle = name ?? '';
 
-    // Memoize so each chapter name is parsed at most once during the sort.
-    final numCache = <int?, int>{};
-    int chapNum(Chapter c) => numCache[c.id] ??= recognition.parseChapterNumber(
-      mangaTitle,
-      c.name ?? '',
+    final data = chapters.toList();
+    final sortKeys = _chapterSortKeys(name ?? '', data);
+    data.sort(
+      (a, b) => (sortKeys[a.id] ?? 0).compareTo(sortKeys[b.id] ?? 0),
     );
-
-    // Sort by chapter number — DB insertion order is NOT guaranteed to be ascending
-    final data = chapters.toList()
-      ..sort((a, b) => chapNum(a).compareTo(chapNum(b)));
 
     final chapterIds = data.map((c) => c.id).whereType<int>().toList();
     final downloadedIds = (filterDownloaded == 0 || chapterIds.isEmpty)
@@ -121,20 +144,11 @@ extension MangaExtensions on Manga {
 
     switch (sortIndex) {
       case 0: // by scanlator, then chapter number
-        // Cache recognition instance — parseChapterNumber is called O(n log n)
-        // times during sort, so avoid constructing it inside the comparator.
-        final recognition = ChapterRecognition();
-        final mangaTitle = name ?? '';
-
-        // Returns the parsed chapter number for a chapter, used as the primary
-        // numeric sort key for cases 0 and 1.
-        final numCache = <int?, int>{};
-        int chapNum(Chapter c) => numCache[c.id] ??= recognition
-            .parseChapterNumber(mangaTitle, c.name ?? '');
+        final sortKeys = _chapterSortKeys(name ?? '', chapters.toList());
         list.sort((a, b) {
           final s = (a.scanlator ?? '').compareTo(b.scanlator ?? '');
           if (s != 0) return s;
-          return chapNum(a).compareTo(chapNum(b));
+          return (sortKeys[a.id] ?? 0).compareTo(sortKeys[b.id] ?? 0);
         });
         break;
       case 2: // by upload date

--- a/lib/utils/extensions/manga_extensions.dart
+++ b/lib/utils/extensions/manga_extensions.dart
@@ -39,9 +39,10 @@ Map<int?, double?> _chapterSortKeys(
     for (final entry in raw.entries)
       entry.key: switch (entry.value.$2) {
         null => null,
-        final ep => resets
-            ? (entry.value.$1 > 0 ? entry.value.$1 * 100000 + ep : ep)
-            : ep,
+        final ep =>
+          resets
+              ? (entry.value.$1 > 0 ? entry.value.$1 * 100000 + ep : ep)
+              : ep,
       },
   };
 }
@@ -98,9 +99,16 @@ extension MangaExtensions on Manga {
 
     final data = chapters.toList();
     final sortKeys = _chapterSortKeys(name ?? '', data);
-    data.sort(
-      (a, b) => (sortKeys[a.id] ?? 0).compareTo(sortKeys[b.id] ?? 0),
-    );
+    // List.sort isn't stable, so chapters tying at the same key (notably
+    // every unrecognized-number chapter, which falls back to 0) would
+    // otherwise shuffle unpredictably between rebuilds. Break ties by
+    // original position to keep them in a consistent, deterministic order.
+    final originalIndex = {for (var i = 0; i < data.length; i++) data[i].id: i};
+    data.sort((a, b) {
+      final cmp = (sortKeys[a.id] ?? 0).compareTo(sortKeys[b.id] ?? 0);
+      if (cmp != 0) return cmp;
+      return (originalIndex[a.id] ?? 0).compareTo(originalIndex[b.id] ?? 0);
+    });
 
     final chapterIds = data.map((c) => c.id).whereType<int>().toList();
     final downloadedIds = (filterDownloaded == 0 || chapterIds.isEmpty)
@@ -155,10 +163,19 @@ extension MangaExtensions on Manga {
     switch (sortIndex) {
       case 0: // by scanlator, then chapter number
         final sortKeys = _chapterSortKeys(name ?? '', chapters.toList());
+        // Same stability concern as getFilteredChapters: break remaining
+        // ties by list's current (already deterministic) order.
+        final originalIndex = {
+          for (var i = 0; i < list.length; i++) list[i].id: i,
+        };
         list.sort((a, b) {
           final s = (a.scanlator ?? '').compareTo(b.scanlator ?? '');
           if (s != 0) return s;
-          return (sortKeys[a.id] ?? 0).compareTo(sortKeys[b.id] ?? 0);
+          final cmp = (sortKeys[a.id] ?? 0).compareTo(sortKeys[b.id] ?? 0);
+          if (cmp != 0) return cmp;
+          return (originalIndex[a.id] ?? 0).compareTo(
+            originalIndex[b.id] ?? 0,
+          );
         });
         break;
       case 2: // by upload date
@@ -199,5 +216,35 @@ extension MangaExtensions on Manga {
       final key = sortKeys[c.id];
       return key == null || seen.add(key);
     }).toList();
+  }
+
+  /// Number of currently-filtered chapters whose name has no detectable
+  /// chapter/episode number at all — surfaced to the user since it means
+  /// automatic sort/dedup can't place them reliably.
+  int unrecognizedChapterNumberCount() {
+    final list = getFilteredChapters();
+    final sortKeys = _chapterSortKeys(name ?? '', list);
+    return list.where((c) => sortKeys[c.id] == null).length;
+  }
+
+  /// Count of whole numbers missing from the recognized chapter sequence —
+  /// e.g. chapters 1, 2, 4, 5 present means 1 (chapter 3) is missing. Decimal
+  /// extras (12.5) are floored into their whole chapter, since they aren't
+  /// part of the main numbering. Season-bucketed keys are unbucketed back to
+  /// their raw episode number first, since gaps only make sense within one
+  /// season's own numbering, not across a season * 100000 jump.
+  int missingChapterCount() {
+    final list = getFilteredChapters();
+    final mangaTitle = name ?? '';
+    final recognition = ChapterRecognition();
+    final numbers = <int>{};
+    for (final c in list) {
+      final (_, ep) = recognition.rawSeasonAndNumber(mangaTitle, c.name ?? '');
+      if (ep != null) numbers.add(ep.floor());
+    }
+    if (numbers.length < 2) return 0;
+    final lowest = numbers.reduce((a, b) => a < b ? a : b);
+    final highest = numbers.reduce((a, b) => a > b ? a : b);
+    return (highest - lowest + 1) - numbers.length;
   }
 }


### PR DESCRIPTION
Fixed where sorter would throw all any seasons + text + other numbers.  which it will send to top. 
and Added missing chapters at header top of chapter list