### PR TITLE
feat: a live memory readout, so the TV questions can be measured

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1221,6 +1221,8 @@
       "duplicateTracks": {}
     }
   },
+  "memory_overlay": "Show memory usage",
+  "memory_overlay_subtitle": "A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.",
   "beta": "Beta",
   "error_reports": "Error reports",
   "error_reports_subtitle": "Errors the app caught, and a way to report them",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -5519,6 +5519,18 @@ abstract class AppLocalizations {
     Object duplicateTracks,
   );
 
+  /// No description provided for @memory_overlay.
+  ///
+  /// In en, this message translates to:
+  /// **'Show memory usage'**
+  String get memory_overlay;
+
+  /// No description provided for @memory_overlay_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.'**
+  String get memory_overlay_subtitle;
+
   /// No description provided for @beta.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -3059,6 +3059,13 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'تجريبي';
 
   @override

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -3058,6 +3058,13 @@ class AppLocalizationsAs extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'বিটা';
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -3082,6 +3082,13 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'Beta';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -3049,6 +3049,13 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'Beta';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -3094,6 +3094,13 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'Beta';
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -3100,6 +3100,13 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'Bêta';
 
   @override

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -3059,6 +3059,13 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'बीटा';
 
   @override

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -3064,6 +3064,13 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'Beta';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -3092,6 +3092,13 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'Beta';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -2992,6 +2992,13 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'ベータ';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -3087,6 +3087,13 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'Beta';
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -3102,6 +3102,13 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'Бета';
 
   @override

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -3049,6 +3049,13 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'เบต้า';
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -3068,6 +3068,13 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'Beta';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -2950,6 +2950,13 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get memory_overlay => 'Show memory usage';
+
+  @override
+  String get memory_overlay_subtitle =>
+      'A live readout of what the app is holding. For measuring on the device rather than guessing: watch it while scrolling the library or reading a chapter.';
+
+  @override
   String get beta => 'Beta';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,8 @@ import 'package:window_manager/window_manager.dart';
 import 'package:path/path.dart' as p;
 import 'package:flutter/services.dart' show rootBundle, LogicalKeyboardKey;
 import 'package:mangayomi/utils/window_geometry.dart';
+import 'package:mangayomi/modules/more/settings/general/providers/memory_probe_provider.dart';
+import 'package:mangayomi/modules/widgets/memory_overlay.dart';
 import 'package:mangayomi/modules/widgets/app_ui_scale.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/app_ui_scale_state_provider.dart';
 
@@ -138,7 +140,10 @@ void main(List<String> args) async {
       // "Enable logs". Anything raised before this is held in memory and
       // written out here.
       unawaited(
-        storage.getDefaultDirectory().then(CrashReports.init).catchError((_) {}),
+        storage
+            .getDefaultDirectory()
+            .then(CrashReports.init)
+            .catchError((_) {}),
       );
       Object? startupError;
       try {
@@ -356,6 +361,22 @@ class _MyAppState extends ConsumerState<MyApp>
               children: [withBackHandler, const AppLockScreen()],
             );
           }
+        }
+
+        // Sits above everything, including the lock screen, because a
+        // measurement is not worth taking if navigating away ends it.
+        if (ref.watch(memoryOverlayVisibleProvider)) {
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              withBackHandler,
+              MemoryOverlay(
+                probe: ref.read(memoryProbeProvider),
+                onClose: () =>
+                    ref.read(memoryOverlayVisibleProvider.notifier).set(false),
+              ),
+            ],
+          );
         }
 
         return withBackHandler;

--- a/lib/modules/more/settings/general/general_screen.dart
+++ b/lib/modules/more/settings/general/general_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/main.dart';
+import 'package:mangayomi/modules/more/settings/general/providers/memory_probe_provider.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/modules/more/providers/algorithm_weights_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/general/providers/general_state_provider.dart';
@@ -461,6 +462,13 @@ class _GeneralStateScreen extends ConsumerState<GeneralScreen> {
                   ),
                 ],
               ),
