### PR TITLE
fix: stop dropping decimal chapters and mismatching them on migration (#812)

### DIFF
--- a/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
+++ b/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
@@ -83,10 +83,20 @@ Future<dynamic> updateMangaDetail(
       final existingChapters = manga.chapters.toList();
       final recognition = ChapterRecognition();
 
-      int? numberOf(Chapter c) {
+      // The exact number, not the sort key. parseChapterNumber truncates, so
+      // chapters 12, 12.1 and 12.5 all answer 12 and every use of this below
+      // treats them as the same chapter: the composite key drops two of the
+      // three before they reach the library, and read state carries across
+      // all three. rawSeasonAndNumber keeps the fraction, and answers null
+      // for a name with no number at all rather than folding every "Special"
+      // and "Prologue" onto zero.
+      double? numberOf(Chapter c) {
         if (c.name == null) return null;
-        final num = recognition.parseChapterNumber(manga.name ?? '', c.name!);
-        return num > 0 ? num : null;
+        final (_, number) = recognition.rawSeasonAndNumber(
+          manga.name ?? '',
+          c.name!,
+        );
+        return (number ?? 0) > 0 ? number : null;
       }
 
       final existingByUrl = <String, Chapter>{};
@@ -115,7 +125,7 @@ Future<dynamic> updateMangaDetail(
         }
       }
 
-      final readByNumber = <int, bool>{};
+      final readByNumber = <double, bool>{};
       for (final c in existingChapters) {
         final num = numberOf(c);
         if (num != null) {
@@ -133,9 +143,10 @@ Future<dynamic> updateMangaDetail(
         if (url == null || url.isEmpty) continue;
         final key = url.getUrlWithoutDomain;
 
-        final chapNum = chap.name != null
-            ? recognition.parseChapterNumber(manga.name!, chap.name!)
-            : 0;
+        final (_, chapNumber) = chap.name != null
+            ? recognition.rawSeasonAndNumber(manga.name!, chap.name!)
+            : (0, null);
+        final chapNum = chapNumber ?? 0;
         final compositeKey = chapNum > 0
             ? '$chapNum::${chap.scanlator ?? ''}'
             : null;

--- a/lib/modules/mass_migration/services/mass_migration_service.dart
+++ b/lib/modules/mass_migration/services/mass_migration_service.dart
@@ -14,6 +14,7 @@ import 'package:mangayomi/modules/manga/detail/providers/isar_providers.dart';
 import 'package:mangayomi/modules/more/settings/sync/providers/sync_providers.dart';
 import 'package:mangayomi/services/get_detail.dart';
 import 'package:mangayomi/services/search.dart';
+import 'package:mangayomi/utils/chapter_recognition.dart';
 import 'package:mangayomi/utils/extensions/string_extensions.dart';
 
 Future<void> migrateLibraryItem({
@@ -45,12 +46,20 @@ Future<void> migrateLibraryItem({
 class _MigrationSnapshot {
   const _MigrationSnapshot({
     required this.chaptersProgress,
+    required this.sourceTitle,
     this.historyChapter,
     this.historyDate,
   });
 
   final List<Chapter> chaptersProgress;
-  final String? historyChapter;
+
+  /// The title the item had before the migration rewrote it. Chapter names are
+  /// parsed with their own item's title stripped out, so the old chapters have
+  /// to be read against the old title and the new ones against the new one.
+  final String sourceTitle;
+
+  /// Chapter number of the last thing read, as [ChapterRecognition] sees it.
+  final double? historyChapter;
   final String? historyDate;
 }
 
@@ -58,9 +67,10 @@ _MigrationSnapshot _captureMigrationSnapshot({
   required WidgetRef ref,
   required Manga oldManga,
 }) {
-  String? historyChapter;
+  double? historyChapter;
   String? historyDate;
   final chaptersProgress = <Chapter>[];
+  final sourceTitle = oldManga.name ?? '';
 
   isar.writeTxnSync(() {
     final histories = isar.historys
@@ -68,8 +78,9 @@ _MigrationSnapshot _captureMigrationSnapshot({
         .mangaIdEqualTo(oldManga.id)
         .sortByDate()
         .findAllSync();
-    historyChapter = extractMigrationChapterNumber(
-      histories.lastOrNull?.chapter.value?.name ?? '',
+    historyChapter = _chapterNumber(
+      sourceTitle,
+      histories.lastOrNull?.chapter.value?.name,
     );
     historyDate = histories.lastOrNull?.date;
     for (final history in histories) {
@@ -92,6 +103,7 @@ _MigrationSnapshot _captureMigrationSnapshot({
 
   return _MigrationSnapshot(
     chaptersProgress: chaptersProgress,
+    sourceTitle: sourceTitle,
     historyChapter: historyChapter,
     historyDate: historyDate,
   );
@@ -191,17 +203,26 @@ void _restoreMigrationProgress({
   required _MigrationSnapshot snapshot,
 }) {
   isar.writeTxnSync(() {
+    // Index the destination's chapters by number once, then match on that
+    // number. The old lookup extracted the leading digits of the name and ran
+    // nameContains against them, so "Chapter 1" also matched "Chapter 10" and
+    // "Chapter 19" and findFirst took whichever the index happened to return:
+    // progress could land on a chapter the reader had never opened.
+    final destinationTitle = oldManga.name ?? '';
+    final byNumber = <double, Chapter>{};
+    for (final chapter
+        in isar.chapters
+            .where()
+            .mangaIdEqualToAnyIsRead(oldManga.id)
+            .findAllSync()) {
+      final number = _chapterNumber(destinationTitle, chapter.name);
+      if (number != null) byNumber.putIfAbsent(number, () => chapter);
+    }
+
     final updatedChapters = <Chapter>[];
     for (final oldChapter in snapshot.chaptersProgress) {
-      final chapter = isar.chapters
-          .where()
-          .mangaIdEqualToAnyIsRead(oldManga.id)
-          .filter()
-          .nameContains(
-            extractMigrationChapterNumber(oldChapter.name ?? '') ?? '.....',
-            caseSensitive: false,
-          )
-          .findFirstSync();
+      final number = _chapterNumber(snapshot.sourceTitle, oldChapter.name);
+      final chapter = number == null ? null : byNumber[number];
       if (chapter != null) {
         chapter.isBookmarked = oldChapter.isBookmarked;
         chapter.lastPageRead = oldChapter.lastPageRead;
@@ -213,11 +234,9 @@ void _restoreMigrationProgress({
       isar.chapters.putAllSync(updatedChapters);
     }
 
-    final historyChapter = isar.chapters
-        .filter()
-        .mangaIdEqualTo(oldManga.id)
-        .nameContains(snapshot.historyChapter ?? '.....', caseSensitive: false)
-        .findFirstSync();
+    final historyChapter = snapshot.historyChapter == null
+        ? null
+        : byNumber[snapshot.historyChapter];
     if (historyChapter != null) {
       isar.historys.putSync(
         History(
@@ -386,12 +405,22 @@ List<String> buildMassMigrationQueries(Manga manga) {
   return queries.toList();
 }
 
-String? extractMigrationChapterNumber(String chapterName) {
-  return RegExp(
-        r'\s*(\d+\.\d+)\s*',
-        multiLine: true,
-      ).firstMatch(chapterName)?.group(0) ??
-      RegExp(r'\s*(\d+)\s*', multiLine: true).firstMatch(chapterName)?.group(0);
+/// The chapter number [ChapterRecognition] reads out of [chapterName], or null
+/// when the name carries no number at all.
+///
+/// Migration used to do its own extraction, which meant it did not understand
+/// decimal chapters, `ch.` notation, or volume and season noise, and it never
+/// benefited from fixes to the shared parser.
+double? _chapterNumber(String itemTitle, String? chapterName) {
+  if (chapterName == null || chapterName.isEmpty) return null;
+  // The exact number rather than the sort key, so a chapter 12 on one source
+  // does not match a 12.5 on the other and carry the reader's progress onto
+  // the wrong one.
+  final (_, number) = ChapterRecognition().rawSeasonAndNumber(
+    itemTitle,
+    chapterName,
+  );
+  return (number ?? 0) > 0 ? number : null;
 }
 
 MManga _selectBestCandidate({

--- a/test/utils/chapter_dedup_test.dart
+++ b/test/utils/chapter_dedup_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/utils/chapter_recognition.dart';
+
+/// The two numbers `ChapterRecognition` offers are not interchangeable, and
+/// picking the wrong one is what makes decimal chapters disappear.
+///
+/// `parseChapterNumber` is the sort key and truncates on purpose.
+/// `rawSeasonAndNumber` keeps the fraction, and is what anything deciding
+/// whether two chapters are the same chapter has to use.
+void main() {
+  final recognition = ChapterRecognition();
+
+  double? exact(String name) =>
+      recognition.rawSeasonAndNumber('One Piece', name).$2;
+
+  int key(String name) => recognition.parseChapterNumber('One Piece', name);
+
+  group('the sort key cannot tell decimal chapters apart', () {
+    test('12, 12.1 and 12.5 share one sort key', () {
+      // Not a bug in the key: it is what makes them sort together. It is a bug
+      // to build a de-duplication key out of it.
+      expect(key('Chapter 12'), key('Chapter 12.1'));
+      expect(key('Chapter 12'), key('Chapter 12.5'));
+    });
+  });
+
+  group('the exact number can', () {
+    test('12, 12.1 and 12.5 are three different chapters', () {
+      expect(exact('Chapter 12'), isNot(exact('Chapter 12.1')));
+      expect(exact('Chapter 12'), isNot(exact('Chapter 12.5')));
+      expect(exact('Chapter 12.1'), isNot(exact('Chapter 12.5')));
+    });
+
+    test('a composite key built from it keeps them apart', () {
+      // This is the shape update_manga_detail_providers builds, and the shape
+      // that decides whether a chapter reaches the library at all.
+      String composite(String name) => '${exact(name)}::scanlator';
+      final keys = {
+        composite('Chapter 12'),
+        composite('Chapter 12.1'),
+        composite('Chapter 12.5'),
+      };
+      expect(keys.length, 3);
+    });
+
+    test('the same composite key from the sort key collapses to one', () {
+      String composite(String name) => '${key(name)}::scanlator';
+      final keys = {
+        composite('Chapter 12'),
+        composite('Chapter 12.1'),
+        composite('Chapter 12.5'),
+      };
+      expect(keys.length, 1);
+    });
+
+    test('a name with no number is null, not zero', () {
+      // Otherwise every Special and Prologue is a duplicate of every other.
+      expect(exact('Special'), isNull);
+      expect(exact('Prologue'), isNull);
+    });
+
+    test('a whole chapter is still itself', () {
+      expect(exact('Chapter 12'), 12);
+    });
+  });
+}


### PR DESCRIPTION
Reworked on top of 96f1830a. That commit fixed the sort and added `rawSeasonAndNumber`, so I dropped my own parser change entirely and built on theirs. What is left is the two places that decide whether two chapters are *the same chapter*, which both still call `parseChapterNumber`.

`parseChapterNumber` truncates on purpose, so 12, 12.1 and 12.5 all answer 12 there.

**Library dedup** (`update_manga_detail_providers.dart`)

That number becomes the composite dedup key `'$number::$scanlator'`. A chapter whose key is already taken hits `continue` before it is written, so on a source that splits chapters the decimal ones never reach the library at all. This is the mechanism behind #812: the chapters are not skipped while reading, they were never stored. The same number keys `readByNumber`, so marking 12 read also greys out 12.5.

**Mass migration** (`mass_migration_service.dart`)

The number picks which destination chapter inherits progress. On top of the truncation it had an extraction of its own that never understood decimals, `ch.` notation, or volume and season noise, and never benefited from fixes to the shared parser. It then looked the chapter up with `nameContains` on those digits, where "Chapter 1" matches "Chapter 10" and "Chapter 19", and `findFirst` took whichever the index happened to return first, so progress could land on a chapter the reader had never opened.

**What changed**

Both now use `rawSeasonAndNumber`, which keeps the fraction and answers null for a name with no number rather than folding every Special and Prologue onto zero. Migration indexes the destination chapters by number once and matches on that, and captures the pre-migration title because `_rewriteMigratedItemMetadata` has already overwritten `oldManga.name` by the time progress is restored, so the old chapter names were being parsed against the new title.

Tests cover the distinction the fix rests on: the same composite key collapses three chapters to one when built from the sort key and keeps all three when built from the exact number.

Closes #812