### PR TITLE
feat: TV is only asked for source and nothing else on the welcome screen cus anime only gate now

### DIFF
--- a/lib/modules/onboarding/onboarding_screen.dart
+++ b/lib/modules/onboarding/onboarding_screen.dart
@@ -95,13 +95,19 @@ class _OnboardingScreenState extends ConsumerState<_OnboardingBody>
     with WidgetsBindingObserver {
   final _controller = TextEditingController();
 
-  _Step _step = _Step.libraries;
+  _Step _step = _firstStep;
 
   /// Which way the last step change went, so the new words arrive from the
   /// side they came from. Going back animating like going forward is what made
   /// the movement feel arbitrary.
   bool _forward = true;
-  final Set<ItemType> _libraries = {...ItemType.values};
+
+  /// A television only ever reads anime, so the question is not asked there
+  /// and this is the answer. Everywhere else it starts with everything ticked
+  /// and the reader narrows it.
+  final Set<ItemType> _libraries = isTv
+      ? {ItemType.anime}
+      : {...ItemType.values};
   bool _mergeLibraries = false;
   ItemType _repoType = ItemType.manga;
 
@@ -168,6 +174,15 @@ class _OnboardingScreenState extends ConsumerState<_OnboardingBody>
     // registers after the router, so it gets first refusal for as long as it
     // is on screen.
     WidgetsBinding.instance.addObserver(this);
+    // A television never visits the library step, so the step that would have
+    // written the choice never runs. Write it here instead, or the answer the
+    // flow made on the reader's behalf would be silently dropped and manga and
+    // novel would stay in the rail.
+    if (isTv) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _applyLibraries();
+      });
+    }
   }
 
   @override
@@ -182,7 +197,7 @@ class _OnboardingScreenState extends ConsumerState<_OnboardingBody>
   /// nothing behind it, so it does nothing and Skip stays the way out.
   @override
   Future<bool> didPopRoute() async {
-    if (!_adding && _step != _Step.libraries) _back();
+    if (!_adding && _step != _firstStep) _back();
     return true;
   }
 
@@ -209,10 +224,15 @@ class _OnboardingScreenState extends ConsumerState<_OnboardingBody>
   /// Not a constant: the arrange step drops out for a single library or a wide
   /// window, so the flow is two steps long as often as three.
   List<_Step> get _visibleSteps => [
-    _Step.libraries,
+    if (!isTv) _Step.libraries,
     if (_shouldArrangeBar) _Step.navigation,
     _Step.repository,
   ];
+
+  /// Where the flow starts. A television skips straight to the source, because
+  /// the two questions before it have one answer each there: anime, and a rail
+  /// rather than a bar.
+  static _Step get _firstStep => isTv ? _Step.repository : _Step.libraries;
 
   /// Whether the arrange step has anything to offer.
   ///
@@ -396,7 +416,7 @@ class _OnboardingScreenState extends ConsumerState<_OnboardingBody>
       _forward = false;
       _step = _step == _Step.repository && _shouldArrangeBar
           ? _Step.navigation
-          : _Step.libraries;
+          : _firstStep;
     });
   }
 
@@ -488,7 +508,7 @@ class _OnboardingScreenState extends ConsumerState<_OnboardingBody>
             _content(l10n, theme),
             // A way back to change an earlier answer. Absent on the first
             // step, where there is nothing behind it.
