### PR TITLE
fix: stop using the player after the reader has left it

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -912,6 +912,12 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     _completed;
     _currentTotalDurationSub;
     _loadAndroidFont().then((_) {
+      // Loading the subtitle font writes a file, so this callback can arrive
+      // after the reader has already left. Everything below it touches the
+      // player, and media_kit asserts "[Player] has been disposed" the moment
+      // it is used after dispose. That is #925. The torrent branch further
+      // down already checked for this; the path everyone takes did not.
+      if (!mounted) return;
       _openMedia(_video.value!, _streamController.getCurrentPosition());
       if (widget.isTorrent) {
         Future.delayed(const Duration(seconds: 10)).then((_) {
@@ -957,7 +963,10 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
         _player.stream.duration
             .firstWhere((d) => d > Duration.zero)
             .timeout(const Duration(seconds: 8))
-            .then((_) => _player.seek(start))
+            // Up to eight seconds after the media opened, which is long
+            // enough for the reader to have gone. Seeking a disposed player
+            // reaches native state that has already been torn down.
+            .then((_) => mounted ? _player.seek(start) : null)
             .catchError((_) {}),
       );
     }
@@ -988,7 +997,9 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
   }
 
   Future<void> _initAniSkip() async {
+    // Waits for the media to buffer, which the reader can outlast.
     await _player.stream.buffer.first;
+    if (!mounted) return;
     _streamController.getAniSkipResults((result) {
       final openingRes = result
           .where((element) => element.skipType == "op")

--- a/test/modules/player_after_dispose_test.dart
+++ b/test/modules/player_after_dispose_test.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// #925 is `Assertion failed: "[Player] has been disposed"`.
+///
+/// media_kit guards every entry point with `if (disposed) throw
+/// AssertionError('[Player] has been disposed')`, so that message means the
+/// app used the player after tearing it down. The player view starts its
+/// playback by chaining off an async font load:
+///
+/// ```dart
+/// _loadAndroidFont().then((_) {
+///   _openMedia(...);          // -> _player.open()
+///   _setPlaybackSpeed(...);   // -> _player.setRate()
+///   _initAniSkip();           // -> _player.stream...
+/// });
+/// ```
+///
+/// Loading the font writes a file, so that callback can land after the reader
+/// has already pressed back. These cover the shape of that, since the real
+/// widget needs a video, a native player and a source to build at all.
+void main() {
+  testWidgets('a pending callback fires after the widget is gone', (
+    tester,
+  ) async {
+    // The premise. If this were not true there would be nothing to guard.
+    final completer = Completer<void>();
+    var firedAfterDisposal = false;
+    late _ProbeState state;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _Probe(
+          work: completer.future,
+          onDone: (s) {
+            if (!s.mounted) firedAfterDisposal = true;
+          },
+          onState: (s) => state = s,
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    expect(state.mounted, false, reason: 'the reader has left');
+
+    completer.complete();
+    await tester.pump();
+
+    expect(firedAfterDisposal, true);
+  });
+
+  testWidgets('guarding on mounted keeps it off the disposed player', (
+    tester,
+  ) async {
+    final completer = Completer<void>();
+    var touchedPlayer = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _Probe(
+          work: completer.future,
+          // The shape the fix uses: bail before anything touches the player.
+          onDone: (s) {
+            if (!s.mounted) return;
+            touchedPlayer = true;
+          },
+          onState: (_) {},
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    completer.complete();
+    await tester.pump();
+
+    expect(touchedPlayer, false);
+  });
+
+  testWidgets('and still runs normally when the reader stays', (tester) async {
+    final completer = Completer<void>();
+    var touchedPlayer = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _Probe(
+          work: completer.future,
+          onDone: (s) {
+            if (!s.mounted) return;
+            touchedPlayer = true;
+          },
+          onState: (_) {},
+        ),
+      ),
+    );
+
+    completer.complete();
+    await tester.pump();
+
+    expect(touchedPlayer, true, reason: 'the guard must not break the app');
+  });
+}
+
+/// Stands in for the player view: kicks off async work in initState and acts
+/// on it when it finishes.
+class _Probe extends StatefulWidget {
+  const _Probe({
+    required this.work,
+    required this.onDone,
+    required this.onState,
+  });
+  final Future<void> work;
+  final void Function(_ProbeState) onDone;
+  final void Function(_ProbeState) onState;
+  @override
+  State<_Probe> createState() => _ProbeState();
+}
+
+class _ProbeState extends State<_Probe> {
+  @override
+  void initState() {
+    super.initState();
+    widget.onState(this);
+    widget.work.then((_) => widget.onDone(this));
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}


### PR DESCRIPTION
Fixes #925.

The report is `Assertion failed: "[Player] has been disposed"`. media_kit guards every entry point with

```dart
if (disposed) {
  throw AssertionError('[Player] has been disposed');
}
```

so that message means the app used the player after tearing it down.

**Where**

The player view starts playback by chaining off an async font load:

```dart
_loadAndroidFont().then((_) {
  _openMedia(...);         // -> _player.open()
  _setPlaybackSpeed(...);  // -> _player.setRate()
  _initAniSkip();          // -> _player.stream...
});
```

Loading that font writes a file to disk, so the callback can land after the reader has already pressed back, and every line in it touches the player.

What makes this fairly clear-cut: the torrent branch **nested inside that same callback** already does `if (mounted)`. So the callback was known to be able to outlive the widget. The guard just went on the ten-second delay, which looks risky, rather than on the path everyone takes, which looks instant and is not.

**Two more of the same shape**, both fixed here:

- the resume seek waits up to **eight seconds** for the media to report a duration before seeking
- aniskip waits for the first buffer

Both are comfortably long enough for someone to press back first.

**Testing**

Three tests on the shape, since the real widget needs a video, a native player and a source before it will build at all. They cover that a pending callback really does fire after disposal (the premise: if that were not true there would be nothing to guard), that the guard keeps it off the player, and that it still runs normally when the reader stays. That last one matters: a guard that broke the ordinary path would be worse than the bug.

**Possible relationship to #902**

#902 is a native SIGSEGV on Linux that happens *only while a video is actively playing*, never when paused. Opening or seeking a disposed player reaches native state that has already been torn down, which is a plausible route to a segfault rather than a Dart assertion. I am not claiming this fixes it. The crash is unsymbolised and I cannot reproduce it, and #902 should stay open until its reporter confirms either way. But if the reports stop after this ships, that is the likely reason.

