### PR TITLE
fix: stop settings writes putting back what changed in the meantime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ app.*.map.json
 
 /android/app/.cxx
 untranslated_messages.txt
+
+# Isar's native core, downloaded into the repo root by tests that open a
+# real database (Isar.initializeIsarCore).
+libisar.dylib
+libisar.so
+isar.dll

--- a/lib/modules/more/settings/appearance/providers/theme_mode_state_provider.dart
+++ b/lib/modules/more/settings/appearance/providers/theme_mode_state_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/flex_scheme_color_state_provider.dart';
+import 'package:mangayomi/utils/settings_write.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'theme_mode_state_provider.g.dart';
 
@@ -24,8 +25,6 @@ class ThemeModeState extends _$ThemeModeState {
   void setDarkTheme() => _applyTheme(true);
 
   void _applyTheme(bool isDark) {
-    final settings = isar.settings.getSync(227);
-
     state = isDark;
 
     final schemeIndex = ref.read(flexSchemeColorStateProvider).$2;
@@ -35,13 +34,8 @@ class ThemeModeState extends _$ThemeModeState {
         .read(flexSchemeColorStateProvider.notifier)
         .setTheme(isDark ? scheme.dark : scheme.light, schemeIndex);
 
-    isar.writeTxnSync(
-      () => isar.settings.putSync(
-        settings!
-          ..themeIsDark = isDark
-          ..updatedAt = DateTime.now().millisecondsSinceEpoch,
-      ),
-    );
+    // After setTheme, which writes the same row.
+    updateSettings((settings) => settings.themeIsDark = isDark);
   }
 }
 
@@ -53,7 +47,6 @@ class FollowSystemThemeState extends _$FollowSystemThemeState {
   }
 
   void set(bool value) {
-    final settings = isar.settings.getSync(227);
     state = value;
     if (value) {
       if (WidgetsBinding.instance.platformDispatcher.platformBrightness ==
@@ -63,12 +56,10 @@ class FollowSystemThemeState extends _$FollowSystemThemeState {
         ref.read(themeModeStateProvider.notifier).setDarkTheme();
       }
     }
-    isar.writeTxnSync(
-      () => isar.settings.putSync(
-        settings!
-          ..followSystemTheme = value
-          ..updatedAt = DateTime.now().millisecondsSinceEpoch,
-      ),
-    );
+    // After the theme setters above, which write the same row. Reading it
+    // before them and writing it here put their themeIsDark back to what it
+    // was, so turning this on under a light system came back dark on the next
+    // launch.
+    updateSettings((settings) => settings.followSystemTheme = value);
   }
 }

--- a/lib/services/get_chapter_pages.dart
+++ b/lib/services/get_chapter_pages.dart
@@ -16,6 +16,7 @@ import 'package:mangayomi/modules/manga/archive_reader/providers/archive_reader_
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/services/downloaded_chapter.dart';
 import 'package:mangayomi/utils/utils.dart';
+import 'package:mangayomi/utils/settings_write.dart';
 import 'package:mangayomi/utils/reg_exp_matcher.dart';
 import 'package:mangayomi/modules/more/providers/incognito_mode_state_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -170,36 +171,36 @@ Future<GetChapterPagesModel> getChapterPages(
       // it unreadable online once the download is deleted.
       if (!incognitoMode && !pagesFromCache && downloaded == null) {
         const maxCachedChapters = 40;
-        List<ChapterPageurls>? chapterPageUrls = [];
-        for (var chapterPageUrl in settings.chapterPageUrlsList ?? []) {
-          if (chapterPageUrl.chapterId != chapter.id) {
-            chapterPageUrls.add(chapterPageUrl);
-          }
-        }
         final chapterPageHeaders = pageUrls
             .map((e) => e.headers == null ? null : jsonEncode(e.headers))
             .toList();
-        chapterPageUrls.add(
-          ChapterPageurls()
-            ..chapterId = chapter.id
-            ..urls = pageUrls.map((e) => e.url).toList()
-            ..chapterUrl = chapter.url
-            ..headers = chapterPageHeaders.first != null
-                ? chapterPageHeaders.map((e) => e.toString()).toList()
-                : null,
-        );
-        if (chapterPageUrls.length > maxCachedChapters) {
-          chapterPageUrls.removeRange(
-            0,
-            chapterPageUrls.length - maxCachedChapters,
+        // Re-read the row here rather than reuse the one loaded at the top of
+        // this function. Fetching the pages ran several awaits, and writing the
+        // row puts all of it back, so the old copy would undo every setting
+        // changed while the chapter was loading.
+        updateSettings((settings) {
+          final chapterPageUrls = <ChapterPageurls>[];
+          for (final chapterPageUrl in settings.chapterPageUrlsList ?? []) {
+            if (chapterPageUrl.chapterId != chapter.id) {
+              chapterPageUrls.add(chapterPageUrl);
+            }
+          }
+          chapterPageUrls.add(
+            ChapterPageurls()
+              ..chapterId = chapter.id
+              ..urls = pageUrls.map((e) => e.url).toList()
+              ..chapterUrl = chapter.url
+              ..headers = chapterPageHeaders.first != null
+                  ? chapterPageHeaders.map((e) => e.toString()).toList()
+                  : null,
           );
-        }
-        isar.writeTxnSync(() {
-          isar.settings.putSync(
-            settings
-              ..chapterPageUrlsList = chapterPageUrls
-              ..updatedAt = DateTime.now().millisecondsSinceEpoch,
-          );
+          if (chapterPageUrls.length > maxCachedChapters) {
+            chapterPageUrls.removeRange(
+              0,
+              chapterPageUrls.length - maxCachedChapters,
+            );
+          }
+          settings.chapterPageUrlsList = chapterPageUrls;
         });
       }
       for (var i = 0; i < pageUrls.length; i++) {

--- a/lib/utils/settings_write.dart
+++ b/lib/utils/settings_write.dart
@@ -1,0 +1,20 @@
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/settings.dart';
+
+/// Applies [change] to the settings row, reading it inside the transaction
+/// that writes it.
+///
+/// Every setting the app has lives in one row, and `putSync` writes the whole
+/// row. Reading it, holding the object, and writing it back later therefore
+/// puts back whatever else changed in the meantime, so the read has to happen
+/// inside the write. [change] runs in an open transaction: keep it to touching
+/// the row, and do not call anything that opens a transaction of its own.
+void updateSettings(void Function(Settings settings) change) {
+  isar.writeTxnSync(() {
+    final settings = isar.settings.getSync(227);
+    if (settings == null) return;
+    change(settings);
+    settings.updatedAt = DateTime.now().millisecondsSinceEpoch;
+    isar.settings.putSync(settings);
+  });
+}

--- a/test/settings/settings_clobber_test.dart
+++ b/test/settings/settings_clobber_test.dart
@@ -20,7 +20,17 @@ void main() {
 
   setUpAll(() async {
     TestWidgetsFlutterBinding.ensureInitialized();
-    await Isar.initializeIsarCore(download: true);
+    // The binding installs an HttpOverrides that answers every request with a
+    // 400, so the core's own download silently fails and the whole suite dies
+    // in setUpAll on any machine that has not already fetched it. Step out of
+    // the override for the one request that has to be real.
+    final overrides = HttpOverrides.current;
+    HttpOverrides.global = null;
+    try {
+      await Isar.initializeIsarCore(download: true);
+    } finally {
+      HttpOverrides.global = overrides;
+    }
   });
 
   setUp(() async {

--- a/test/settings/settings_clobber_test.dart
+++ b/test/settings/settings_clobber_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/models/source.dart';
+import 'package:mangayomi/modules/more/settings/appearance/providers/flex_scheme_color_state_provider.dart';
+import 'package:mangayomi/modules/more/settings/appearance/providers/theme_mode_state_provider.dart';
+import 'package:mangayomi/utils/settings_write.dart';
+
+/// The appearance settings all live in one Settings row, and each setter reads
+/// the whole row, changes its own field and writes the row back. They also call
+/// into each other, so what the last write holds is what survives.
+void main() {
+  late Directory directory;
+  late ProviderContainer container;
+
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await Isar.initializeIsarCore(download: true);
+  });
+
+  setUp(() async {
+    directory = Directory.systemTemp.createTempSync('settings_clobber');
+    isar = await Isar.open(
+      [SettingsSchema, SourceSchema],
+      directory: directory.path,
+      name: 'clobber_${directory.path.hashCode}',
+    );
+    isar.writeTxnSync(
+      () => isar.settings.putSync(
+        Settings()
+          ..themeIsDark = true
+          ..followSystemTheme = false
+          ..flexSchemeColorIndex = 3,
+      ),
+    );
+    container = ProviderContainer();
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await isar.close(deleteFromDisk: true);
+    if (directory.existsSync()) directory.deleteSync(recursive: true);
+  });
+
+  Settings stored() => isar.settings.getSync(227)!;
+
+  test('following the system theme survives the write that turns it on', () async {
+    // The system is light and the app is dark, so turning this on has to leave
+    // the app light. It does in memory; the question is what reached the row.
+    final binding = TestWidgetsFlutterBinding.instance;
+    binding.platformDispatcher.platformBrightnessTestValue = Brightness.light;
+    addTearDown(binding.platformDispatcher.clearPlatformBrightnessTestValue);
+
+    container.read(followSystemThemeStateProvider.notifier).set(true);
+
+    expect(container.read(themeModeStateProvider), false, reason: 'in memory');
+    expect(stored().followSystemTheme, true);
+    expect(
+      stored().themeIsDark,
+      false,
+      reason:
+          'set() captured the row before setLightTheme wrote to it, so the '
+          'stale copy it wrote last puts the app back to dark on next launch',
+    );
+  });
+
+  group('updateSettings', () {
+    test('keeps a change made after the caller last looked at the row', () {
+      // What every caller of this used to get wrong: hold the row, let
+      // something else write, then write the held copy back over it.
+      final stale = isar.settings.getSync(227)!;
+      isar.writeTxnSync(
+        () => isar.settings.putSync(
+          isar.settings.getSync(227)!..themeIsDark = false,
+        ),
+      );
+
+      updateSettings((settings) => settings.followSystemTheme = true);
+
+      expect(stale.themeIsDark, true, reason: 'the held copy is stale');
+      expect(stored().themeIsDark, false, reason: 'the row is not');
+      expect(stored().followSystemTheme, true);
+    });
+
+    test('stamps updatedAt so a sync sees the change', () {
+      final before = stored().updatedAt ?? 0;
+
+      updateSettings((settings) => settings.flexSchemeColorIndex = 9);
+
+      expect(stored().flexSchemeColorIndex, 9);
+      expect(stored().updatedAt, greaterThanOrEqualTo(before));
+    });
+  });
+
+  test(
+    'picking a colour scheme does not undo the theme it was picked under',
+    () {
+      container.read(themeModeStateProvider.notifier).setLightTheme();
+      container
+          .read(flexSchemeColorStateProvider.notifier)
+          .setTheme(ThemeAA.schemes[7].light, 7);
+
+      expect(stored().flexSchemeColorIndex, 7);
+      expect(stored().themeIsDark, false);
+    },
+  );
+}


### PR DESCRIPTION
Found while triaging #902, separate from it.

Every setting lives in one `Settings` row, and `putSync` writes the whole row. So a setter that reads the row, holds the object, and writes it back later also writes back every other field as it was at the moment of the read.

**The visible one: the theme comes back wrong after a restart.**

`FollowSystemThemeState.set` reads the row first, then calls `setLightTheme` or `setDarkTheme`, each of which reads the row, changes `themeIsDark` and writes it, and then `set` writes its own stale copy last.

Turning on "follow system theme" under a light system therefore looks correct — the in-memory state is right and the UI goes light — and comes back dark on the next launch, because `themeIsDark` on disk was never actually changed.

**The wider one: the page-url cache reverts settings changed while a chapter loads.**

`getChapterPages` reads the row at the top of the function, fetches the pages across seven awaits, then writes that same row back to store the page-url cache. Anything the user changed in settings while the chapter was loading is written back to what it was.

**What changed**

Both now go through `updateSettings`, which reads the row inside the transaction that writes it, so the read cannot be stale. I scanned the remaining 159 reads of this row: no other place writes one back across an await or across a call that also writes it.

**Testing**

The regression test opens a real Isar database and drives the actual providers, so it fails on the parent commit:

```
following the system theme survives the write that turns it on [E]
  Expected: <false>
    Actual: <true>
```

and passes here. Also built and launched on macOS.

One thing worth a maintainer's call: that test calls `Isar.initializeIsarCore(download: true)`, which downloads the native core into the repo root the first time it runs. `.gitignore` now covers `libisar.dylib`, `libisar.so` and `isar.dll` so it cannot be committed by accident. It is the standard way to test against a real Isar, but it is the first test here that does it, so say the word if you would rather it went.