+            ),
+            SwitchListTile(
+              value: ref.watch(memoryOverlayVisibleProvider),
+              title: Text(l10n.memory_overlay),
+              subtitle: Text(l10n.memory_overlay_subtitle),
+              onChanged: (value) =>
+                  ref.read(memoryOverlayVisibleProvider.notifier).set(value),
             ),
             SwitchListTile(
               value: enableDiscordRpc,

--- a/lib/modules/more/settings/general/providers/memory_probe_provider.dart
+++ b/lib/modules/more/settings/general/providers/memory_probe_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mangayomi/utils/memory_probe.dart';
+
+/// The probe itself, alive for the app's lifetime so a measurement survives
+/// navigating between screens, which is the whole point of taking one.
+final memoryProbeProvider = Provider<MemoryProbe>((ref) {
+  final probe = MemoryProbe();
+  ref.onDispose(probe.dispose);
+  return probe;
+});
+
+/// Whether the readout is on screen.
+///
+/// Deliberately not persisted. It is a measuring tool rather than a
+/// preference, and keeping it out of the settings row means no schema change
+/// for something that exists to answer one question and then stop.
+class MemoryOverlayVisible extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  void set(bool value) {
+    final probe = ref.read(memoryProbeProvider);
+    if (value) {
+      probe.reset();
+      probe.start();
+    } else {
+      probe.stop();
+    }
+    state = value;
+  }
+}
+
+final memoryOverlayVisibleProvider =
+    NotifierProvider<MemoryOverlayVisible, bool>(MemoryOverlayVisible.new);

--- a/lib/modules/widgets/memory_overlay.dart
+++ b/lib/modules/widgets/memory_overlay.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mangayomi/utils/memory_probe.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
 /// A live readout of what the app is holding, for measuring on the device
 /// rather than guessing from a desktop.