-            if (_step != _Step.libraries)
+            if (_step != _firstStep)
               Align(
                 alignment: AlignmentDirectional.topStart,
                 child: Padding(

--- a/test/widgets/onboarding_screen_test.dart
+++ b/test/widgets/onboarding_screen_test.dart
@@ -528,20 +528,40 @@ void main() {
   });
 
   group('on a TV', () {
-    setUp(() => debugIsTvOverride = true);
+    setUp(() {
+      debugIsTvOverride = true;
+      _StubHideItems.lastSet = null;
+    });
 
-    testWidgets('chooses with pills, not chips', (tester) async {
+    testWidgets('never asks which libraries, it is a television', (
+      tester,
+    ) async {
+      // Nobody reads manga on a television, so the question has one answer and
+      // is not worth a screen of d-pad presses. The flow opens on the source.
       await pump(tester);
-      // A chip row is not reliably reachable with a d-pad.
+
+      expect(find.byType(TvPill), findsNothing);
       expect(find.byType(FilterChip), findsNothing);
-      expect(find.byType(TvPill), findsNWidgets(ItemType.values.length));
+      expect(find.byType(TextField), findsOneWidget, reason: 'the repo step');
+    });
+
+    testWidgets('and hides the libraries it did not choose', (tester) async {
+      // The step that writes that choice is the one being skipped, so it has
+      // to be written anyway or manga and novel stay in the rail.
+      await pump(tester);
+      await tester.pumpAndSettle();
+
+      final hidden = _StubHideItems.lastSet;
+      expect(hidden, isNotNull, reason: 'the choice was written at all');
+      expect(hidden, contains('/MangaLibrary'));
+      expect(hidden, contains('/NovelLibrary'));
+      expect(hidden, isNot(contains('/AnimeLibrary')));
     });
 
     testWidgets('the url field takes focus, so OK opens the keyboard', (
       tester,
     ) async {
       await pump(tester);
-      await toRepoStep(tester);
       final field = tester.widget<TextField>(find.byType(TextField));
       expect(field.autofocus, isTrue);
     });
@@ -550,7 +570,6 @@ void main() {
       tester,
     ) async {
       await pump(tester);
-      await toRepoStep(tester);
       // Typing a url on a remote is miserable; leaving now has to look like a
       // real option rather than a failure.
       expect(
@@ -595,11 +614,19 @@ class _StubLocalFolders extends LocalFoldersState {
 }
 
 class _StubHideItems extends HideItemsState {
+  /// What the screen last wrote. Captured because the provider is autoDispose:
+  /// reading it back after nothing is listening rebuilds it and the write is
+  /// gone, which made an earlier version of this test look like a failure.
+  static List<String>? lastSet;
+
   @override
   List<String> build() => const ['/trackerLibrary'];
 
   @override
-  void set(List<String> values) => state = values;
+  void set(List<String> values) {
+    lastSet = values;
+    state = values;
+  }
 }
 
 class _StubMergeNav extends MergeLibraryNavMobileState {


### PR DESCRIPTION
Found while testing the first run on a Fire TV.

The welcome screen asked a television the same three questions it asks a phone, and two of them have exactly one answer there.

**Libraries.** Nobody reads manga on a television. Asking costs a screen of d-pad presses to arrive at anime.

**Arrange the bar.** Already skipped on TV, and for a good reason: the setting it writes is read as `mergeLibraryNavMobile && !context.isTablet`, so on anything 600dp or wider the answer would have been stored and then ignored.

So a television now opens directly on the source step, which is the only one with a real answer, and where the url field already takes focus so OK opens the keyboard.

**The catch, which the test caught.** The step that writes the library choice is the one being skipped, so the choice the flow made on the reader's behalf was silently dropped and manga and novel stayed in the rail. It is written from `initState` instead. Back navigation follows the same change: the first step is no longer always `libraries`, so both the back arrow and the system back button key off whichever step the flow actually starts on.

**Scope.** This is the welcome screen only. The app still renders manga and novel grids on a TV if you navigate to them, and only the anime library gets the dedicated d-pad home. Making the whole TV UI anime-only is a bigger change and a separate decision; this stops the first run from asking a question whose answer is already known.

**Testing.** Two of the existing TV tests asserted the old behaviour and now assert the new one, plus a test that the skipped choice is still persisted. That last one reads what the screen wrote through the stub rather than through the provider, because the provider is autoDispose: reading it back once nothing is listening rebuilds it and loses the write, which made a first version of the test look like a failure when the code was correct.
