### PR TITLE
fix: stop the library disposing a TabController the tabs still paint from

### DIFF
--- a/lib/modules/library/library_screen.dart
+++ b/lib/modules/library/library_screen.dart
@@ -73,8 +73,30 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   void dispose() {
     _textEditingController.dispose();
     tabBarController?.dispose();
+    // Anything waiting for the end of a frame that will now never come.
+    for (final controller in _retiredTabControllers) {
+      controller.dispose();
+    }
+    _retiredTabControllers.clear();
     _searchDebounce?.cancel();
     super.dispose();
+  }
+
+  /// Controllers replaced this frame, disposed once nothing can still paint
+  /// from them.
+  final List<TabController> _retiredTabControllers = [];
+
+  /// Schedules [controller] for disposal after the current frame.
+  ///
+  /// Held in a list rather than disposed inline because the widgets built in
+  /// the previous frame still reference it until this frame is painted.
+  void _retireTabController(TabController? controller) {
+    if (controller == null) return;
+    _retiredTabControllers.add(controller);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_retiredTabControllers.remove(controller)) return;
+      controller.dispose();
+    });
   }
 
   @override
@@ -353,7 +375,13 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         (tabBarController == null || tabBarController!.length != tabCount)) {
       int newTabIndex = _tabIndex;
       if (newTabIndex >= tabCount) newTabIndex = tabCount - 1;
-      tabBarController?.dispose();
+      // Retire the old one after this frame rather than here. Disposing a
+      // TabController sets its animation to null, and the TabBar built in the
+      // previous frame is still holding this one: its _IndicatorPainter reads
+      // `controller.animation!.value` on the next paint and dies on the null
+      // check. That is #923, reported from the library screen with exactly
+      // that frame at the top of the stack.
+      _retireTabController(tabBarController);
       tabBarController = TabController(
         length: tabCount,
         vsync: this,

--- a/test/widgets/tab_controller_retire_test.dart
+++ b/test/widgets/tab_controller_retire_test.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// #923: "Null check operator used on a null value" at
+/// `_IndicatorPainter.paint (tabs.dart:633)`, reported from the library.
+///
+/// That line is `controller.animation!.value`, and `TabController.dispose()`
+/// sets `_animationController = null`, so `animation` returns null afterwards.
+/// The library rebuilt its TabController whenever the category count changed
+/// and disposed the old one **inside build**, while the TabBar from the
+/// previous frame was still holding it.
+///
+/// These pin the Flutter behaviour the fix depends on, and the shape of the
+/// fix, without needing the whole library screen and its providers.
+void main() {
+  testWidgets('a disposed TabController has no animation left to read', (
+    tester,
+  ) async {
+    late TabController controller;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _Host(
+          onInit: (c) => controller = c,
+          child: (c) => TabBar(
+            controller: c,
+            tabs: const [Tab(text: 'a')],
+          ),
+        ),
+      ),
+    );
+
+    expect(controller.animation, isNotNull);
+    controller.dispose();
+
+    // This is the value tabs.dart:633 dereferences with `!`.
+    expect(controller.animation, isNull);
+  });
+
+  testWidgets('the replaced controller is still alive during that build', (
+    tester,
+  ) async {
+    // The property the fix rests on, checked from inside the build itself:
+    // one pump runs build, paint and post-frame callbacks together, so from
+    // outside the disposal has already happened by the time the test looks.
+    // What matters is that it had not happened *yet* while the tree was being
+    // built, because that is when the old TabBar still holds it.
+    await tester.pumpWidget(const MaterialApp(home: _Swapper()));
+
+    await tester.tap(find.text('swap'));
+    await tester.pump();
+
+    expect(
+      _SwapperState.current!.oldAliveDuringBuild,
+      isTrue,
+      reason:
+          'disposed in build, and the next paint reads null at tabs.dart:633',
+    );
+  });
+
+  testWidgets('and disposes it once the frame is done, so nothing leaks', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: _Swapper()));
+    final old = _SwapperState.current!.controller!;
+
+    await tester.tap(find.text('swap'));
+    await tester.pump();
+    await tester.pump(); // post-frame callbacks run
+
+    expect(old.animation, isNull, reason: 'retired, not kept forever');
+  });
+
+  testWidgets('a controller still waiting when the screen goes is disposed', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: _Swapper()));
+    final old = _SwapperState.current!.controller!;
+
+    await tester.tap(find.text('swap'));
+    await tester.pump();
+    // Torn down before the post-frame callback could run.
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+
+    expect(old.animation, isNull);
+  });
+}
+
+class _Host extends StatefulWidget {
+  const _Host({required this.onInit, required this.child});
+  final void Function(TabController) onInit;
+  final Widget Function(TabController) child;
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> with TickerProviderStateMixin {
+  late final TabController controller = TabController(length: 1, vsync: this);
+  @override
+  void initState() {
+    super.initState();
+    widget.onInit(controller);
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    appBar: AppBar(
+      bottom: PreferredSize(
+        preferredSize: const Size.fromHeight(48),
+        child: widget.child(controller),
+      ),
+    ),
+  );
+}
+
+/// Rebuilds its TabController with a different length, the way the library
+/// does when the category count changes.
+class _Swapper extends StatefulWidget {
+  const _Swapper();
+  @override
+  State<_Swapper> createState() => _SwapperState();
+}
+
+class _SwapperState extends State<_Swapper> with TickerProviderStateMixin {
+  static _SwapperState? current;
+  int _length = 2;
+  TabController? _controller;
+  TabController? get controller => _controller;
+
+  /// Whether the controller being replaced was still usable at the moment the
+  /// tree was rebuilt without it.
+  bool? oldAliveDuringBuild;
+  final _retired = <TabController>[];
+
+  @override
+  void initState() {
+    super.initState();
+    current = this;
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    for (final c in _retired) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_controller == null || _controller!.length != _length) {
+      // The same shape as library_screen: retire rather than dispose inline.
+      final old = _controller;
+      if (old != null) {
+        // Recorded here because this is the only moment it can be observed.
+        oldAliveDuringBuild = old.animation != null;
+        _retired.add(old);
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (_retired.remove(old)) old.dispose();
+        });
+      }
+      _controller = TabController(length: _length, vsync: this);
+    }
+
+    return Scaffold(
+      body: Column(
+        children: [
+          TabBar(
+            controller: _controller,
+            tabs: [for (var i = 0; i < _length; i++) Tab(text: '$i')],
+          ),
+          TextButton(
+            onPressed: () => setState(() => _length = 3),
+            child: const Text('swap'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Fixes #923.

The report is "Null check operator used on a null value" at `_IndicatorPainter.paint`, `tabs.dart:633`, from the library screen on 0.8.9. It came through the crash reporter with a full stack, which is what made it findable.

**What that line is**

```dart
final double value = controller.animation!.value;   // tabs.dart:633
```

and `TabController.dispose()` does:

```dart
_animationController?.dispose();
_animationController = null;      // so `animation` returns null from here on
```

**What the library was doing**

`library_screen.dart` rebuilt its `TabController` whenever the category count changed, and disposed the old one **inside `build`**:

```dart
if (tabCount > 0 && (tabBarController == null || tabBarController!.length != tabCount)) {
  ...
  tabBarController?.dispose();     // <- during build
  tabBarController = TabController(length: tabCount, ...);
```

The `TabBar` built in the previous frame is still holding that controller while the frame paints, so the next paint reads the null and dies. Category counts change on adding or removing a category, on hiding one, and on the default category appearing or disappearing as items become uncategorised, so it is not a rare path.

**The fix**

The old controller is retired rather than disposed: kept until the end of the frame and disposed from a post-frame callback, by which point nothing can still paint from it. Any still waiting when the screen goes away are disposed with it, so it does not leak either.

**Testing**

Four tests, and I want to be straight about what they do and do not cover.

They pin the Flutter behaviour the fix rests on, that a disposed `TabController` has no `animation` left to read, and they check that the controller being replaced is still usable at the moment the tree is rebuilt without it. That last one is recorded from *inside* the build, because a single `pump()` runs build, paint and post-frame callbacks together, so from outside the disposal has already happened by the time a test can look.

I first wrote a test that claimed to reproduce the crash itself and it did not fail against the old code. The real thing is a paint-timing race I could not stage reliably. Rather than ship a test that asserts something it is not really testing, I dropped it and pinned the properties I can actually observe. The mechanism above is read from Flutter's own source rather than inferred.

