### PR TITLE
Use correct image extensions

### DIFF
--- a/lib/modules/library/providers/file_scanner.dart
+++ b/lib/modules/library/providers/file_scanner.dart
@@ -9,6 +9,7 @@ import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/library/providers/local_archive.dart';
 import 'package:mangayomi/modules/manga/archive_reader/providers/archive_reader_providers.dart';
 import 'package:mangayomi/src/rust/api/epub.dart';
+import 'package:mangayomi/utils/downloaded_page_file.dart';
 import 'package:mangayomi/utils/extensions/others.dart';
 import 'package:mangayomi/utils/local_directory_access.dart';
 import 'package:mangayomi/utils/localized_message.dart';
@@ -1241,8 +1242,7 @@ bool _isJson(String path) {
 /// Returns if file is an image
 bool _isImage(String path) {
   if (_isHiddenSystemFile(path)) return false;
-  final ext = p.extension(path).toLowerCase();
-  return ext == '.jpg' || ext == '.jpeg' || ext == '.png' || ext == '.webp';
+  return isRecognizedImageFile(path);
 }
 
 /// Returns if file is an archive

--- a/lib/modules/manga/archive_reader/providers/archive_reader_providers.dart
+++ b/lib/modules/manga/archive_reader/providers/archive_reader_providers.dart
@@ -3,18 +3,12 @@ import 'dart:io';
 import 'package:archive/archive_io.dart';
 import 'package:flutter/foundation.dart';
 import 'package:mangayomi/modules/manga/archive_reader/models/models.dart';
+import 'package:mangayomi/utils/downloaded_page_file.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:path/path.dart' as p;
 part 'archive_reader_providers.g.dart';
 
 // Constants for supported file types
-const List<String> _kImageExtensions = [
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.webp',
-];
 const List<String> _kArchiveExtensions = ['.cbz', '.zip', '.cbt', '.tar'];
 
 @riverpod
@@ -139,8 +133,7 @@ Future<void> _scanDirectoryRecursive(
 /// Check if a file is an image based on extension
 bool _isImageFile(String path) {
   if (_isHiddenSystemFile(path)) return false;
-  final extension = p.extension(path).toLowerCase();
-  return _kImageExtensions.contains(extension);
+  return isRecognizedImageFile(path);
 }
 
 /// Check if a file is a supported archive based on extension

--- a/lib/modules/manga/detail/providers/export_metadata.dart
+++ b/lib/modules/manga/detail/providers/export_metadata.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/services/http/m_client.dart';
+import 'package:mangayomi/utils/downloaded_page_file.dart';
 import 'package:path/path.dart' as p;
 
 Future<void> exportMangaMetadata({
@@ -13,10 +14,9 @@ Future<void> exportMangaMetadata({
 }) async {
   await directory.create(recursive: true);
 
-  final coverFile = File(p.join(directory.path, "cover.jpg"));
   final metadataFile = File(p.join(directory.path, "metadata.json"));
 
-  if (!onlyIfMissing || !await coverFile.exists()) {
+  if (!onlyIfMissing || findMangaCoverFile(directory) == null) {
     final imageUrl = (manga.customCoverFromTracker ?? manga.imageUrl ?? "")
         .trim();
     if (imageUrl.isNotEmpty) {
@@ -26,6 +26,8 @@ Future<void> exportMangaMetadata({
           final client = MClient.init();
           final res = await client.get(uri, headers: headers);
           if (res.bodyBytes.isNotEmpty) {
+            final ext = detectImageExtension(res.bodyBytes);
+            final coverFile = File(p.join(directory.path, "cover$ext"));
             await coverFile.writeAsBytes(res.bodyBytes);
           }
         } catch (_) {
@@ -55,10 +57,12 @@ Future<void> exportMangaCoverFromFile({
   required File imageFile,
   bool onlyIfMissing = true,
 }) async {
-  final coverFile = File(p.join(directory.path, "cover.jpg"));
-  if (onlyIfMissing && await coverFile.exists()) return;
+  if (onlyIfMissing && findMangaCoverFile(directory) != null) return;
   if (!await imageFile.exists()) return;
 
   await directory.create(recursive: true);
-  await coverFile.writeAsBytes(await imageFile.readAsBytes());
+  final bytes = await imageFile.readAsBytes();
+  final ext = detectImageExtension(bytes);
+  final coverFile = File(p.join(directory.path, "cover$ext"));
+  await coverFile.writeAsBytes(bytes);
 }

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -178,15 +178,9 @@ Future<void> downloadChapter(
     bool nonM3U8File = false;
     M3u8Downloader? m3u8Downloader;
 
-    bool isMangaImageFile(String path) {
-      final ext = p.extension(path).toLowerCase();
-      return ext == '.jpg' || ext == '.jpeg' || ext == '.png' || ext == '.webp';
-    }
-
     Future<void> exportCoverFromDownloadedPages() async {
       if (itemType != ItemType.manga) return;
-      final coverFile = File(p.join(mangaMainDirectory.path, "cover.jpg"));
-      if (await coverFile.exists()) return;
+      if (findMangaCoverFile(mangaMainDirectory) != null) return;
 
       final dir = Directory(chapterDirectory.path);
       if (!await dir.exists()) return;
@@ -195,7 +189,8 @@ Future<void> downloadChapter(
           await dir
                 .list()
                 .where(
-                  (entity) => entity is File && isMangaImageFile(entity.path),
+                  (entity) =>
+                      entity is File && isRecognizedImageFile(entity.path),
                 )
                 .cast<File>()
                 .toList()

--- a/lib/services/downloaded_chapter.dart
+++ b/lib/services/downloaded_chapter.dart
@@ -6,7 +6,7 @@ import 'package:mangayomi/models/download.dart';
 import 'package:mangayomi/modules/library/providers/file_scanner.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/utils/extensions/string_extensions.dart';
-import 'package:mangayomi/utils/reg_exp_matcher.dart';
+import 'package:mangayomi/utils/downloaded_page_file.dart';
 import 'package:path/path.dart' as p;
 
 /// Where a downloaded chapter's pages actually sit on disk.
@@ -135,13 +135,12 @@ File? findChapterArchive(Directory mangaDirectory, String chapterName) {
 
 /// How many pages of [directory] the reader can actually address.
 ///
-/// The reader asks for page `i` by rebuilding `padIndex(i).jpg`, so the run has
-/// to be counted from the first page and stop at the first gap. A folder
-/// missing `003.jpg` can only serve two pages however many files it holds.
+/// Uses [findDownloadedPageFile] so callers don’t need to assume a fixed
+/// extension. Counts from page 0 upward until the first missing page.
 int countDownloadedPages(Directory directory) {
   if (!directory.existsSync()) return 0;
   var count = 0;
-  while (File(p.join(directory.path, '${padIndex(count)}.jpg')).existsSync()) {
+  while (findDownloadedPageFile(directory, count) != null) {
     count++;
   }
   return count;

--- a/lib/utils/downloaded_page_file.dart
+++ b/lib/utils/downloaded_page_file.dart
@@ -16,6 +16,24 @@ const List<String> knownPageImageExtensions = [
   '.avif',
 ];
 
+/// Superset of [knownPageImageExtensions] for recognizing image files
+/// mangayomi didn't create itself - user-added local comics, archive
+/// contents, anything from outside the downloader. Includes the '.jpeg'
+/// spelling some external tools use, which detectImageExtension never
+/// produces, so [knownPageImageExtensions] deliberately excludes it - a
+/// lookup for one of mangayomi's own downloaded pages should never need to
+/// check for a spelling it never writes.
+const List<String> recognizedImageExtensions = [
+  ...knownPageImageExtensions,
+  '.jpeg',
+];
+
+/// Whether [path]'s extension is a recognized image format. Case-insensitive.
+/// For scanning arbitrary files - see [recognizedImageExtensions].
+bool isRecognizedImageFile(String path) {
+  return recognizedImageExtensions.contains(p.extension(path).toLowerCase());
+}
+
 /// Sniffs [bytes] for a known image-format magic number and returns the
 /// matching extension (including the leading dot). Falls back to '.jpg' for
 /// anything unrecognized - matches the historical always-.jpg behavior for
@@ -69,6 +87,19 @@ bool isGifImage(Uint8List bytes) {
       bytes[3] == 0x38 && // '8'
       (bytes[4] == 0x37 || bytes[4] == 0x39) && // '7' or '9'
       bytes[5] == 0x61; // 'a'
+}
+
+/// The single source of truth for "does an exported cover already exist in
+/// [directory], and under what extension" - same tolerant-extension lookup
+/// as [findDownloadedPageFile], but for the fixed "cover" basename that
+/// exportMangaMetadata/exportMangaCoverFromFile write under (see
+/// export_metadata.dart), rather than a page index.
+File? findMangaCoverFile(Directory directory) {
+  for (final ext in knownPageImageExtensions) {
+    final file = File(p.join(directory.path, 'cover$ext'));
+    if (file.existsSync()) return file;
+  }
+  return null;
 }
 
 /// The single source of truth for "where is page [index] of this chapter on


### PR DESCRIPTION
`countDownloadedPages()` inside downloaded_chapter.dart still used the old hardcoded .jpg extension.

This PR fixes that and makes it use the image's real extensions.

\+ some clean up.