### PR TITLE
fix: only file things that belong in the tracker

### DIFF
--- a/lib/eval/lnreader/m_plugin.dart
+++ b/lib/eval/lnreader/m_plugin.dart
@@ -81,7 +81,15 @@ class SourceNovel extends NovelItem {
 
   factory SourceNovel.fromJson(Map<String, dynamic> json) {
     if (json['path'] == null) {
-      throw 'path is null';
+      // Reported as "path is null" and filed as an app bug (#936), because a
+      // bare string says nothing about whose fault it is. A novel with no
+      // path came from the plugin, and the fix belongs wherever that plugin
+      // is maintained.
+      throw Exception(
+        'The source returned a novel with no path, so it cannot be opened. '
+        'This is the extension rather than Mangayomi'
+        '${json['name'] is String ? ' (while reading "${json['name']}")' : ''}.',
+      );
     }
     return SourceNovel(
       name: json['name'] ?? '',

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1232,6 +1232,7 @@
   "error_reports_copy": "Copy",
   "error_reports_copied": "Copied to the clipboard",
   "error_reports_clear": "Clear",
+  "error_reports_expected_failure": "This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.",
   "share_unavailable_copied": "Sharing isn't available on this platform, so it was copied to the clipboard instead.",
   "onboarding_title": "Welcome to Mangayomi",
   "onboarding_libraries_body": "Pick what you read and watch. The ones you leave out stay out of the navigation bar, and you can change this later under Appearance.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1232,6 +1232,8 @@
   "error_reports_copy": "Copy",
   "error_reports_copied": "Copied to the clipboard",
   "error_reports_clear": "Clear",
+  "error_reports_extension_failure": "This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.",
+  "error_reports_already_reported": "Already reported",
   "error_reports_expected_failure": "This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.",
   "share_unavailable_copied": "Sharing isn't available on this platform, so it was copied to the clipboard instead.",
   "onboarding_title": "Welcome to Mangayomi",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -5585,6 +5585,18 @@ abstract class AppLocalizations {
   /// **'Clear'**
   String get error_reports_clear;
 
+  /// No description provided for @error_reports_extension_failure.
+  ///
+  /// In en, this message translates to:
+  /// **'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.'**
+  String get error_reports_extension_failure;
+
+  /// No description provided for @error_reports_already_reported.
+  ///
+  /// In en, this message translates to:
+  /// **'Already reported'**
+  String get error_reports_already_reported;
+
   /// No description provided for @error_reports_expected_failure.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -5585,6 +5585,12 @@ abstract class AppLocalizations {
   /// **'Clear'**
   String get error_reports_clear;
 
+  /// No description provided for @error_reports_expected_failure.
+  ///
+  /// In en, this message translates to:
+  /// **'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.'**
+  String get error_reports_expected_failure;
+
   /// No description provided for @share_unavailable_copied.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -3092,6 +3092,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get error_reports_clear => 'مسح';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -3092,6 +3092,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get error_reports_clear => 'مسح';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'المشاركة غير متاحة، تم النسخ إلى الحافظة.';
 

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -3092,6 +3092,13 @@ class AppLocalizationsAs extends AppLocalizations {
   String get error_reports_clear => 'পৰিষ্কাৰ কৰক';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -3092,6 +3092,10 @@ class AppLocalizationsAs extends AppLocalizations {
   String get error_reports_clear => 'পৰিষ্কাৰ কৰক';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'শ্বেয়াৰ উপলব্ধ নহয়, ক্লিপব\'ৰ্ডলৈ কপি কৰা হ\'ল।';
 

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -3116,6 +3116,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get error_reports_clear => 'Löschen';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -3116,6 +3116,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get error_reports_clear => 'Löschen';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'Teilen nicht verfügbar, in Zwischenablage kopiert.';
 

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -3084,6 +3084,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get error_reports_clear => 'Clear';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'Sharing isn\'t available on this platform, so it was copied to the clipboard instead.';
 

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -3084,6 +3084,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get error_reports_clear => 'Clear';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -3129,6 +3129,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get error_reports_clear => 'Limpiar';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'La función de compartir no está disponible en esta plataforma, por lo que se copió al portapapeles.';
 

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -3129,6 +3129,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get error_reports_clear => 'Limpiar';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -3135,6 +3135,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get error_reports_clear => 'Effacer';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'Le partage n\'est pas disponible sur cette plateforme, le lien a donc été copié dans le presse-papiers.';
 

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -3135,6 +3135,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get error_reports_clear => 'Effacer';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -3093,6 +3093,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get error_reports_clear => 'साफ़ करें';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -3093,6 +3093,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get error_reports_clear => 'साफ़ करें';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'साझाकरण उपलब्ध नहीं है, क्लिपबोर्ड पर कॉपी किया गया।';
 

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -3098,6 +3098,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get error_reports_clear => 'Bersihkan';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -3098,6 +3098,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get error_reports_clear => 'Bersihkan';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'Berbagi tidak tersedia, disalin ke papan klip.';
 

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -3126,6 +3126,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get error_reports_clear => 'Cancella';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'Condivisione non disponibile, copiato negli appunti.';
 

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -3126,6 +3126,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get error_reports_clear => 'Cancella';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -3025,6 +3025,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get error_reports_clear => 'クリア';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied => '共有機能が利用できないためクリップボードにコピーしました。';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -3025,6 +3025,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get error_reports_clear => 'クリア';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -3121,6 +3121,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get error_reports_clear => 'Limpar';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -3121,6 +3121,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get error_reports_clear => 'Limpar';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'Partilha indisponível, copiado para a área de transferência.';
 

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -3136,6 +3136,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get error_reports_clear => 'Очистить';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'Отправка недоступна, скопировано в буфер обмена.';
 

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -3136,6 +3136,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get error_reports_clear => 'Очистить';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -3082,6 +3082,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get error_reports_clear => 'ล้าง';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -3082,6 +3082,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get error_reports_clear => 'ล้าง';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'ไม่สามารถแชร์ได้ จึงคัดลอกไปยังคลิปบอร์ดแทน';
 

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -3102,6 +3102,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get error_reports_clear => 'Temizle';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied =>
       'Paylaşım kullanılamıyor, panoya kopyalandı.';
 

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -3102,6 +3102,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get error_reports_clear => 'Temizle';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2983,6 +2983,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get error_reports_clear => '清除';
 
   @override
+  String get error_reports_expected_failure =>
+      'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
+
+  @override
   String get share_unavailable_copied => '此平台不支持分享，已复制到剪贴板。';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2983,6 +2983,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get error_reports_clear => '清除';
 
   @override
+  String get error_reports_extension_failure =>
+      'This came from an extension, not from Mangayomi. Extensions are written and maintained by whoever runs the repository you installed this source from, so a fix has to go there. The source name and what you were opening are the useful details to give them.';
+
+  @override
+  String get error_reports_already_reported => 'Already reported';
+
+  @override
   String get error_reports_expected_failure =>
       'This one is usually the source or the network rather than the app: a link that expired, a server that was down, or a connection that dropped. Worth reporting only if it keeps happening on a source that works elsewhere.';
 

--- a/lib/modules/more/about/error_reports_screen.dart
+++ b/lib/modules/more/about/error_reports_screen.dart
@@ -85,6 +85,21 @@ class _ReportTile extends StatelessWidget {
       childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
       expandedCrossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        if (isExpectedFailure(report.error)) ...[
+          // #915 and #916 were both filed through this screen for images that
+          // failed to load. The likely-cause line was not enough on its own,
+          // so say plainly that this one is probably not the app's fault.
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: context.secondaryColor.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(l10n.error_reports_expected_failure),
+          ),
+          const SizedBox(height: 12),
+        ],
         if (cause != null) ...[
           Text(
             l10n.error_reports_likely_cause,

--- a/lib/modules/more/about/error_reports_screen.dart
+++ b/lib/modules/more/about/error_reports_screen.dart
@@ -58,17 +58,22 @@ class _ErrorReportsScreenState extends ConsumerState<ErrorReportsScreen> {
           : ListView.separated(
               itemCount: reports.length,
               separatorBuilder: (_, _) => const Divider(height: 1),
-              itemBuilder: (context, index) =>
-                  _ReportTile(report: reports[index]),
+              itemBuilder: (context, index) => _ReportTile(
+                report: reports[index],
+                onReported: () => setState(() {}),
+              ),
             ),
     );
   }
 }
 
 class _ReportTile extends StatelessWidget {
-  const _ReportTile({required this.report});
+  const _ReportTile({required this.report, required this.onReported});
 
   final CrashReport report;
+
+  /// Lets the list redraw once a fault has been sent, so the button says so.
+  final VoidCallback onReported;
 
   @override
   Widget build(BuildContext context) {
@@ -85,6 +90,21 @@ class _ReportTile extends StatelessWidget {
       childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
       expandedCrossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        if (isExtensionFailure(report.error)) ...[
+          // #914 was an extension bug filed here, because the screen offered a
+          // Report button pointing at this repository and gave the reader no
+          // way to know the difference.
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: context.secondaryColor.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(l10n.error_reports_extension_failure),
+          ),
+          const SizedBox(height: 12),
+        ],
         if (isExpectedFailure(report.error)) ...[
           // #915 and #916 were both filed through this screen for images that
           // failed to load. The likely-cause line was not enough on its own,
@@ -124,11 +144,20 @@ class _ReportTile extends StatelessWidget {
         Wrap(
           spacing: 8,
           children: [
-            FilledButton.icon(
-              onPressed: () => _report(context),
-              icon: const Icon(Icons.bug_report_outlined, size: 18),
-              label: Text(l10n.error_reports_report),
-            ),
+            // An extension bug does not belong in this repository, and a
+            // fault already sent does not need sending twice (#917, #918).
+            if (!isExtensionFailure(report.error))
+              FilledButton.icon(
+                onPressed: CrashReports.wasReported(report)
+                    ? null
+                    : () => _report(context),
+                icon: const Icon(Icons.bug_report_outlined, size: 18),
+                label: Text(
+                  CrashReports.wasReported(report)
+                      ? l10n.error_reports_already_reported
+                      : l10n.error_reports_report,
+                ),
+              ),
             TextButton.icon(
               onPressed: () async {
                 await Clipboard.setData(
@@ -148,6 +177,8 @@ class _ReportTile extends StatelessWidget {
   }
 
   Future<void> _report(BuildContext context) async {
+    CrashReports.markReported(report);
+    onReported();
     final url = buildIssueUrl(
       report,
       appVersion: await appVersionDescription(),

--- a/lib/services/crash_report.dart
+++ b/lib/services/crash_report.dart
@@ -145,7 +145,12 @@ bool isExpectedFailure(Object error) {
       // MangaDex page loads, then this, seconds apart. It is the same failure
       // one step further along, not a separate bug.
       text.contains('could not decompress image') ||
-      text.contains('invalid image data');
+      text.contains('invalid image data') ||
+      // The Rust HTTP stack's transport errors, which are the same network
+      // failures one layer down. #933 is one of these.
+      text.contains('rhttpunknownexception') ||
+      text.contains('hyper_util') ||
+      text.contains('statuscode: 5');
 }
 
 /// Whether [error] came from an extension rather than from the app.
@@ -160,10 +165,22 @@ bool isExpectedFailure(Object error) {
 /// told apart from an app bug with reasonable confidence.
 bool isExtensionFailure(Object error) {
   final text = error.toString();
-  return text.startsWith('Runtime Error:') ||
+  return
+  // d4rt, the Dart interpreter
+  text.startsWith('Runtime Error:') ||
       text.startsWith('SourceCodeException:') ||
       text.contains('Native error during bridged method call') ||
-      text.contains('Undefined property or method');
+      text.contains('Undefined property or method') ||
+      // Mihon extensions, which are Kotlin and fail their own way. #935 is a
+      // source answering 500 and the extension's deserialisation reporting a
+      // missing field, named by its JVM package.
+      text.contains('eu.kanade.tachiyomi.extension') ||
+      text.contains("is required for type with serial name") ||
+      // LNReader plugins. #936 is a plugin returning a novel with no path.
+      // The old wording is still matched because reports keep arriving from
+      // builds that predate the clearer message.
+      text.contains('path is null') ||
+      text.contains('returned a novel with no path');
 }
 
 /// A stable key for "this same thing went wrong again".

--- a/lib/services/crash_report.dart
+++ b/lib/services/crash_report.dart
@@ -139,7 +139,13 @@ bool isExpectedFailure(Object error) {
       text.contains('connection reset') ||
       text.contains('connection refused') ||
       text.contains('timeoutexception') ||
-      text.contains('handshakeexception');
+      text.contains('handshakeexception') ||
+      // What a half-downloaded or non-image response decodes to. #927 shows
+      // the sequence plainly in its own recent-errors block: two failed
+      // MangaDex page loads, then this, seconds apart. It is the same failure
+      // one step further along, not a separate bug.
+      text.contains('could not decompress image') ||
+      text.contains('invalid image data');
 }
 
 /// Whether [error] came from an extension rather than from the app.

--- a/lib/services/crash_report.dart
+++ b/lib/services/crash_report.dart
@@ -114,6 +114,34 @@ String? describeLikelyCause(String error) {
   return null;
 }
 
+/// Whether [error] is a thing that goes wrong rather than a thing that is
+/// broken.
+///
+/// A cover that 404s, a CDN that times out, a source that is down: these are
+/// expected on a network, they already show as a broken image in the UI, and
+/// nothing in the app needs changing when one happens. They still reach
+/// FlutterError.onError, though, because an ImageProvider reports a failed
+/// load whether or not the widget drew a placeholder for it.
+///
+/// Left unfiltered they raise the "something went wrong" banner and get filed
+/// as bugs. Issues #915 and #916 are exactly that: two reports about images
+/// not loading from a CDN, sent through the reporter as if the app had
+/// crashed.
+///
+/// These are still recorded, because "images stopped loading" is worth being
+/// able to look up. They just do not interrupt anybody.
+bool isExpectedFailure(Object error) {
+  final text = error.toString().toLowerCase();
+  return text.contains('failed to load http') ||
+      text.contains('socketexception') ||
+      text.contains('failed host lookup') ||
+      text.contains('connection closed') ||
+      text.contains('connection reset') ||
+      text.contains('connection refused') ||
+      text.contains('timeoutexception') ||
+      text.contains('handshakeexception');
+}
+
 /// Strips anything from [text] that identifies the reader or what they were
 /// reading, so a report can be sent without sending their library with it.
 ///
@@ -242,7 +270,9 @@ class CrashReports {
       );
       _reports.add(report);
       if (!_loaded) _pending.add(report);
-      _seen = false;
+      // Kept, but it does not raise the banner: nothing here needs the
+      // reader's attention or a bug report.
+      if (!isExpectedFailure(error)) _seen = false;
       _trim();
       _flush();
     } catch (_) {}

--- a/lib/services/crash_report.dart
+++ b/lib/services/crash_report.dart
@@ -142,6 +142,34 @@ bool isExpectedFailure(Object error) {
       text.contains('handshakeexception');
 }
 
+/// Whether [error] came from an extension rather than from the app.
+///
+/// Extensions are third-party code the app runs in an interpreter, and when
+/// one is wrong the fix belongs in the repository it came from. #914 is an
+/// extension calling `.toList()` on a Map, filed here because the reporter had
+/// no way to tell the difference and the app offered them a button.
+///
+/// d4rt prefixes everything it raises with "Runtime Error:", and wraps
+/// failures inside bridged calls with a recognisable phrase, so this can be
+/// told apart from an app bug with reasonable confidence.
+bool isExtensionFailure(Object error) {
+  final text = error.toString();
+  return text.startsWith('Runtime Error:') ||
+      text.startsWith('SourceCodeException:') ||
+      text.contains('Native error during bridged method call') ||
+      text.contains('Undefined property or method');
+}
+
+/// A stable key for "this same thing went wrong again".
+///
+/// The first line only, with digits flattened, so two runs of the same fault
+/// match even though their addresses, ids and timestamps differ. #917 and #918
+/// are one crash reported twice by one person, which is what this is for.
+String fingerprintOf(Object error) {
+  final first = error.toString().split('\n').first.trim();
+  return first.replaceAll(RegExp(r'\d+'), '#').toLowerCase();
+}
+
 /// Strips anything from [text] that identifies the reader or what they were
 /// reading, so a report can be sent without sending their library with it.
 ///
@@ -183,6 +211,10 @@ class CrashReports {
   static const _fileName = 'crash_reports.json';
 
   static final List<CrashReport> _reports = [];
+
+  /// Fingerprints the reader has already opened a report for. Kept so the
+  /// same fault is not filed twice, which is what #917 and #918 are.
+  static final Set<String> _reported = {};
 
   /// Recorded before [init] found somewhere to put them. The handlers are
   /// installed before storage is resolved, so a startup error arrives with
@@ -227,13 +259,19 @@ class CrashReports {
     try {
       if (await _file!.exists()) {
         final decoded = jsonDecode(await _file!.readAsString());
-        if (decoded is List) {
-          for (final entry in decoded) {
-            if (entry is! Map) continue;
-            final report = CrashReport.fromJson(
-              Map<String, dynamic>.from(entry),
-            );
-            if (report != null) _reports.add(report);
+        // Earlier builds wrote a bare list. Read it rather than throwing the
+        // reader's history away on upgrade.
+        final entries = decoded is List
+            ? decoded
+            : (decoded is Map ? decoded['reports'] as List? : null) ?? const [];
+        for (final entry in entries) {
+          if (entry is! Map) continue;
+          final report = CrashReport.fromJson(Map<String, dynamic>.from(entry));
+          if (report != null) _reports.add(report);
+        }
+        if (decoded is Map) {
+          for (final f in (decoded['reported'] as List?) ?? const []) {
+            if (f is String) _reported.add(f);
           }
         }
       }
@@ -278,6 +316,16 @@ class CrashReports {
     } catch (_) {}
   }
 
+  /// Whether this fault has already been sent somewhere.
+  static bool wasReported(CrashReport report) =>
+      _reported.contains(fingerprintOf(report.error));
+
+  /// Records that the reader opened a report for this fault.
+  static void markReported(CrashReport report) {
+    _reported.add(fingerprintOf(report.error));
+    _flush();
+  }
+
   /// Marks what is kept as shown, so the banner stops offering it.
   static void markSeen() {
     _seen = true;
@@ -297,6 +345,7 @@ class CrashReports {
   static void resetForTest() {
     _reports.clear();
     _pending.clear();
+    _reported.clear();
     _file = null;
     _screen = null;
     _seen = false;
@@ -315,7 +364,10 @@ class CrashReports {
     if (file == null) return;
     try {
       file.writeAsStringSync(
-        jsonEncode(_reports.map((e) => e.toJson()).toList()),
+        jsonEncode({
+          'reports': _reports.map((e) => e.toJson()).toList(),
+          'reported': _reported.toList(),
+        }),
         flush: true,
       );
     } catch (_) {}

--- a/test/services/crash_report_test.dart
+++ b/test/services/crash_report_test.dart
@@ -177,6 +177,16 @@ void main() {
       );
     });
 
+    test('the Rust http stack failing is the same network failure', () {
+      // #933, a transport error one layer below SocketException.
+      expect(
+        isExpectedFailure(
+          '[RhttpUnknownException] hyper_util::client::legacy::Error',
+        ),
+        true,
+      );
+    });
+
     test('and what a failed download decodes to afterwards', () {
       // #927, whose own recent-errors block shows two failed page loads
       // seconds before it. The bytes that arrived were not an image.
@@ -243,6 +253,31 @@ void main() {
       expect(
         isExtensionFailure(
           "Native error during bridged method call 'forEach' on List",
+        ),
+        true,
+      );
+    });
+
+    test('a Mihon extension failing is one too', () {
+      // #935: the source answered 500 and the extension's deserialisation
+      // reported a missing field, named by its JVM package.
+      expect(
+        isExtensionFailure(
+          "Field 'largeImage' is required for type with serial name "
+          "'eu.kanade.tachiyomi.extension.en.atsumaru.MangaDto', but it was "
+          "missing at path: \$.mangaPage",
+        ),
+        true,
+      );
+    });
+
+    test('and an LNReader plugin returning nothing usable', () {
+      // #936, in both the old wording and the clearer one that replaced it.
+      expect(isExtensionFailure('path is null'), true);
+      expect(
+        isExtensionFailure(
+          'Exception: The source returned a novel with no path, so it cannot '
+          'be opened. This is the extension rather than Mangayomi.',
         ),
         true,
       );

--- a/test/services/crash_report_test.dart
+++ b/test/services/crash_report_test.dart
@@ -114,7 +114,7 @@ void main() {
         expect(CrashReports.reports, hasLength(10));
         expect(CrashReports.reports.first.error, 'error 20');
         final stored = jsonDecode(file().readAsStringSync()) as Map;
-      expect(stored['reports'], hasLength(10));
+        expect(stored['reports'], hasLength(10));
       },
     );
 
@@ -175,6 +175,13 @@ void main() {
         isExpectedFailure("SocketException: Failed host lookup: 'x.test'"),
         true,
       );
+    });
+
+    test('and what a failed download decodes to afterwards', () {
+      // #927, whose own recent-errors block shows two failed page loads
+      // seconds before it. The bytes that arrived were not an image.
+      expect(isExpectedFailure('Exception: Could not decompress image.'), true);
+      expect(isExpectedFailure('Exception: Invalid image data'), true);
     });
 
     test('an app bug is not one of them', () {

--- a/test/services/crash_report_test.dart
+++ b/test/services/crash_report_test.dart
@@ -154,6 +154,74 @@ void main() {
     });
   });
 
+  group('an expected failure', () {
+    setUp(CrashReports.resetForTest);
+    tearDown(CrashReports.resetForTest);
+
+    test('is recognised from what the app actually reports', () {
+      // Captured from #915 and #916, both filed as bugs through the reporter.
+      expect(
+        isExpectedFailure('Bad state: Failed to load https://manhwaz.com/...'),
+        true,
+      );
+      expect(
+        isExpectedFailure(
+          'Bad state: Failed to load https://cdn.jsdelivr.net/...',
+        ),
+        true,
+      );
+      expect(
+        isExpectedFailure("SocketException: Failed host lookup: 'x.test'"),
+        true,
+      );
+    });
+
+    test('an app bug is not one of them', () {
+      expect(
+        isExpectedFailure(
+          "Runtime Error: Undefined property or method 'toList'",
+        ),
+        false,
+      );
+      expect(
+        isExpectedFailure('Null check operator used on a null value'),
+        false,
+      );
+      expect(
+        isExpectedFailure('PanicException(Expect rustls-platform-verifier)'),
+        false,
+      );
+    });
+
+    test('is kept, but does not interrupt the reader', () async {
+      final directory = Directory.systemTemp.createTempSync('expected');
+      addTearDown(() => directory.deleteSync(recursive: true));
+      await CrashReports.init(directory);
+
+      CrashReports.record(
+        source: 'FlutterError',
+        error: 'Bad state: Failed to load https://example.test/...',
+      );
+
+      expect(CrashReports.reports, hasLength(1), reason: 'still recorded');
+      expect(CrashReports.hasUnseen, false, reason: 'but no banner');
+    });
+
+    test('a real bug alongside one still interrupts', () async {
+      final directory = Directory.systemTemp.createTempSync('mixed');
+      addTearDown(() => directory.deleteSync(recursive: true));
+      await CrashReports.init(directory);
+
+      CrashReports.record(
+        source: 'FlutterError',
+        error: 'Bad state: Failed to load https://example.test/...',
+      );
+      CrashReports.record(source: 'FlutterError', error: 'Null check operator');
+
+      expect(CrashReports.hasUnseen, true);
+    });
+  });
+
   group('the issue link', () {
     final report = CrashReport(
       time: DateTime.utc(2026, 8, 22, 21, 35),

--- a/test/services/crash_report_test.dart
+++ b/test/services/crash_report_test.dart
@@ -113,7 +113,8 @@ void main() {
 
         expect(CrashReports.reports, hasLength(10));
         expect(CrashReports.reports.first.error, 'error 20');
-        expect(jsonDecode(file().readAsStringSync()), hasLength(10));
+        final stored = jsonDecode(file().readAsStringSync()) as Map;
+      expect(stored['reports'], hasLength(10));
       },
     );
 
@@ -219,6 +220,100 @@ void main() {
       CrashReports.record(source: 'FlutterError', error: 'Null check operator');
 
       expect(CrashReports.hasUnseen, true);
+    });
+  });
+
+  group('an extension failure', () {
+    test('is told apart from an app bug', () {
+      // #914, filed here because the screen offered a button pointing at this
+      // repository.
+      expect(
+        isExtensionFailure(
+          "Runtime Error: Undefined property or method 'toList' on bi<qOb, dynamic>.",
+        ),
+        true,
+      );
+      expect(
+        isExtensionFailure(
+          "Native error during bridged method call 'forEach' on List",
+        ),
+        true,
+      );
+    });
+
+    test('an app bug is not one', () {
+      expect(
+        isExtensionFailure('Null check operator used on a null value'),
+        false,
+      );
+      expect(
+        isExtensionFailure('PanicException(Expect rustls-platform-verifier)'),
+        false,
+      );
+      expect(
+        isExtensionFailure('Bad state: Failed to load https://a.test/...'),
+        false,
+      );
+    });
+  });
+
+  group('reporting the same fault twice', () {
+    late Directory directory;
+
+    setUp(() async {
+      CrashReports.resetForTest();
+      directory = Directory.systemTemp.createTempSync('reported');
+      await CrashReports.init(directory);
+    });
+
+    tearDown(() {
+      CrashReports.resetForTest();
+      if (directory.existsSync()) directory.deleteSync(recursive: true);
+    });
+
+    test('is refused once it has been sent', () {
+      CrashReports.record(source: 'test', error: 'PanicException(boom)');
+      final report = CrashReports.latest!;
+
+      expect(CrashReports.wasReported(report), false);
+      CrashReports.markReported(report);
+      expect(CrashReports.wasReported(report), true);
+    });
+
+    test('matches the same fault across runs, ids and all', () {
+      // #917 and #918 are one crash filed twice. The numbers in a message
+      // change between runs; the fault does not.
+      expect(
+        fingerprintOf('Failed at offset 4821 in isolate 3'),
+        fingerprintOf('Failed at offset 9902 in isolate 7'),
+      );
+      expect(
+        fingerprintOf('Null check operator used on a null value'),
+        isNot(fingerprintOf('Bad state: no element')),
+      );
+    });
+
+    test('survives a restart, or the reader is asked again', () async {
+      CrashReports.record(source: 'test', error: 'PanicException(boom)');
+      CrashReports.markReported(CrashReports.latest!);
+
+      CrashReports.resetForTest();
+      await CrashReports.init(directory);
+
+      expect(CrashReports.wasReported(CrashReports.latest!), true);
+    });
+
+    test('a file written by an older build is still read', () async {
+      // That build stored a bare list rather than an object.
+      File(p.join(directory.path, 'crash_reports.json')).writeAsStringSync(
+        '[{"time":"2026-08-25T10:00:00.000","source":"test","error":"old"}]',
+      );
+      CrashReports.resetForTest();
+
+      await CrashReports.init(directory);
+
+      expect(CrashReports.reports, hasLength(1));
+      expect(CrashReports.latest!.error, 'old');
     });
   });
 


### PR DESCRIPTION
#906 is doing its job, and #915 and #916 are the cost. Both are reports about an image failing to load, one of them from a CDN, filed through the reporter as though the app had crashed.

They are not crashes. A cover that 404s or a source that is briefly down already shows as a broken image, and nothing in the app needs changing when one happens. They reach `FlutterError.onError` anyway, because an `ImageProvider` reports a failed load whether or not the widget drew a placeholder for it, and from there they raised the banner and offered a Report button like anything else.

**What changed**

Those failures are still recorded, since "images stopped loading" is worth being able to look up in the reports screen. They just no longer interrupt anybody, and the report screen now says plainly that the source or the network is the usual cause, and that it is worth reporting only if it keeps happening on a source that works elsewhere.

A real bug recorded alongside one still raises the banner, so this does not quieten anything that matters.

The patterns are taken from what the app actually reported in #915 and #916 rather than invented, and the tests use those exact strings.

This is the volume problem from the #906 discussion showing up for real, just far smaller than an auto-filer would have made it.

---

**Second commit: the rest of what the first day produced**

Five reports came in on 2026-08-25. Counted honestly:

| | |
| --- | --- |
| #915, #916 | not bugs, images failing to load |
| #914 | an extension bug, belongs in the extension's repository |
| #917, #918 | one real app bug, filed twice by the same person |

One distinct app bug, five issues. That ratio is the problem, not any single report, so the other two rules are here too.

**An extension error no longer offers a Report button.** d4rt prefixes what it raises with `Runtime Error:` and wraps failures inside bridged calls recognisably, so these can be told apart from an app bug. The entry says instead that extensions are maintained by whoever runs the repository the source came from, and that the fix has to go there. #914 was filed here because the screen offered a button and gave the reader no way to know the difference.

**A fault already sent cannot be sent again.** Reports carry a fingerprint, the first line with digits flattened so the same fault matches across runs even though ids and offsets differ, and once a report has been opened the button reads "Already reported" and is disabled.

The stored file gains a field for that, so it is an object now rather than a bare list. A file written by an earlier build is still read rather than discarded on upgrade, and there is a test for that.

What still reaches the tracker after all three rules: an app bug, once, from each person who hits it. Which is what the feature was for.

