### PR TITLE
fix: track anime on Simkl as anime, not as a TV show

### DIFF
--- a/lib/services/trackers/simkl.dart
+++ b/lib/services/trackers/simkl.dart
@@ -18,6 +18,21 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'simkl.g.dart';
 
 @riverpod
+/// Which Simkl library a mangayomi library maps to.
+///
+/// Simkl keeps anime apart from tv, with their own endpoints. Asking the tv
+/// ones for an anime is why tracked entries landed under TV Shows (#922):
+/// searching `/search/tv` for "frieren" returns nothing, while
+/// `/search/anime` returns the series.
+///
+/// Manga stays mapped onto movies, which is what it already did. Simkl has no
+/// manga library and changing that is a separate question.
+String simklMediaType(bool isManga) => isManga ? "movies" : "anime";
+
+/// The same choice where Simkl uses the singular: a search path and a public
+/// URL.
+String simklSearchType(bool isManga) => isManga ? "tv" : "anime";
+
 class Simkl extends _$Simkl implements BaseTracker {
   final http = MClient.init(reqcopyWith: {'useDartHttpClient': true});
   static const _baseOAuthUrl = 'https://simkl.com/oauth';
@@ -73,7 +88,9 @@ class Simkl extends _$Simkl implements BaseTracker {
     String rankingType = "trending",
   }) async {
     /// isManga <> isMovie
-    final type = isManga ? "movies" : "tv";
+    // Simkl keeps anime apart from tv, with its own endpoints. Asking the tv
+    // ones for an anime is why entries landed under TV Shows (#922).
+    final type = simklMediaType(isManga);
     final accessToken = await _getAccessToken();
     final url = Uri.parse('$_baseApiUrl/$type/$rankingType').replace(
       queryParameters: {
@@ -113,14 +130,16 @@ class Simkl extends _$Simkl implements BaseTracker {
 
   @override
   Future<List<TrackSearch>> fetchUserData({bool isManga = true}) async {
-    final type = isManga ? "movies" : "shows";
-    final nodeType = isManga ? "movie" : "show";
+    final type = simklMediaType(isManga);
     final accessToken = await _getAccessToken();
     final url = Uri.parse('$_baseApiUrl/sync/all-items/$type');
     final result = await _makeGetRequest(url, accessToken);
     final data = jsonDecode(result.body) as Map<String, dynamic>?;
     return (data?[type] as List?)?.map((e) {
-          final node = e[nodeType];
+          // Simkl models anime as shows internally, so an entry under the
+          // anime key can still arrive with a "show" node. Accept either
+          // rather than depend on which one this account happens to get.
+          final node = e['anime'] ?? e['show'] ?? e['movie'];
           return TrackSearch(
             mediaId: node['ids']?['simkl'],
             summary: 'No summary available.',
@@ -131,7 +150,7 @@ class Simkl extends _$Simkl implements BaseTracker {
             title: node['title'] ?? 'Unknown Title',
             score: 0,
             startDate: "",
-            publishingType: isManga ? "movie" : "tv",
+            publishingType: isManga ? "movie" : "anime",
             publishingStatus: e["status"],
             trackingUrl: "https://simkl.com/$type/${node['ids']?['simkl']}",
             syncId: syncId,
@@ -209,14 +228,15 @@ class Simkl extends _$Simkl implements BaseTracker {
           );
         }).toList() ??
         [];
-    final urlSeries = Uri.parse('$_baseApiUrl/search/tv').replace(
-      queryParameters: {
-        'q': query,
-        'extended': 'full',
-        'clientId': _clientId,
-        'limit': '15',
-      },
-    );
+    final urlSeries =
+        Uri.parse('$_baseApiUrl/search/${simklSearchType(isManga)}').replace(
+          queryParameters: {
+            'q': query,
+            'extended': 'full',
+            'clientId': _clientId,
+            'limit': '15',
+          },
+        );
     final resultSeries = await _makeGetRequest(urlSeries, accessToken);
     final dataSeries = jsonDecode(resultSeries.body) as List?;
     final series =
@@ -231,10 +251,10 @@ class Simkl extends _$Simkl implements BaseTracker {
             title: e['title'] ?? 'Unknown Title',
             score: (e["ratings"]?["simkl"]?["rating"] as num?)?.toDouble(),
             startDate: e["release_date"] ?? "",
-            publishingType: "tv",
+            publishingType: simklSearchType(isManga),
             publishingStatus: e["status"],
             trackingUrl:
-                "https://simkl.com/tv/${e['ids']?['simkl_id'] ?? e['ids']?['simkl']}",
+                "https://simkl.com/${simklSearchType(isManga)}/${e['ids']?['simkl_id'] ?? e['ids']?['simkl']}",
             syncId: syncId,
           );
         }).toList() ??

--- a/test/services/simkl_endpoints_test.dart
+++ b/test/services/simkl_endpoints_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/trackers/simkl.dart';
+
+/// #922: tracking an anime with Simkl filed it under TV Shows.
+///
+/// Simkl keeps anime apart from tv, with their own endpoints, and the tracker
+/// asked the tv ones for everything that was not manga. Checked against the
+/// live API while fixing this: `/search/tv?q=frieren` returns zero rows,
+/// `/search/anime?q=frieren` returns "Sousou no Frieren".
+///
+/// These call the functions the tracker itself uses to build its URLs, so a
+/// regression here is a regression there. The requests are not exercised —
+/// that needs an account and a token.
+void main() {
+  group('an anime', () {
+    test('goes to the anime endpoints, not the tv ones', () {
+      expect(simklMediaType(false), 'anime');
+      expect(simklSearchType(false), 'anime');
+    });
+
+    test('so its search path and public URL both say anime', () {
+      expect('/search/${simklSearchType(false)}', '/search/anime');
+      expect(
+        'https://simkl.com/${simklSearchType(false)}/12345',
+        'https://simkl.com/anime/12345',
+      );
+    });
+
+    test('and its trending and library lists do too', () {
+      expect('/${simklMediaType(false)}/trending', '/anime/trending');
+      expect(
+        '/sync/all-items/${simklMediaType(false)}',
+        '/sync/all-items/anime',
+      );
+    });
+  });
+
+  group('manga', () {
+    test('is left exactly where it was', () {
+      // Simkl has no manga library; the tracker maps it onto movies, and this
+      // fix is not the place to revisit that.
+      expect(simklMediaType(true), 'movies');
+      expect(simklSearchType(true), 'tv');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #922.

Simkl keeps anime apart from tv, with their own endpoints. The tracker asked the tv ones for everything that was not manga. `search()` took an `isManga` argument and then never used it, querying `/search/movies` and `/search/tv` either way.

**Checked against the live API** while fixing it:

| request | result |
| --- | --- |
| `/search/tv?q=frieren` | **0 rows** |
| `/search/anime?q=frieren` | Sousou no Frieren |

So an anime was either not found at all, or matched against whatever tv row came closest, and the entry it created pointed at `simkl.com/tv/...`. That is what the screenshots in the issue show.

**What changed**

Anime now uses `/search/anime`, `/anime/trending` and `/sync/all-items/anime`, and links to `simkl.com/anime/...`. All three endpoints were confirmed to exist, and for trending I compared the response fields against what the parser reads: `ids.simkl_id`, `poster`, `ratings`, `release_date` and `title` are all present on both.

Manga stays mapped onto movies exactly as before. Simkl has no manga library, and changing that is a separate question from this bug.

The type choice is now two small functions that the tracker calls in all five places it builds a URL, so the tests exercise the real thing rather than a copy of it. My first attempt at a test duplicated the mapping locally and would have passed no matter what the tracker did; extracting the functions is what made it worth having.

**One thing I could not verify.** `/sync/all-items/anime` needs an account, so I could not confirm whether an anime row arrives with an `"anime"` node or a `"show"` node, since Simkl models anime as shows internally so it may well be the latter. The parser now accepts either rather than guessing, which costs nothing and cannot break whichever one is real. Worth a sanity check from anyone with a connected Simkl account.

