### PR TITLE
fix: say when a JS source fails to load instead of showing it as empty

### DIFF
--- a/lib/eval/javascript/js_errors.dart
+++ b/lib/eval/javascript/js_errors.dart
@@ -1,0 +1,32 @@
+/// Reading what a JS source reported when it went wrong.
+///
+/// `flutter_qjs` reports a failure by returning a `JsEvalResult` with `isError`
+/// set. It does not throw. Code that ignores the returned value therefore
+/// cannot tell a working source from a broken one, which is how a source that
+/// failed to evaluate ended up looking like a source that returned nothing:
+/// "Video list is empty" (#873).
+library;
+
+/// Whether [message] is the base class saying a source does not implement an
+/// optional method, rather than the source going wrong.
+///
+/// `MProvider` throws `"<name> not implemented"` on purpose for anything a
+/// source chooses not to define, and falling back to a default there is
+/// correct. Everything else has to reach the reader.
+bool isNotImplementedError(String message) =>
+    message.contains('not implemented');
+
+/// What to tell the reader when a source fails.
+///
+/// Names the source and repeats what it actually said. The old behaviour was
+/// either silence or a JSON parse failure, neither of which says which source
+/// broke, or why, or that the problem is the source at all.
+String jsExtensionErrorMessage({
+  required String sourceName,
+  required String whileDoing,
+  required String reported,
+}) {
+  final detail = reported.trim();
+  return 'Extension "$sourceName" failed while $whileDoing'
+      '${detail.isEmpty ? '' : ': $detail'}';
+}

--- a/lib/eval/javascript/service.dart
+++ b/lib/eval/javascript/service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter_qjs/flutter_qjs.dart';
 import 'package:mangayomi/eval/javascript/dom_selector.dart';
+import 'package:mangayomi/eval/javascript/js_errors.dart';
 import 'package:mangayomi/eval/javascript/extractors.dart';
 import 'package:mangayomi/eval/javascript/http.dart';
 import 'package:mangayomi/eval/javascript/preferences.dart';
