### PR TITLE
fix: stop a running update from the updates screen, and a grey box in its list

### DIFF
--- a/lib/modules/updates/updates_screen.dart
+++ b/lib/modules/updates/updates_screen.dart
@@ -75,11 +75,30 @@ class _UpdatesScreenState extends BaseLibraryTabScreenState<UpdatesScreen> {
             MaterialPageRoute(builder: (_) => const UpdateErrorsScreen()),
           ),
         ),
-      IconButton(
-        splashRadius: 20,
-        icon: Icon(Icons.refresh_outlined, color: Theme.of(context).hintColor),
-        onPressed: _updateLibrary,
-      ),
+      // While an update is running this is the way to stop it, the same as on
+      // the library screen. Watching the provider rather than this screen's own
+      // flag means the button is also correct for an update started elsewhere.
+      if (ref.watch(libraryUpdateProvider).running)
+        IconButton(
+          splashRadius: 20,
+          tooltip: l10n.cancel,
+          icon: Icon(
+            Icons.stop_circle_outlined,
+            color: Theme.of(context).hintColor,
+          ),
+          onPressed: () =>
+              ref.read(libraryUpdateProvider.notifier).requestCancel(),
+        )
+      else
+        IconButton(
+          splashRadius: 20,
+          tooltip: l10n.refresh,
+          icon: Icon(
+            Icons.refresh_outlined,
+            color: Theme.of(context).hintColor,
+          ),
+          onPressed: _updateLibrary,
+        ),
       IconButton(
         splashRadius: 20,
         icon: Icon(

--- a/lib/modules/updates/updates_screen.dart
+++ b/lib/modules/updates/updates_screen.dart
@@ -78,7 +78,7 @@ class _UpdatesScreenState extends BaseLibraryTabScreenState<UpdatesScreen> {
       // While an update is running this is the way to stop it, the same as on
       // the library screen. Watching the provider rather than this screen's own
       // flag means the button is also correct for an update started elsewhere.
-      if (ref.watch(libraryUpdateProvider).running)
+      if (ref.watch(libraryUpdateProvider.select((s) => s.running)))
         IconButton(
           splashRadius: 20,
           tooltip: l10n.cancel,
@@ -224,6 +224,18 @@ class _UpdateTabState extends ConsumerState<UpdateTab>
                 if (m != null) m.id!: m,
             };
 
+            // Both maps above skip an entry that no longer resolves, and the
+            // itemBuilder below then asserted it was there. An update whose
+            // chapter has been deleted (a refresh cleaning up duplicates) or
+            // whose manga has left the library therefore threw mid-build, and
+            // in a release build a throwing child is replaced by a plain grey
+            // box, leaving the list ending in scrollable grey. Drop those
+            // updates instead: the row has nothing left to show anyway.
+            final resolved = entries.where((e) {
+              final chapter = chapterByUpdateId[e.id];
+              return chapter != null && mangaById.containsKey(chapter.mangaId);
+            }).toList();
+
             int? lastUpdated;
             for (final c in chapterByUpdateId.values) {
               final value = mangaById[c.mangaId]?.lastUpdate;
@@ -232,7 +244,7 @@ class _UpdateTabState extends ConsumerState<UpdateTab>
                 lastUpdated = value;
               }
             }
-            if (entries.isNotEmpty) {
+            if (resolved.isNotEmpty) {
               return CustomScrollView(
                 slivers: [
                   if (lastUpdated != null)
@@ -263,7 +275,7 @@ class _UpdateTabState extends ConsumerState<UpdateTab>
                       ),
                     ),
                   CustomSliverGroupedListView<Update, String>(
-                    elements: entries,
+                    elements: resolved,
                     groupBy: (element) => dateFormat(
                       element.date!,
                       context: context,


### PR DESCRIPTION
Two fixes to the updates screen. The second is the one worth reading.

## The updates screen could not stop an update

The library screen grows a stop button while an update runs, and the updates screen kept showing refresh. So the one place dedicated to new chapters was the one place that could not call off a long update, and pressing refresh again did nothing, because `updateLibrary` refuses to start a second concurrent run.

The refresh button becomes stop for as long as an update is running. It watches `libraryUpdateProvider` rather than the screen's own loading flag, so it is also correct for an update that was started from the library and left running while the user switched tabs.

## A deleted chapter turned the list into a grey box

`UpdateTab` resolves each update's chapter and manga into two maps up front, and both skip anything that no longer resolves:

```dart
if (c != null) chapterByUpdateId[e.id!] = c;
...
for (final m in isar.mangas.getAllSync(mangaIds))
  if (m != null) m.id!: m,
```

It then passed the full `entries` list to the grouped list, whose `itemBuilder` asserted both were present:

```dart
final chapter = chapterByUpdateId[element.id]!;
final manga = mangaById[chapter.mangaId]!;
```

So the code already knew a chapter could be missing, and then threw on exactly that case. A library refresh deletes chapters when it cleans up duplicates (`isar.chapters.deleteAll(duplicateIds)`) and nothing removes the `Update` rows pointing at them.

In a release build a child that throws is replaced by `ErrorWidget`, which paints a plain grey rectangle, so the symptom is the list ending in scrollable grey rather than a crash, and nothing in the app says what happened. It took a screenshot from a user to notice.

The entries are now filtered to the ones that still resolve before the list is built. A row whose chapter has gone has nothing to show, so dropping it loses nothing.

This is pre-existing rather than caused by the first fix, but watching the provider from the stop button rebuilds the screen more often and widened the window where it gets hit, which is how it surfaced.

The stop button's watch is narrowed to the running flag as well, so a cancel request no longer rebuilds the screen at all.

## Testing

Full suite passes, `dart analyze lib/` is clean. Verified on an iPhone 14.