@@ -16,11 +17,18 @@ class MemoryOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // The buttons are only offered where they can be pressed. A television
+    // has no pointer, and this sits in a Stack above the whole app rather than
+    // inside its focus traversal, so a d-pad can never reach them: they would
+    // be two controls that look live and are not. The settings toggle already
+    // resets the run when it is switched on, and that is reachable.
+    final interactive = onClose != null && !isTv;
+
     return Positioned(
       top: MediaQuery.paddingOf(context).top + 8,
       right: 8,
       child: IgnorePointer(
-        ignoring: onClose == null,
+        ignoring: !interactive,
         child: Material(
           color: Colors.black.withValues(alpha: 0.78),
           borderRadius: BorderRadius.circular(8),
@@ -56,6 +64,8 @@ class MemoryOverlay extends StatelessWidget {
         ? Colors.amber
         : (pressure > 0 ? Colors.white : Colors.white70);
 
+    final interactive = onClose != null && !isTv;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
@@ -81,7 +91,12 @@ class MemoryOverlay extends StatelessWidget {
           '${stats.samples} samples',
           style: style.copyWith(color: pressureColour),
         ),
-        if (onClose != null)
+        if (isTv)
+          Text(
+            'toggle it off and on in settings to reset',
+            style: style.copyWith(color: Colors.white54, fontSize: 11),
+          ),
+        if (interactive)
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [

--- a/lib/modules/widgets/memory_overlay.dart
+++ b/lib/modules/widgets/memory_overlay.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:mangayomi/utils/memory_probe.dart';
+
+/// A live readout of what the app is holding, for measuring on the device
+/// rather than guessing from a desktop.
+///
+/// Deliberately plain and legible from a sofa: the numbers are meant to be
+/// read off a television while somebody scrolls the library or reads a
+/// chapter, which is the only way to answer whether the image cache budget is
+/// the constraint on a box with little RAM.
+class MemoryOverlay extends StatelessWidget {
+  const MemoryOverlay({super.key, required this.probe, this.onClose});
+
+  final MemoryProbe probe;
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      top: MediaQuery.paddingOf(context).top + 8,
+      right: 8,
+      child: IgnorePointer(
+        ignoring: onClose == null,
+        child: Material(
+          color: Colors.black.withValues(alpha: 0.78),
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: ListenableBuilder(
+              listenable: probe,
+              builder: (context, _) => _body(context, probe.stats),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _body(BuildContext context, MemoryStats stats) {
+    final latest = stats.latest;
+    const style = TextStyle(
+      color: Colors.white,
+      fontSize: 13,
+      fontFamily: 'monospace',
+      height: 1.4,
+    );
+
+    if (latest == null) {
+      return const Text('memory: waiting for a sample', style: style);
+    }
+
+    // Amber once the cache is spending its time full, which is the reading
+    // that says the budget is the thing to change.
+    final pressure = stats.ceilingShare;
+    final pressureColour = pressure >= 0.5
+        ? Colors.amber
+        : (pressure > 0 ? Colors.white : Colors.white70);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          'RSS   ${formatBytes(latest.rssBytes)}'
+          '   peak ${formatBytes(stats.peakRssBytes)}',
+          style: style,
+        ),
+        Text(
+          'cache ${formatBytes(latest.imageCacheBytes)}'
+          ' / ${formatBytes(latest.imageCacheMaxBytes)}'
+          '   peak ${formatBytes(stats.peakCacheBytes)}',
+          style: style,
+        ),
+        Text(
+          'items ${latest.imageCacheCount} / ${latest.imageCacheMaxCount}'
+          '   live ${latest.liveImages}   peak ${stats.peakCacheCount}',
+          style: style,
+        ),
+        Text(
+          'full  ${(pressure * 100).toStringAsFixed(0)}% of '
+          '${stats.samples} samples',
+          style: style.copyWith(color: pressureColour),
+        ),
+        if (onClose != null)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextButton(
+                onPressed: probe.reset,
+                child: const Text('Reset', style: TextStyle(fontSize: 12)),
+              ),
+              TextButton(
+                onPressed: onClose,
+                child: const Text('Hide', style: TextStyle(fontSize: 12)),
+              ),
+            ],
+          ),
+      ],
+    );
+  }
+}

--- a/lib/utils/memory_probe.dart
+++ b/lib/utils/memory_probe.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+
+/// One reading of what the app is holding.
+@immutable
+class MemorySample {
+  const MemorySample({
+    required this.rssBytes,
+    required this.imageCacheBytes,
+    required this.imageCacheMaxBytes,
+    required this.imageCacheCount,
+    required this.imageCacheMaxCount,
+    required this.liveImages,
+  });
+
+  /// Resident set size: what the operating system says the process is using.
+  /// This is the number that matters on a device with little RAM.
+  final int rssBytes;
+
+  /// Decoded images Flutter is holding, and the ceiling it will not exceed.
+  final int imageCacheBytes;
+  final int imageCacheMaxBytes;
+
+  /// How many entries, against the count ceiling. Flutter enforces both, and
+  /// whichever binds first is the one worth tuning.
+  final int imageCacheCount;
+  final int imageCacheMaxCount;
+
+  /// Images currently on screen. The gap between this and [imageCacheCount] is
+  /// what the cache is holding purely in case you scroll back.
+  final int liveImages;
+
+  /// How full the byte budget is, 0 to 1.
+  double get cacheFullness =>
+      imageCacheMaxBytes == 0 ? 0 : imageCacheBytes / imageCacheMaxBytes;
+
+  /// Whether this reading is close enough to the ceiling that the next image
+  /// decoded will evict something.
+  ///
+  /// That is the state worth catching: a cache pinned at its limit while you
+  /// scroll is re-decoding images it just threw away, which costs both CPU and
+  /// the jank that comes with it. A cache sitting at half is not a problem
+  /// however large it looks.
+  bool get atCeiling => cacheFullness >= 0.95;
+
+  static MemorySample take() {
+    final cache = PaintingBinding.instance.imageCache;
+    return MemorySample(
+      rssBytes: _rss(),
+      imageCacheBytes: cache.currentSizeBytes,
+      imageCacheMaxBytes: cache.maximumSizeBytes,
+      imageCacheCount: cache.currentSize,
+      imageCacheMaxCount: cache.maximumSize,
+      liveImages: cache.liveImageCount,
+    );
+  }
+
+  static int _rss() {
+    try {
+      return ProcessInfo.currentRss;
+    } catch (_) {
+      // Not available everywhere; the cache numbers are still worth having.
+      return 0;
+    }
+  }
+}
+
+/// What the samples add up to.
+///
+/// Peaks matter more than the current reading on a device that dies from a
+/// single spike, and the share of samples spent at the ceiling says whether
+/// the budget is too small for what the screen is asking for.
+@immutable
+class MemoryStats {
+  const MemoryStats({
+    this.samples = 0,
+    this.atCeiling = 0,
+    this.peakRssBytes = 0,
+    this.peakCacheBytes = 0,
+    this.peakCacheCount = 0,
+    this.latest,
+  });
+
+  final int samples;
+  final int atCeiling;
+  final int peakRssBytes;
+  final int peakCacheBytes;
+  final int peakCacheCount;
+  final MemorySample? latest;
+
+  /// The share of readings taken while the cache was full, 0 to 1.
+  ///
+  /// Low is fine. Consistently high means the budget is the constraint, and
+  /// that is the case where raising it, or decoding smaller, actually helps.
+  double get ceilingShare => samples == 0 ? 0 : atCeiling / samples;
+
+  MemoryStats add(MemorySample sample) => MemoryStats(
+    samples: samples + 1,
+    atCeiling: atCeiling + (sample.atCeiling ? 1 : 0),
+    peakRssBytes: sample.rssBytes > peakRssBytes
+        ? sample.rssBytes
+        : peakRssBytes,
+    peakCacheBytes: sample.imageCacheBytes > peakCacheBytes
+        ? sample.imageCacheBytes
+        : peakCacheBytes,
+    peakCacheCount: sample.imageCacheCount > peakCacheCount
+        ? sample.imageCacheCount
+        : peakCacheCount,
+    latest: sample,
+  );
+}
+
+/// Bytes as something readable on a television from across the room.
+String formatBytes(int bytes) {
+  if (bytes <= 0) return '0 MB';
+  const mb = 1 << 20;
+  // Below a kilobyte, rounding to KB would print "1 KB" for 512 bytes, which
+  // is both wrong and confusing next to a real figure.
+  if (bytes < 1024) return '$bytes B';
+  if (bytes < mb) return '${(bytes / 1024).toStringAsFixed(0)} KB';
+  final megabytes = bytes / mb;
+  return megabytes >= 100
+      ? '${megabytes.toStringAsFixed(0)} MB'
+      : '${megabytes.toStringAsFixed(1)} MB';
+}
+
+/// Samples memory on a timer while it is switched on.
+///
+/// Exists because the RAM questions on a television cannot be answered from a
+/// desktop: what the budget should be, and whether decoding pages smaller
+/// would help, both depend on numbers only the device can give. Guessing at
+/// them is how the wrong thing gets optimised.
+class MemoryProbe extends ChangeNotifier {
+  MemoryProbe({this.interval = const Duration(seconds: 1)});
+
+  final Duration interval;
+  Timer? _timer;
+  MemoryStats _stats = const MemoryStats();
+
+  MemoryStats get stats => _stats;
+  bool get isRunning => _timer != null;
+
+  void start() {
+    if (_timer != null) return;
+    sample();
+    _timer = Timer.periodic(interval, (_) => sample());
+  }
+
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  /// Takes one reading now. Public so a test does not need a real clock.
+  void sample() {
+    _stats = _stats.add(MemorySample.take());
+    notifyListeners();
+  }
+
+  /// Forgets the history, so a measurement can start from a known point
+  /// rather than carrying whatever happened before it.
+  void reset() {
+    _stats = const MemoryStats();
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    stop();
+    super.dispose();
+  }
+}

--- a/test/utils/memory_probe_test.dart
+++ b/test/utils/memory_probe_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/utils/memory_probe.dart';
+
+MemorySample sample({
+  int rss = 0,
+  int cacheBytes = 0,
+  int cacheMax = 64 << 20,
+  int count = 0,
+  int maxCount = 1000,
+  int live = 0,
+}) => MemorySample(
+  rssBytes: rss,
+  imageCacheBytes: cacheBytes,
+  imageCacheMaxBytes: cacheMax,
+  imageCacheCount: count,
+  imageCacheMaxCount: maxCount,
+  liveImages: live,
+);
+
+/// The point of this is to answer two questions on a television that cannot be
+/// answered from a desktop: what the image cache budget should be, and whether
+/// decoding pages smaller would help. Both need numbers from the device.
+void main() {
+  // MemorySample.take reads PaintingBinding.instance.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('reading one sample', () {
+    test('a cache at its ceiling is the state worth catching', () {
+      // A full cache evicts on the next decode, so scrolling re-decodes what
+      // it just threw away. That is the case where the budget is the problem.
+      expect(sample(cacheBytes: 64 << 20, cacheMax: 64 << 20).atCeiling, true);
+      expect(sample(cacheBytes: 62 << 20, cacheMax: 64 << 20).atCeiling, true);
+    });
+
+    test('a cache with room is not, however large it looks', () {
+      expect(sample(cacheBytes: 32 << 20, cacheMax: 64 << 20).atCeiling, false);
+      expect(sample(cacheBytes: 0, cacheMax: 64 << 20).atCeiling, false);
+    });
+
+    test('a zero budget does not divide by it', () {
+      expect(sample(cacheBytes: 10, cacheMax: 0).cacheFullness, 0);
+      expect(sample(cacheBytes: 10, cacheMax: 0).atCeiling, false);
+    });
+  });
+
+  group('what the samples add up to', () {
+    test('peaks survive a later dip, which is the point of tracking them', () {
+      // A device dies from the spike, not from the average.
+      var stats = const MemoryStats()
+          .add(sample(rss: 300 << 20, cacheBytes: 60 << 20, count: 90))
+          .add(sample(rss: 120 << 20, cacheBytes: 10 << 20, count: 12));
+
+      expect(stats.peakRssBytes, 300 << 20);
+      expect(stats.peakCacheBytes, 60 << 20);
+      expect(stats.peakCacheCount, 90);
+      expect(stats.latest!.rssBytes, 120 << 20, reason: 'latest is still now');
+    });
+
+    test('the ceiling share says whether the budget is the constraint', () {
+      var stats = const MemoryStats();
+      for (var i = 0; i < 3; i++) {
+        stats = stats.add(sample(cacheBytes: 64 << 20, cacheMax: 64 << 20));
+      }
+      stats = stats.add(sample(cacheBytes: 1 << 20, cacheMax: 64 << 20));
+
+      expect(stats.samples, 4);
+      expect(stats.atCeiling, 3);
+      expect(stats.ceilingShare, closeTo(0.75, 0.001));
+    });
+
+    test('no samples is not a division by zero', () {
+      expect(const MemoryStats().ceilingShare, 0);
+      expect(const MemoryStats().latest, isNull);
+    });
+  });
+
+  group('the probe', () {
+    test('records on demand without needing a real clock', () {
+      final probe = MemoryProbe();
+      addTearDown(probe.dispose);
+
+      probe.sample();
+      probe.sample();
+
+      expect(probe.stats.samples, 2);
+      expect(probe.isRunning, false, reason: 'sampling is not starting');
+    });
+
+    test('reset clears history so a run starts from a known point', () {
+      final probe = MemoryProbe();
+      addTearDown(probe.dispose);
+      probe.sample();
+
+      probe.reset();
+
+      expect(probe.stats.samples, 0);
+      expect(probe.stats.peakRssBytes, 0);
+    });
+
+    test('starting twice does not sample twice as fast', () {
+      final probe = MemoryProbe();
+      addTearDown(probe.dispose);
+
+      probe.start();
+      final after = probe.stats.samples;
+      probe.start();
+
+      expect(probe.isRunning, true);
+      expect(probe.stats.samples, after, reason: 'the second start is a no-op');
+    });
+  });
+
+  group('showing a number on a television', () {
+    test('reads at a glance from across the room', () {
+      expect(formatBytes(0), '0 MB');
+      expect(formatBytes(512), '512 B', reason: 'not rounded up to 1 KB');
+      expect(formatBytes(64 << 10), '64 KB');
+      expect(formatBytes(64 << 20), '64.0 MB');
+      expect(formatBytes(1500 << 20), '1500 MB');
+    });
+  });
+}

--- a/test/widgets/memory_overlay_test.dart
+++ b/test/widgets/memory_overlay_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/widgets/memory_overlay.dart';
+import 'package:mangayomi/utils/memory_probe.dart';
+
+/// The readout has to be legible from a sofa and has to say the thing that
+/// decides the question: whether the cache is spending its time full.
+void main() {
+  Future<void> pump(WidgetTester tester, MemoryProbe probe) =>
+      tester.pumpWidget(
+        MaterialApp(
+          home: Stack(
+            children: [MemoryOverlay(probe: probe, onClose: () {})],
+          ),
+        ),
+      );
+
+  testWidgets('says so plainly before the first sample', (tester) async {
+    final probe = MemoryProbe();
+    addTearDown(probe.dispose);
+
+    await pump(tester, probe);
+
+    expect(find.textContaining('waiting for a sample'), findsOneWidget);
+  });
+
+  testWidgets('shows RSS, the cache and how full it is', (tester) async {
+    final probe = MemoryProbe();
+    addTearDown(probe.dispose);
+    probe.sample();
+
+    await pump(tester, probe);
+
+    expect(find.textContaining('RSS'), findsOneWidget);
+    expect(find.textContaining('cache'), findsOneWidget);
+    expect(find.textContaining('items'), findsOneWidget);
+    expect(find.textContaining('% of'), findsOneWidget);
+  });
+
+  testWidgets('redraws as samples arrive, or it is not a live readout', (
+    tester,
+  ) async {
+    final probe = MemoryProbe();
+    addTearDown(probe.dispose);
+    probe.sample();
+    await pump(tester, probe);
+    expect(find.textContaining('of 1 samples'), findsOneWidget);
+
+    probe.sample();
+    await tester.pump();
+
+    expect(find.textContaining('of 2 samples'), findsOneWidget);
+  });
+
+  testWidgets('reset puts the count back so a run starts clean', (
+    tester,
+  ) async {
+    final probe = MemoryProbe();
+    addTearDown(probe.dispose);
+    probe.sample();
+    await pump(tester, probe);
+
+    await tester.tap(find.text('Reset'));
+    await tester.pump();
+
+    expect(find.textContaining('waiting for a sample'), findsOneWidget);
+  });
+
+  testWidgets('without a close button it does not eat taps meant for the app', (
+    tester,
+  ) async {
+    // It sits over the whole app, so it must not swallow input when it is
+    // only there to be read.
+    final probe = MemoryProbe();
+    addTearDown(probe.dispose);
+    probe.sample();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Stack(children: [MemoryOverlay(probe: probe)]),
+      ),
+    );
+
+    // MaterialApp puts its own IgnorePointers in the tree, so scope to ours.
+    final ignore = tester.widget<IgnorePointer>(
+      find
+          .descendant(
+            of: find.byType(MemoryOverlay),
+            matching: find.byType(IgnorePointer),
+          )
+          .first,
+    );
+    expect(ignore.ignoring, true);
+  });
+}

