### PR TITLE
fix: restore bundled TLS roots so Android stops panicking on HTTPS

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1549,8 +1549,10 @@ dependencies = [
  "flutter_rust_bridge",
  "futures-util",
  "reqwest",
+ "rustls",
  "tokio",
  "tokio-util",
+ "webpki-roots",
  "zip 8.5.0",
 ]
 
@@ -2310,6 +2312,15 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,6 +15,9 @@ tokio = { version = "1.50.0", features = ["full"] }
 tokio-util = "0.7.16"
 epub = "2.1.5"
 zip = "8.5.0"
+# Pinned to what reqwest 0.13 already resolves, so the build has one rustls.
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "aws-lc-rs"] }
+webpki-roots = "1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/rhttp/client.rs
+++ b/rust/src/api/rhttp/client.rs
@@ -107,9 +107,62 @@ impl RequestClient {
     }
 }
 
+/// A TLS config that trusts the bundled Mozilla root store instead of the
+/// platform's.
+///
+/// reqwest 0.13 dropped the `rustls-tls-webpki-roots` feature this app used to
+/// build with, and its `rustls` feature verifies against the OS trust store
+/// through `rustls-platform-verifier`. On Android that crate has to be handed
+/// a JNI environment and an Android `Context` before anything uses it, and
+/// nothing here can do that: Flutter does not pass a `Context` down to the
+/// Rust side. So the first HTTPS request panicked with
+/// "Expect rustls-platform-verifier to be initialized" (#917, #918).
+///
+/// Bundling the roots is what the app did before v0.8.9, needs no platform
+/// setup, and behaves the same on every target.
+fn webpki_tls_config() -> Result<rustls::ClientConfig, RhttpError> {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    // Reuse whichever provider is already installed rather than installing a
+    // second one; fall back to the one compiled in when nothing has yet.
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .cloned()
+        .unwrap_or_else(|| std::sync::Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
+
+    rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| RhttpError::RhttpUnknownError(format!("TLS setup failed: {e:?}")))
+        .map(|builder| builder.with_root_certificates(roots).with_no_client_auth())
+}
+
+/// Whether the caller asked for something the bundled-roots config cannot
+/// express, in which case reqwest's own TLS handling is left alone.
+///
+/// Those paths still go through the platform verifier and so still need it
+/// initialized, but they are opt-in and were already broken; this is about not
+/// silently discarding a certificate or a version pin somebody set on purpose.
+fn wants_custom_tls(settings: &Option<TlsSettings>) -> bool {
+    match settings {
+        None => false,
+        Some(tls) => {
+            !tls.trust_root_certificates
+                || !tls.trusted_root_certificates.is_empty()
+                || !tls.verify_certificates
+                || tls.client_certificate.is_some()
+                || tls.min_tls_version.is_some()
+                || tls.max_tls_version.is_some()
+        }
+    }
+}
+
 fn create_client(settings: ClientSettings) -> Result<RequestClient, RhttpError> {
+    let custom_tls = wants_custom_tls(&settings.tls_settings);
     let client: reqwest::Client = {
         let mut client = reqwest::Client::builder();
+        if !custom_tls {
+            client = client.use_preconfigured_tls(webpki_tls_config()?);
+        }
         if let Some(proxy_settings) = settings.proxy_settings {
             match proxy_settings {
                 ProxySettings::NoProxy => client = client.no_proxy(),
@@ -357,5 +410,69 @@ impl SocketAddrDigester for String {
         }
 
         self
+    }
+}
+
+#[cfg(test)]
+mod tls_tests {
+    use super::*;
+
+    fn tls(f: impl FnOnce(&mut TlsSettings)) -> Option<TlsSettings> {
+        let mut settings = TlsSettings {
+            trust_root_certificates: true,
+            trusted_root_certificates: vec![],
+            verify_certificates: true,
+            client_certificate: None,
+            min_tls_version: None,
+            max_tls_version: None,
+        };
+        f(&mut settings);
+        Some(settings)
+    }
+
+    #[test]
+    fn the_bundled_root_store_is_not_empty() {
+        // If webpki-roots ever ships an empty set, every HTTPS request fails
+        // closed and this is the cheapest place to notice.
+        let config = webpki_tls_config().expect("config should build");
+        assert!(config.crypto_provider().cipher_suites.len() > 0);
+        assert!(!webpki_roots::TLS_SERVER_ROOTS.is_empty());
+    }
+
+    #[test]
+    fn ordinary_settings_use_the_bundled_roots() {
+        // The case that was crashing on Android: no custom TLS at all.
+        assert!(!wants_custom_tls(&None));
+        assert!(!wants_custom_tls(&tls(|_| {})));
+    }
+
+    #[test]
+    fn anything_deliberate_is_left_to_reqwest() {
+        // Silently discarding one of these would be worse than the panic.
+        assert!(wants_custom_tls(&tls(|s| s.trust_root_certificates = false)));
+        assert!(wants_custom_tls(&tls(|s| s.verify_certificates = false)));
+        assert!(wants_custom_tls(&tls(|s| {
+            s.trusted_root_certificates = vec![vec![1, 2, 3]]
+        })));
+        assert!(wants_custom_tls(&tls(|s| {
+            s.min_tls_version = Some(TlsVersion::Tls1_2)
+        })));
+        assert!(wants_custom_tls(&tls(|s| {
+            s.max_tls_version = Some(TlsVersion::Tls1_3)
+        })));
+    }
+
+    /// Proves the bundled roots actually verify a real certificate chain.
+    ///
+    /// Needs the network, so it does not run by default:
+    /// `cargo test -- --ignored tls`
+    #[test]
+    #[ignore]
+    fn a_real_https_request_succeeds() {
+        let client = create_client(ClientSettings::default()).expect("client");
+        let response = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { client.client.get("https://github.com").send().await });
+        assert!(response.is_ok(), "request failed: {:?}", response.err());
     }
 }


### PR DESCRIPTION
Fixes #917. Fixes #918. HTTPS is broken on Android in v0.8.9.

Both reports are `PanicException(Expect rustls-platform-verifier to be initialized)`, which is the first request failing rather than anything the reader did.

**What happened**

The dependency update changed reqwest `0.12.15` with `rustls-tls-webpki-roots` to `0.13.2` with `rustls`. That was not careless: **0.13 removed the webpki-roots feature**, and every remaining rustls option pulls in `rustls-platform-verifier`, which verifies against the OS trust store.

On Android that crate has to be handed a JNI environment and an Android `Context` before anything uses it (`init_with_env` / `init_with_refs`). Nothing here can do that, because Flutter does not pass a `Context` down to the Rust side. So the first HTTPS request panics.

**The fix**

The client now hands reqwest a preconfigured rustls config that trusts the bundled Mozilla roots. That is what the app did before v0.8.9, it needs no platform setup, and it behaves the same on every target. `rustls` was already in the dependency graph via reqwest, and the crypto provider is reused rather than installing a second one.

Anything asking for **custom** TLS is left alone: a pinned version, a supplied root certificate, a client certificate, or disabled verification all still go through reqwest's own handling. Those paths still need the verifier initialized and so are still broken on Android, but they are opt-in and were already broken, and silently discarding a certificate somebody set on purpose would be worse than the panic. `wants_custom_tls` is the one place that decides.

**Testing**

Three unit tests cover which settings take which path. A fourth, marked `#[ignore]` so it does not need the network by default, makes a real HTTPS request through the new config to prove the bundled roots verify a genuine chain — run with `cargo test -- --ignored tls`. It passes.

Also built and launched on macOS to confirm the crate still links and the app starts.

**What I could not test:** Android itself. I have no Android device here, so the platform that was broken is the one I could not verify on. The change removes the platform verifier from the default path entirely, which is the mechanism behind the panic, but a confirmation from anyone who hit #917 or #918 would be worth having before this is relied on.