@@ -82,9 +83,18 @@ async function jsonStringify(fn) {
     return JSON.stringify(await fn());
 }
 ''');
-    runtime.evaluate('''${source.sourceCode}
+    // evaluate() reports a failure by returning a result with isError set; it
+    // does not throw. Ignoring that meant a source which failed to evaluate
+    // still set _isInitialized, so `extention` was never created and every
+    // later call answered its default. That is what "Video list is empty"
+    // was: not an empty list from the source, but a source that never loaded.
+    // See #873.
+    _throwIfError(
+      runtime.evaluate('''${source.sourceCode}
 var extention = new DefaultExtension();
-''');
+'''),
+      'loading the source',
+    );
     _isInitialized = true;
   }
 
@@ -225,15 +235,20 @@ var extention = new DefaultExtension();
   T _extensionCall<T>(String call, T def) {
     _init();
 
-    try {
-      final res = runtime.evaluate('JSON.stringify(extention.$call)');
+    final res = runtime.evaluate('JSON.stringify(extention.$call)');
+    if (res.isError) {
+      // A source that simply does not implement an optional method is not a
+      // failure, and falling back is the whole point of `def`. Anything else
+      // is a real error and used to arrive as a JSON parse failure, or as
+      // silence when def was non-null.
+      if (_isNotImplemented(res) && def != null) return def;
+      _throwIfError(res, call);
+    }
 
+    try {
       return jsonDecode(res.stringResult) as T;
     } catch (_) {
-      if (def != null) {
-        return def;
-      }
-
+      if (def != null) return def;
       rethrow;
     }
   }
@@ -241,14 +256,35 @@ var extention = new DefaultExtension();
   Future<T> _extensionCallAsync<T>(String call) async {
     _init();
 
-    try {
-      final promised = await runtime.handlePromise(
-        await runtime.evaluateAsync('jsonStringify(() => extention.$call)'),
-      );
+    final evaluated = await runtime.evaluateAsync(
+      'jsonStringify(() => extention.$call)',
+    );
+    _throwIfError(evaluated, call);
 
-      return jsonDecode(promised.stringResult) as T;
-    } catch (e) {
-      rethrow;
-    }
+    final promised = await runtime.handlePromise(evaluated);
+    _throwIfError(promised, call);
+
+    return jsonDecode(promised.stringResult) as T;
   }
+
+  /// Turns a failed evaluation into an error that says what the source
+  /// actually reported.
+  ///
+  /// Without this the message reaching the reader is either nothing at all or
+  /// a JSON parse failure, neither of which says which source broke or why.
+  void _throwIfError(JsEvalResult result, String what) {
+    if (!result.isError) return;
+    throw Exception(
+      jsExtensionErrorMessage(
+        sourceName: source.name ?? 'unknown',
+        whileDoing: what,
+        reported: result.stringResult,
+      ),
+    );
+  }
+
+  /// Whether this is the base class saying the source does not implement
+  /// something, rather than the source going wrong.
+  bool _isNotImplemented(JsEvalResult result) =>
+      isNotImplementedError(result.stringResult);
 }

--- a/test/eval/js_errors_test.dart
+++ b/test/eval/js_errors_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/eval/javascript/js_errors.dart';
+
+/// #873 reported "Video list is empty" on sources that worked on 0.8.0, and
+/// occasionally `ReferenceError: 'extention' is not defined` instead.
+///
+/// Both are the same thing: `flutter_qjs` reports a failed evaluation by
+/// returning a result with `isError` set rather than throwing, the source
+/// evaluation ignored that, and so `extention` was never defined while the
+/// runtime was marked initialized anyway. Every later call then answered its
+/// default, which looked like an empty list.
+void main() {
+  group('telling an unimplemented method from a broken source', () {
+    test('the base class saying so is not a failure', () {
+      // MProvider throws these on purpose for anything a source leaves out,
+      // and falling back to a default there is correct.
+      expect(
+        isNotImplementedError('Error: getFilterList not implemented'),
+        true,
+      );
+      expect(
+        isNotImplementedError('Error: getVideoList not implemented'),
+        true,
+      );
+    });
+
+    test('anything else is', () {
+      expect(
+        isNotImplementedError("ReferenceError: 'extention' is not defined"),
+        false,
+      );
+      expect(
+        isNotImplementedError('TypeError: x.toList is not a function'),
+        false,
+      );
+      expect(isNotImplementedError('SyntaxError: unexpected token'), false);
+    });
+  });
+
+  group('what the reader is told', () {
+    test('names the source, what it was doing, and what it said', () {
+      final message = jsExtensionErrorMessage(
+        sourceName: 'AnimeWorld',
+        whileDoing: 'loading the source',
+        reported: "ReferenceError: 'extention' is not defined",
+      );
+
+      expect(message, contains('AnimeWorld'));
+      expect(message, contains('loading the source'));
+      expect(message, contains('extention'));
+    });
+
+    test('says which call failed when it is a call', () {
+      final message = jsExtensionErrorMessage(
+        sourceName: 'AnimeWorld',
+        whileDoing: 'getVideoList("/ep/1")',
+        reported: 'TypeError: undefined',
+      );
+
+      expect(message, contains('getVideoList'));
+    });
+
+    test('still says something when the source said nothing', () {
+      final message = jsExtensionErrorMessage(
+        sourceName: 'AnimeWorld',
+        whileDoing: 'loading the source',
+        reported: '   ',
+      );
+
+      expect(message, contains('AnimeWorld'));
+      expect(message, isNot(endsWith(': ')));
+    });
+  });
+}


### PR DESCRIPTION
Towards #873, which reports "Video list is empty" on sources that worked in 0.8.0, and occasionally `ReferenceError: 'extention' is not defined` instead, on both Android and desktop.

Those two symptoms are the same thing.

**What happens**

`flutter_qjs` reports a failed evaluation by returning a `JsEvalResult` with `isError` set. It does not throw. `_init` ignored the returned value:

```dart
runtime.evaluate('''${source.sourceCode}
var extention = new DefaultExtension();
''');
_isInitialized = true;
```

So a source whose code fails to evaluate still sets `_isInitialized`, and the `extention` object the next line should have created never exists. `_extensionCall` then ignored `isError` too, tried to `jsonDecode` the error text, failed, and returned its default through `catch (_)`. An empty list, from a source that never loaded.

That is why the message names neither the source nor the reason, and why the one place the real error leaked through named a variable the reader has never heard of.

**What changed**

Evaluation failures are surfaced, with the source's name, what it was doing, and what the source actually reported. A method the source chooses not to implement still falls back to its default, because `MProvider` throws `"<name> not implemented"` on purpose and that is not a failure — `isNotImplementedError` is the one place that distinguishes them.

**What this does not do**

It does not explain why that reporter's source stopped evaluating between 0.8.0 and 0.8.4. I could not reproduce that without their extension. What it does mean is that the app now says what the source is unhappy about, which is the thing nobody has been able to see — including them, which is why they could not bisect it.

**Testing**

The classification and the message are covered by unit tests. The runtime behaviour underneath is not: QuickJS is a native library and `flutter test` cannot load it (`Failed to lookup symbol 'jsNewRuntime'`), so I moved the logic out of the class rather than ship an untested judgement inside it. The `isError`-not-throwing contract is read from `flutter_qjs`'s own `JsEvalResult`, which has no throwing path.