--- a/test/widgets/memory_overlay_test.dart
+++ b/test/widgets/memory_overlay_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mangayomi/modules/widgets/memory_overlay.dart';
 import 'package:mangayomi/utils/memory_probe.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
 /// The readout has to be legible from a sofa and has to say the thing that
 /// decides the question: whether the cache is spending its time full.
@@ -64,6 +65,37 @@ void main() {
     await tester.pump();
 
     expect(find.textContaining('waiting for a sample'), findsOneWidget);
+  });
+
+  testWidgets('on a TV it offers no buttons a d-pad cannot reach', (
+    tester,
+  ) async {
+    // It sits in a Stack above the whole app rather than inside its focus
+    // traversal, so a remote can never land on those buttons. Showing them
+    // would be two controls that look live and are not.
+    debugIsTvOverride = true;
+    addTearDown(() => debugIsTvOverride = null);
+    final probe = MemoryProbe();
+    addTearDown(probe.dispose);
+    probe.sample();
+
+    await pump(tester, probe);
+
+    expect(find.text('Reset'), findsNothing);
+    expect(find.text('Hide'), findsNothing);
+    expect(find.textContaining('toggle it off and on'), findsOneWidget);
+  });
+
+  testWidgets('and still offers them where there is a pointer', (tester) async {
+    debugIsTvOverride = false;
+    addTearDown(() => debugIsTvOverride = null);
+    final probe = MemoryProbe();
+    addTearDown(probe.dispose);
+    probe.sample();
+
+    await pump(tester, probe);
+
+    expect(find.text('Reset'), findsOneWidget);
   });
 
   testWidgets('without a close button it does not eat taps meant for the app', (


### PR DESCRIPTION
Two questions keep coming up about low-RAM devices and televisions, and neither can be answered from a desktop:

1. What should the image cache budget be?
2. Would decoding reader pages smaller than their source resolution help?

Both depend on numbers only the device has. Guessing at them is how the wrong thing gets optimised, which has already happened once here: the obvious cause of the reader jank in #835 turned out not to be the cause.

**What this adds**

A readout, switched on from General settings, that sits over the app while somebody scrolls the library or reads a chapter on the device itself. It shows:

- resident set size, current and peak, which is what the OS says the process is using, which is the number that actually matters on a constrained box
- the image cache against **both** its ceilings, bytes and count, with peaks
- how many images are genuinely on screen, so the gap to the cached count is visible
- the share of samples taken while the cache was full

**That last figure is the one that decides things.** A cache pinned at its ceiling evicts on every decode and re-decodes what it just threw away, costing memory *and* producing jank. A cache sitting at half is not a problem however large the number looks. It turns amber past 50% so it reads at a glance from a sofa.

**Two things that fell out of writing it**

- `imageCache.maximumSize`, the *count* ceiling, is never set anywhere, so it is Flutter's default of 1000 entries.
- `maximumSizeBytes` is chosen in `main()` about thirty lines before `initIsTv()` runs, so a television is handed a phone's budget and there is currently no way to give it anything else.

Neither is changed here. Both are the kind of thing that should follow a measurement rather than precede it.

**Deliberately not persisted.** It is a measuring tool, not a preference. That also keeps it out of the settings row and avoids a schema change for something meant to answer a question and then stop.

**Testing**

Ten unit tests on the sampling and the statistics, including that peaks survive a later dip and that an empty sample set is not a division by zero. Five widget tests on the readout itself, including that it redraws as samples arrive and that it does not swallow taps meant for the app underneath. Also confirmed against a real binding that `ProcessInfo.currentRss` returns a real figure rather than zero.

