### PR TITLE
feat: show what a title is related to, and open it in your sources

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1273,5 +1273,14 @@
       }
     }
   },
-  "missing_source_check_result_message": "These library entries point at a source that isn't installed on this device. Tap one to migrate it to an installed source, install the matching extension, or use \"Delete a source & its manga\" to remove them."
+  "missing_source_check_result_message": "These library entries point at a source that isn't installed on this device. Tap one to migrate it to an installed source, install the matching extension, or use \"Delete a source & its manga\" to remove them.",
+  "related_titles": "Related",
+  "related_none": "Nothing related was found for this title.",
+  "relation_adaptation": "Adaptation",
+  "relation_sequel": "Sequel",
+  "relation_prequel": "Prequel",
+  "relation_parent": "Parent story",
+  "relation_side_story": "Side story",
+  "relation_spin_off": "Spin-off",
+  "relation_alternative": "Alternative version"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -5782,6 +5782,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'These library entries point at a source that isn\'t installed on this device. Tap one to migrate it to an installed source, install the matching extension, or use \"Delete a source & its manga\" to remove them.'**
   String get missing_source_check_result_message;
+
+  /// No description provided for @related_titles.
+  ///
+  /// In en, this message translates to:
+  /// **'Related'**
+  String get related_titles;
+
+  /// No description provided for @related_none.
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing related was found for this title.'**
+  String get related_none;
+
+  /// No description provided for @relation_adaptation.
+  ///
+  /// In en, this message translates to:
+  /// **'Adaptation'**
+  String get relation_adaptation;
+
+  /// No description provided for @relation_sequel.
+  ///
+  /// In en, this message translates to:
+  /// **'Sequel'**
+  String get relation_sequel;
+
+  /// No description provided for @relation_prequel.
+  ///
+  /// In en, this message translates to:
+  /// **'Prequel'**
+  String get relation_prequel;
+
+  /// No description provided for @relation_parent.
+  ///
+  /// In en, this message translates to:
+  /// **'Parent story'**
+  String get relation_parent;
+
+  /// No description provided for @relation_side_story.
+  ///
+  /// In en, this message translates to:
+  /// **'Side story'**
+  String get relation_side_story;
+
+  /// No description provided for @relation_spin_off.
+  ///
+  /// In en, this message translates to:
+  /// **'Spin-off'**
+  String get relation_spin_off;
+
+  /// No description provided for @relation_alternative.
+  ///
+  /// In en, this message translates to:
+  /// **'Alternative version'**
+  String get relation_alternative;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -3208,4 +3208,31 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'تشير هذه العناصر إلى مصادر غير مثبتة. اضغط لنقلها أو ثبت الإضافة.';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -3207,4 +3207,31 @@ class AppLocalizationsAs extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'এই এণ্ট্ৰিসমূহ ইনষ্টল নথকা উৎসৰ সৈতে জড়িত। স্থানান্তৰ কৰিবলৈ টিপক বা এক্সটেনচন ইনষ্টল কৰক।';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -3239,4 +3239,31 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'Diese Einträge verweisen auf nicht installierte Quellen. Tippe auf einen Eintrag zur Migration oder installiere die Erweiterung.';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -3206,4 +3206,31 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'These library entries point at a source that isn\'t installed on this device. Tap one to migrate it to an installed source, install the matching extension, or use \"Delete a source & its manga\" to remove them.';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -3252,6 +3252,33 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'Estas entradas apuntan a una fuente no instalada en este dispositivo. Toca una para migrarla a una fuente instalada, instala la extensión correspondiente o usa \"Eliminar fuente y sus mangas\".';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -3259,4 +3259,31 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'Ces entrées de bibliothèque pointent vers une source non installée sur cet appareil. Touchez-en une pour la migrer vers une source installée, installez l\'extension correspondante ou utilisez « Supprimer une source et ses mangas » pour les retirer.';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -3211,4 +3211,31 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'ये प्रविष्टियां ऐसे स्रोत की ओर इशारा करती हैं जो स्थापित नहीं है। माइग्रेट करने के लिए टैप करें या एक्सटेंशन स्थापित करें।';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -3218,4 +3218,31 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'Entri ini mengarah ke sumber yang tidak terpasang. Ketuk untuk memigrasikan atau pasang ekstensi.';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -3246,4 +3246,31 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'Queste voci puntano a sorgenti non installate. Tocca per migrare o installare l\'estensione.';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -3134,4 +3134,31 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'これらの作品のソースがインストールされていません。移行するか拡張機能をインストールしてください。';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -3243,6 +3243,33 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'Estas entradas apontam para fontes não instaladas. Toque para migrar ou instale a extensão.';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -3258,4 +3258,31 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'Эти тайтлы привязаны к неустановленным источникам. Нажмите для миграции или установите расширение.';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -3195,4 +3195,31 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'รายการเหล่านี้เชื่อมโยงกับแหล่งที่มาที่ไม่ได้ติดตั้ง แตะเพื่อย้ายหรือติดตั้งส่วนขยาย';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -3220,4 +3220,31 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       'Bu girdiler yüklü olmayan kaynaklara işaret ediyor. Taşımak için dokunun veya eklentiyi yükleyin.';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -3092,4 +3092,31 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get missing_source_check_result_message =>
       '这些条目关联的图源未安装。点击可进行迁移或安装对应扩展。';
+
+  @override
+  String get related_titles => 'Related';
+
+  @override
+  String get related_none => 'Nothing related was found for this title.';
+
+  @override
+  String get relation_adaptation => 'Adaptation';
+
+  @override
+  String get relation_sequel => 'Sequel';
+
+  @override
+  String get relation_prequel => 'Prequel';
+
+  @override
+  String get relation_parent => 'Parent story';
+
+  @override
+  String get relation_side_story => 'Side story';
+
+  @override
+  String get relation_spin_off => 'Spin-off';
+
+  @override
+  String get relation_alternative => 'Alternative version';
 }

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -1677,6 +1677,36 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                     ),
                   ),
                   const SizedBox(height: 15),
+                  // Everything this title is related to, including the one
+                  // thing that cannot be reached any other way from in here:
+                  // its adaptation in the other medium.
+                  SizedBox(
+                    width: context.width(1),
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: OutlinedButton.icon(
+                        style: ButtonStyle(
+                          shape: WidgetStatePropertyAll(
+                            RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(30.0),
+                            ),
+                          ),
+                        ),
+                        onPressed: () {
+                          context.push(
+                            "/related",
+                            extra: (
+                              widget.manga!.name!,
+                              widget.manga!.itemType,
+                            ),
+                          );
+                        },
+                        label: Text(l10n.related_titles),
+                        icon: Icon(Icons.arrow_right_alt_outlined),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 15),
                   if (widget.manga!.itemType == ItemType.anime)
                     SizedBox(
                       width: context.width(1),

--- a/lib/modules/manga/detail/widgets/related_screen.dart
+++ b/lib/modules/manga/detail/widgets/related_screen.dart
@@ -17,12 +17,6 @@ import 'package:mangayomi/utils/platform_utils.dart';
 const double _coverWidth = 96;
 const double _coverHeight = 144;
 
-/// Cover plus the card's vertical padding.
-const double _cardExtent = _coverHeight + 12;
-
-/// One column on a phone, two above this, and never more than two.
-const double _twoColumnBreakpoint = 700;
-
 const double _alphaTint = 0.08;
 const double _alphaFocus = 0.14;
 const double _alphaSecondary = 0.70;
@@ -96,24 +90,15 @@ class _RelatedScreenState extends State<RelatedScreen> {
             )
           : (data == null || data!.isEmpty)
           ? Center(child: Text(l10n.related_none))
-          : LayoutBuilder(
-              builder: (context, constraints) {
-                final columns = constraints.maxWidth >= _twoColumnBreakpoint
-                    ? 2
-                    : 1;
-                return GridView.builder(
-                  padding: tvPageInsets,
-                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: columns,
-                    mainAxisExtent: _cardExtent,
-                    crossAxisSpacing: 10,
-                    mainAxisSpacing: 10,
-                  ),
-                  itemCount: data!.length,
-                  itemBuilder: (context, index) =>
-                      _card(context, data![index], index),
-                );
-              },
+          // One column, like the watch order this sits beside. The list is
+          // short, and an adaptation is meant to be read down the page rather
+          // than scanned across it.
+          : ListView.separated(
+              padding: tvPageInsets,
+              itemCount: data!.length,
+              separatorBuilder: (_, _) => const SizedBox(height: 4),
+              itemBuilder: (context, index) =>
+                  _card(context, data![index], index),
             ),
     );
   }

--- a/lib/modules/manga/detail/widgets/related_screen.dart
+++ b/lib/modules/manga/detail/widgets/related_screen.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mangayomi/l10n/generated/app_localizations.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/modules/widgets/error_state.dart';
+import 'package:mangayomi/modules/widgets/progress_center.dart';
+import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/services/related_titles.dart';
+import 'package:mangayomi/utils/cached_network.dart';
+import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/utils/item_type_localization.dart';
+
+/// Covers are 2:3, matching the recommendation screen so the two read as the
+/// same kind of list.
+const double _coverWidth = 64;
+const double _coverHeight = 96;
+
+/// What the manga being read is related to.
+///
+/// Opening one searches the sources installed for its medium, so an anime
+/// adaptation found here leads to somewhere it can actually be watched rather
+/// than to a database entry.
+class RelatedScreen extends StatefulWidget {
+  const RelatedScreen({super.key, required this.name, required this.itemType});
+
+  final String name;
+  final ItemType itemType;
+
+  @override
+  State<RelatedScreen> createState() => _RelatedScreenState();
+}
+
+class _RelatedScreenState extends State<RelatedScreen> {
+  late Future<List<RelatedTitle>> _future = _load();
+
+  Future<List<RelatedTitle>> _load() =>
+      fetchRelatedTitles(widget.name, widget.itemType);
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = l10nLocalizations(context)!;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.related_titles)),
+      body: FutureBuilder<List<RelatedTitle>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const ProgressCenter();
+          }
+          if (snapshot.hasError) {
+            return ErrorState(
+              // The real message, not "no result": a lookup that failed and a
+              // title with nothing related to it are different answers.
+              message: snapshot.error.toString(),
+              onRetry: () => setState(() => _future = _load()),
+            );
+          }
+
+          final titles = snapshot.data ?? const <RelatedTitle>[];
+          if (titles.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  l10n.related_none,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: context.secondaryColor),
+                ),
+              ),
+            );
+          }
+
+          return ListView.builder(
+            itemCount: titles.length,
+            itemBuilder: (context, index) =>
+                _RelatedTile(title: titles[index], from: widget.itemType),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RelatedTile extends StatelessWidget {
+  const _RelatedTile({required this.title, required this.from});
+
+  final RelatedTitle title;
+  final ItemType from;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = l10nLocalizations(context)!;
+    final cover = title.coverImage;
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      leading: SizedBox(
+        width: _coverWidth,
+        height: _coverHeight,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(6),
+          child: cover == null
+              ? Container(
+                  color: context.secondaryColor.withValues(alpha: 0.12),
+                  child: const Icon(Icons.image_not_supported_outlined),
+                )
+              : Image(
+                  image: coverProvider(cover),
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, _, _) =>
+                      const Icon(Icons.broken_image_outlined),
+                ),
+        ),
+      ),
+      title: Text(title.title),
+      subtitle: Text(
+        [
+          _relationLabel(l10n, title.relation),
+          if (title.format != null) _prettyFormat(title.format!),
+        ].join(' · '),
+        style: TextStyle(color: context.secondaryColor, fontSize: 12),
+      ),
+      // The medium is the thing worth spotting at a glance, so it is a chip
+      // rather than another line of prose.
+      trailing: title.crossesMedium(from)
+          ? Chip(
+              label: Text(
+                title.itemType.localized(l10n),
+                style: const TextStyle(fontSize: 11),
+              ),
+              visualDensity: VisualDensity.compact,
+            )
+          : null,
+      onTap: () =>
+          context.push('/globalSearch', extra: (title.title, title.itemType)),
+    );
+  }
+}
+
+/// Both services name relations the same way once upper-cased. Anything not
+/// named here is still shown, under a neutral label, rather than hidden.
+String _relationLabel(AppLocalizations l10n, String relation) =>
+    switch (relation) {
+      'ADAPTATION' => l10n.relation_adaptation,
+      'SEQUEL' => l10n.relation_sequel,
+      'PREQUEL' => l10n.relation_prequel,
+      'PARENT' => l10n.relation_parent,
+      'SIDE_STORY' => l10n.relation_side_story,
+      'SPIN_OFF' => l10n.relation_spin_off,
+      'ALTERNATIVE' ||
+      'ALTERNATIVE_SETTING' ||
+      'ALTERNATIVE_VERSION' => l10n.relation_alternative,
+      _ => l10n.related_titles,
+    };
+
+/// SIDE_STORY reads badly on a card; Side story does not.
+String _prettyFormat(String format) {
+  final words = format.toLowerCase().split('_');
+  return [
+    words.first.isEmpty
+        ? ''
+        : words.first[0].toUpperCase() + words.first.substring(1),
+    ...words.skip(1),
+  ].join(' ');
+}

--- a/lib/modules/manga/detail/widgets/related_screen.dart
+++ b/lib/modules/manga/detail/widgets/related_screen.dart
@@ -7,19 +7,31 @@ import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/related_titles.dart';
 import 'package:mangayomi/utils/cached_network.dart';
+import 'package:mangayomi/utils/constant.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/item_type_localization.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
 
-/// Covers are 2:3, matching the recommendation screen so the two read as the
-/// same kind of list.
-const double _coverWidth = 64;
-const double _coverHeight = 96;
+/// Covers are 2:3, matching the recommendation screen so the two read as one
+/// kind of list rather than two.
+const double _coverWidth = 96;
+const double _coverHeight = 144;
 
-/// What the manga being read is related to.
+/// Cover plus the card's vertical padding.
+const double _cardExtent = _coverHeight + 12;
+
+/// One column on a phone, two above this, and never more than two.
+const double _twoColumnBreakpoint = 700;
+
+const double _alphaTint = 0.08;
+const double _alphaFocus = 0.14;
+const double _alphaSecondary = 0.70;
+
+/// What the open title is related to.
 ///
 /// Opening one searches the sources installed for its medium, so an anime
-/// adaptation found here leads to somewhere it can actually be watched rather
-/// than to a database entry.
+/// adaptation found from a manga leads somewhere it can be watched rather than
+/// to a database entry.
 class RelatedScreen extends StatefulWidget {
   const RelatedScreen({super.key, required this.name, required this.itemType});
 
@@ -31,109 +43,215 @@ class RelatedScreen extends StatefulWidget {
 }
 
 class _RelatedScreenState extends State<RelatedScreen> {
-  late Future<List<RelatedTitle>> _future = _load();
+  String _errorMessage = "";
+  bool _isLoading = true;
+  List<RelatedTitle>? data;
 
-  Future<List<RelatedTitle>> _load() =>
-      fetchRelatedTitles(widget.name, widget.itemType);
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  Future<void> _init() async {
+    try {
+      _errorMessage = "";
+      data = await fetchRelatedTitles(widget.name, widget.itemType);
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = e.toString();
+          _isLoading = false;
+        });
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    final l10n = l10nLocalizations(context)!;
+    final l10n = context.l10n;
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.related_titles)),
-      body: FutureBuilder<List<RelatedTitle>>(
-        future: _future,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState != ConnectionState.done) {
-            return const ProgressCenter();
-          }
-          if (snapshot.hasError) {
-            return ErrorState(
-              // The real message, not "no result": a lookup that failed and a
-              // title with nothing related to it are different answers.
-              message: snapshot.error.toString(),
-              onRetry: () => setState(() => _future = _load()),
-            );
-          }
+      body: _isLoading
+          ? const ProgressCenter()
+          : _errorMessage.isNotEmpty
+          // The cause goes in detail, not message: a lookup that failed and a
+          // title with nothing related to it are different answers, and only
+          // one of them is worth a stack.
+          ? ErrorState(
+              detail: _errorMessage,
+              onRetry: () {
+                setState(() {
+                  _isLoading = true;
+                  _errorMessage = "";
+                });
+                _init();
+              },
+            )
+          : (data == null || data!.isEmpty)
+          ? Center(child: Text(l10n.related_none))
+          : LayoutBuilder(
+              builder: (context, constraints) {
+                final columns = constraints.maxWidth >= _twoColumnBreakpoint
+                    ? 2
+                    : 1;
+                return GridView.builder(
+                  padding: tvPageInsets,
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: columns,
+                    mainAxisExtent: _cardExtent,
+                    crossAxisSpacing: 10,
+                    mainAxisSpacing: 10,
+                  ),
+                  itemCount: data!.length,
+                  itemBuilder: (context, index) =>
+                      _card(context, data![index], index),
+                );
+              },
+            ),
+    );
+  }
 
-          final titles = snapshot.data ?? const <RelatedTitle>[];
-          if (titles.isEmpty) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Text(
-                  l10n.related_none,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(color: context.secondaryColor),
+  Widget _card(BuildContext context, RelatedTitle related, int index) {
+    final l10n = context.l10n;
+    final crossesMedium = related.crossesMedium(widget.itemType);
+
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(8),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        // Nothing is focusable on entry otherwise, so a remote does nothing
+        // until the user guesses a direction.
+        autofocus: isTv && index == 0,
+        focusColor: context.primaryColor.withValues(alpha: _alphaFocus),
+        onTap: () => context.push(
+          '/globalSearch',
+          extra: (related.title, related.itemType),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(6),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(6),
+                child: Image(
+                  // toImgUrl stands a blank in for an entry with no poster, so
+                  // a missing cover leaves a gap of the right shape instead of
+                  // collapsing the row.
+                  image: coverProvider(toImgUrl(related.coverImage ?? "")),
+                  width: _coverWidth,
+                  height: _coverHeight,
+                  fit: BoxFit.cover,
                 ),
               ),
-            );
-          }
-
-          return ListView.builder(
-            itemCount: titles.length,
-            itemBuilder: (context, index) =>
-                _RelatedTile(title: titles[index], from: widget.itemType),
-          );
-        },
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _relationPill(
+                          context,
+                          _relationLabel(l10n, related.relation),
+                          filled: crossesMedium,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            related.title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 7),
+                    Wrap(
+                      spacing: 5,
+                      runSpacing: 4,
+                      children: [
+                        _chip(context, related.itemType.localized(l10n)),
+                        if (related.format != null)
+                          _chip(context, _prettyFormat(related.format!)),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
-}
 
-class _RelatedTile extends StatelessWidget {
-  const _RelatedTile({required this.title, required this.from});
+  /// The relation, in the same place the recommendation card puts its score,
+  /// because it answers the same question: why is this here.
+  ///
+  /// Filled with the accent only when the entry is in the other medium. That
+  /// is the one the list exists for, and it should be findable without
+  /// reading.
+  Widget _relationPill(
+    BuildContext context,
+    String label, {
+    required bool filled,
+  }) {
+    final accent = context.primaryColor;
+    // Computed against the accent rather than the theme, so it stays readable
+    // whichever hue the user picked and in either brightness.
+    final onAccent = accent.computeLuminance() > 0.5
+        ? Colors.black
+        : Colors.white;
 
-  final RelatedTitle title;
-  final ItemType from;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = l10nLocalizations(context)!;
-    final cover = title.coverImage;
-
-    return ListTile(
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-      leading: SizedBox(
-        width: _coverWidth,
-        height: _coverHeight,
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(6),
-          child: cover == null
-              ? Container(
-                  color: context.secondaryColor.withValues(alpha: 0.12),
-                  child: const Icon(Icons.image_not_supported_outlined),
-                )
-              : Image(
-                  image: coverProvider(cover),
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, _, _) =>
-                      const Icon(Icons.broken_image_outlined),
-                ),
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: filled
+            ? accent
+            : context.textColor.withValues(alpha: _alphaTint),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w800,
+          color: filled
+              ? onAccent
+              : context.textColor.withValues(alpha: _alphaSecondary),
         ),
       ),
-      title: Text(title.title),
-      subtitle: Text(
-        [
-          _relationLabel(l10n, title.relation),
-          if (title.format != null) _prettyFormat(title.format!),
-        ].join(' · '),
-        style: TextStyle(color: context.secondaryColor, fontSize: 12),
+    );
+  }
+
+  Widget _chip(BuildContext context, String text) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+      decoration: BoxDecoration(
+        color: context.textColor.withValues(alpha: _alphaTint),
+        borderRadius: BorderRadius.circular(6),
       ),
-      // The medium is the thing worth spotting at a glance, so it is a chip
-      // rather than another line of prose.
-      trailing: title.crossesMedium(from)
-          ? Chip(
-              label: Text(
-                title.itemType.localized(l10n),
-                style: const TextStyle(fontSize: 11),
-              ),
-              visualDensity: VisualDensity.compact,
-            )
-          : null,
-      onTap: () =>
-          context.push('/globalSearch', extra: (title.title, title.itemType)),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 11,
+          color: context.textColor.withValues(alpha: _alphaSecondary),
+        ),
+      ),
     );
   }
 }
@@ -154,13 +272,12 @@ String _relationLabel(AppLocalizations l10n, String relation) =>
       _ => l10n.related_titles,
     };
 
-/// SIDE_STORY reads badly on a card; Side story does not.
+/// LIGHT_NOVEL reads badly on a card; Light novel does not.
 String _prettyFormat(String format) {
   final words = format.toLowerCase().split('_');
+  if (words.first.isEmpty) return format;
   return [
-    words.first.isEmpty
-        ? ''
-        : words.first[0].toUpperCase() + words.first.substring(1),
+    words.first[0].toUpperCase() + words.first.substring(1),
     ...words.skip(1),
   ].join(' ');
 }

--- a/lib/modules/manga/detail/widgets/related_screen.dart
+++ b/lib/modules/manga/detail/widgets/related_screen.dart
@@ -94,7 +94,13 @@ class _RelatedScreenState extends State<RelatedScreen> {
           // short, and an adaptation is meant to be read down the page rather
           // than scanned across it.
           : ListView.separated(
-              padding: tvPageInsets,
+              // tvPageInsets is zero off TV, and the card draws its own row
+              // rather than a ListTile, so without this the covers run flush
+              // to the window edge.
+              padding: const EdgeInsets.symmetric(
+                horizontal: 12,
+                vertical: 8,
+              ).add(tvPageInsets),
               itemCount: data!.length,
               separatorBuilder: (_, _) => const SizedBox(height: 4),
               itemBuilder: (context, index) =>
@@ -106,6 +112,10 @@ class _RelatedScreenState extends State<RelatedScreen> {
   Widget _card(BuildContext context, RelatedTitle related, int index) {
     final l10n = context.l10n;
     final crossesMedium = related.crossesMedium(widget.itemType);
+    final medium = related.itemType.localized(l10n);
+    final format = related.format == null
+        ? null
+        : prettyFormat(related.format!);
 
     return Material(
       color: Colors.transparent,
@@ -142,36 +152,39 @@ class _RelatedScreenState extends State<RelatedScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        _relationPill(
-                          context,
-                          _relationLabel(l10n, related.relation),
-                          filled: crossesMedium,
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            related.title,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w700,
-                            ),
-                          ),
-                        ),
-                      ],
+                    // The title gets the full width. Putting a tag beside it
+                    // cost it a line on anything with a subtitle, and the
+                    // title is what is being scanned for.
+                    Text(
+                      related.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                      ),
                     ),
                     const SizedBox(height: 7),
                     Wrap(
                       spacing: 5,
                       runSpacing: 4,
                       children: [
-                        _chip(context, related.itemType.localized(l10n)),
-                        if (related.format != null)
-                          _chip(context, _prettyFormat(related.format!)),
+                        // The medium leads and is filled with the accent when
+                        // it differs from what is being read, because that is
+                        // the whole point of the list.
+                        _tag(
+                          context,
+                          medium,
+                          filled: crossesMedium,
+                          bold: true,
+                        ),
+                        _tag(context, _relationLabel(l10n, related.relation)),
+                        // Kitsu's subtype for a manga is "manga", so this said
+                        // "Manga  Manga" on every manga entry. Shown only when
+                        // it narrows the medium: Manhwa, Oneshot, TV, Movie.
+                        if (format != null &&
+                            format.toLowerCase() != medium.toLowerCase())
+                          _tag(context, format),
                       ],
                     ),
                   ],
@@ -184,16 +197,16 @@ class _RelatedScreenState extends State<RelatedScreen> {
     );
   }
 
-  /// The relation, in the same place the recommendation card puts its score,
-  /// because it answers the same question: why is this here.
+  /// One tag.
   ///
-  /// Filled with the accent only when the entry is in the other medium. That
-  /// is the one the list exists for, and it should be findable without
-  /// reading.
-  Widget _relationPill(
+  /// Filled with the accent when it is the thing the row is here for, tinted
+  /// otherwise, so a glance down the list finds the medium changes without
+  /// reading any of the words.
+  Widget _tag(
     BuildContext context,
     String label, {
-    required bool filled,
+    bool filled = false,
+    bool bold = false,
   }) {
     final accent = context.primaryColor;
     // Computed against the accent rather than the theme, so it stays readable
@@ -203,7 +216,7 @@ class _RelatedScreenState extends State<RelatedScreen> {
         : Colors.white;
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
       decoration: BoxDecoration(
         color: filled
             ? accent
@@ -214,27 +227,10 @@ class _RelatedScreenState extends State<RelatedScreen> {
         label,
         style: TextStyle(
           fontSize: 11,
-          fontWeight: FontWeight.w800,
+          fontWeight: bold ? FontWeight.w800 : FontWeight.w400,
           color: filled
               ? onAccent
               : context.textColor.withValues(alpha: _alphaSecondary),
-        ),
-      ),
-    );
-  }
-
-  Widget _chip(BuildContext context, String text) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
-      decoration: BoxDecoration(
-        color: context.textColor.withValues(alpha: _alphaTint),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(
-          fontSize: 11,
-          color: context.textColor.withValues(alpha: _alphaSecondary),
         ),
       ),
     );
@@ -257,12 +253,26 @@ String _relationLabel(AppLocalizations l10n, String relation) =>
       _ => l10n.related_titles,
     };
 
-/// LIGHT_NOVEL reads badly on a card; Light novel does not.
-String _prettyFormat(String format) {
-  final words = format.toLowerCase().split('_');
-  if (words.first.isEmpty) return format;
+/// Kitsu and AniList both hand these over shouting: TV, OVA, ONE_SHOT,
+/// LIGHT_NOVEL. Title case reads better on a card, except where the word is an
+/// acronym and title case turns TV into "Tv".
+@visibleForTesting
+const formatAcronyms = {'TV', 'OVA', 'ONA', 'OAV', 'CM', 'PV'};
+
+@visibleForTesting
+String prettyFormat(String format) {
+  final words = format.split('_').where((w) => w.isNotEmpty).map((word) {
+    if (formatAcronyms.contains(word.toUpperCase())) return word.toUpperCase();
+    final lower = word.toLowerCase();
+    return lower[0].toUpperCase() + lower.substring(1);
+  }).toList();
+
+  if (words.isEmpty) return format;
+  // Only the first word is capitalised: "Light novel", not "Light Novel".
   return [
-    words.first[0].toUpperCase() + words.first.substring(1),
-    ...words.skip(1),
+    words.first,
+    ...words
+        .skip(1)
+        .map((w) => formatAcronyms.contains(w) ? w : w.toLowerCase()),
   ].join(' ');
 }

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -18,6 +18,7 @@ import 'package:mangayomi/modules/calendar/calendar_screen.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/migrate_screen.dart';
 import 'package:mangayomi/modules/mass_migration/mass_migration_source_selection_screen.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/recommendation_screen.dart';
+import 'package:mangayomi/modules/manga/detail/widgets/related_screen.dart';
 import 'package:mangayomi/modules/manga/detail/widgets/watch_order_screen.dart';
 import 'package:mangayomi/modules/more/data_and_storage/create_backup.dart';
 import 'package:mangayomi/modules/more/data_and_storage/data_and_storage.dart';
@@ -287,6 +288,10 @@ class RouterNotifier extends ChangeNotifier {
     _genericRoute<(Manga, TrackSearch)>(
       name: "migrate/tracker",
       builder: (data) => MigrationScreen(manga: data.$1, trackSearch: data.$2),
+    ),
+    _genericRoute<(String, ItemType)>(
+      name: "related",
+      builder: (data) => RelatedScreen(name: data.$1, itemType: data.$2),
     ),
     _genericRoute<(String, ItemType, AlgorithmWeights)>(
       name: "recommendations",

--- a/lib/services/discovery/kitsu_discovery.dart
+++ b/lib/services/discovery/kitsu_discovery.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/services/anilist_discovery.dart';
+import 'package:mangayomi/services/discovery/title_match.dart';
 import 'package:mangayomi/services/discovery/service_availability.dart';
 import 'package:mangayomi/utils/constant.dart';
 
@@ -94,15 +95,43 @@ DiscoveryMedia kitsuMediaFrom(Map<String, dynamic> entry) {
   );
 }
 
-/// Resolves [title] to a Kitsu id.
+/// Resolves [title] to a Kitsu id, or null when nothing is close enough.
+///
+/// Asks for several and picks the one whose own titles match, rather than
+/// taking the first and trusting it. A library title comes from whichever
+/// source it was added from, and those disagree with Kitsu about punctuation,
+/// romanisation and how much of a subtitle to keep.
+///
+/// Returning null is a real answer here. Relations of the wrong series look
+/// exactly as confident as relations of the right one.
 Future<int?> kitsuSearchMediaId(ItemType itemType, String title) async {
   final body = await _get('/${_kitsuType(itemType)}', {
     'filter[text]': title,
-    'page[limit]': '1',
+    'page[limit]': '5',
   });
-  final data = body?["data"] as List?;
-  final first = data?.firstOrNull as Map<String, dynamic>?;
-  return first == null ? null : int.tryParse('${first["id"]}');
+  final data = (body?["data"] as List?)
+      ?.whereType<Map<String, dynamic>>()
+      .toList();
+  if (data == null || data.isEmpty) return null;
+
+  final best = bestTitleMatch(title, [for (final e in data) kitsuTitlesOf(e)]);
+  if (best == null) return null;
+  return int.tryParse('${data[best]["id"]}');
+}
+
+/// Every name Kitsu knows an entry by.
+///
+/// The abbreviations are worth including: they carry the alternate
+/// romanisations and the fan-translation names, which is often what a source
+/// called it.
+List<String> kitsuTitlesOf(Map<String, dynamic> entry) {
+  final attributes = (entry["attributes"] as Map<String, dynamic>?) ?? const {};
+  final titles = (attributes["titles"] as Map<String, dynamic>?) ?? const {};
+  return [
+    ...titles.values.whereType<String>(),
+    if (attributes["canonicalTitle"] case final String canonical) canonical,
+    ...?(attributes["abbreviatedTitles"] as List?)?.whereType<String>(),
+  ].where((t) => t.isNotEmpty).toList();
 }
 
 /// A Kitsu media plus its relations, shaped like the AniList call it stands in

--- a/lib/services/discovery/title_match.dart
+++ b/lib/services/discovery/title_match.dart
@@ -1,0 +1,71 @@
+/// Picking the right entry out of a title search.
+///
+/// A library title comes from whichever source it was added from, and those
+/// disagree with a metadata database about punctuation, romanisation and how
+/// much of a subtitle to keep. Taking the first hit and trusting it is how a
+/// lookup ends up confidently describing a different series.
+library;
+
+/// Lowercased, punctuation dropped, whitespace collapsed.
+///
+/// Only the separators are removed, so scripts that do not use spaces are
+/// left as one token rather than being erased.
+String normalizeTitle(String title) => title
+    .toLowerCase()
+    .replaceAll(RegExp(r'''[\s\-_:;,.!?'"()\[\]{}~/\\|+*&#@]+'''), ' ')
+    .trim();
+
+List<String> _tokens(String normalized) =>
+    normalized.split(' ').where((t) => t.isNotEmpty).toList();
+
+/// How well two titles match, from 0 to 1.
+///
+/// Token overlap rather than substring, because a database subtitle
+/// ("Chainsaw Man: Buddy Stories") shares every word of the shorter title and
+/// should still score below the title itself.
+double titleSimilarity(String a, String b) {
+  final left = normalizeTitle(a);
+  final right = normalizeTitle(b);
+  if (left.isEmpty || right.isEmpty) return 0;
+  if (left == right) return 1;
+
+  final leftTokens = _tokens(left).toSet();
+  final rightTokens = _tokens(right).toSet();
+  if (leftTokens.isEmpty || rightTokens.isEmpty) return 0;
+
+  final shared = leftTokens.intersection(rightTokens).length;
+  if (shared == 0) return 0;
+  return shared / leftTokens.union(rightTokens).length;
+}
+
+/// The best of [candidates] for [query], or null when none is close enough.
+///
+/// Each candidate is every name the database knows it by, so a library holding
+/// the Japanese title still matches an entry whose English title is different
+/// but which lists both.
+///
+/// Returning null matters as much as returning a match: "nothing related was
+/// found" is a true answer, and the relations of some other series is not.
+int? bestTitleMatch(
+  String query,
+  List<List<String>> candidates, {
+  double floor = 0.5,
+}) {
+  var bestIndex = -1;
+  var bestScore = 0.0;
+
+  for (var i = 0; i < candidates.length; i++) {
+    for (final title in candidates[i]) {
+      final score = titleSimilarity(query, title);
+      // Strictly greater, so an earlier candidate wins a tie. The search comes
+      // back in the database's own relevance order and that is a better
+      // tiebreak than position in this loop.
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+  }
+
+  return bestScore >= floor ? bestIndex : null;
+}

--- a/lib/services/related_titles.dart
+++ b/lib/services/related_titles.dart
@@ -1,0 +1,124 @@
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/services/anilist_discovery.dart';
+import 'package:mangayomi/services/discovery/kitsu_discovery.dart';
+
+/// A title related to the one being read, ready to put on screen.
+///
+/// The point of this is the cross-medium jump: someone reading a manga wants
+/// to know there is an anime, and wants to land on it in a source they have
+/// installed rather than on a database page.
+class RelatedTitle {
+  const RelatedTitle({
+    required this.title,
+    required this.relation,
+    required this.itemType,
+    this.coverImage,
+    this.format,
+  });
+
+  final String title;
+
+  /// ADAPTATION, SEQUEL, PREQUEL, SIDE_STORY, SPIN_OFF, ALTERNATIVE and the
+  /// rest, upper-cased. Kitsu and AniList disagree on case and agree on names.
+  final String relation;
+
+  /// Which library this belongs in, and so which sources to search when it is
+  /// opened.
+  final ItemType itemType;
+
+  final String? coverImage;
+
+  /// TV, MOVIE, MANGA, NOVEL and so on. Shown beside the title because
+  /// "adaptation" alone does not say whether it is a series or a film.
+  final String? format;
+
+  /// True when this is in a different medium from the title it hangs off.
+  bool crossesMedium(ItemType from) => _isVideo(itemType) != _isVideo(from);
+}
+
+bool _isVideo(ItemType type) => type == ItemType.anime;
+
+/// Where a related entry belongs: an anime, a novel, or a manga.
+///
+/// Kitsu has no novel type, it has a manga whose subtype is `novel`, so the
+/// format decides between the two.
+ItemType relatedItemType(DiscoveryMedia media) {
+  if ((media.type ?? '').toUpperCase() == 'ANIME') return ItemType.anime;
+  final format = (media.format ?? '').toUpperCase();
+  if (format == 'NOVEL' || format == 'LIGHT_NOVEL') return ItemType.novel;
+  return ItemType.manga;
+}
+
+/// Orders relations so the useful ones are first and drops the noise.
+///
+/// An adaptation in another medium leads first, because it is the thing that
+/// cannot be found any other way from inside a manga. Then the story order,
+/// then everything else. Entries with no usable title are dropped rather than
+/// drawn as a blank card.
+List<RelatedTitle> orderRelations(
+  List<DiscoveryRelation> relations,
+  ItemType from,
+) {
+  final out = <RelatedTitle>[];
+  final seen = <String>{};
+
+  for (final relation in relations) {
+    final media = relation.media;
+    final title = media.english ?? media.romaji ?? media.native;
+    if (title == null || title.isEmpty) continue;
+
+    final itemType = relatedItemType(media);
+    // The same work is listed under more than one relation by both services,
+    // and a title repeated in one medium is a duplicate, not two entries.
+    if (!seen.add('${itemType.name}:${title.toLowerCase()}')) continue;
+
+    out.add(
+      RelatedTitle(
+        title: title,
+        relation: relation.relationType.toUpperCase(),
+        itemType: itemType,
+        coverImage: media.coverImage,
+        format: media.format,
+      ),
+    );
+  }
+
+  out.sort((a, b) => _rank(a, from).compareTo(_rank(b, from)));
+  return out;
+}
+
+/// Lower sorts first.
+int _rank(RelatedTitle title, ItemType from) {
+  if (title.relation == 'ADAPTATION') return title.crossesMedium(from) ? 0 : 1;
+  return switch (title.relation) {
+    'SEQUEL' => 2,
+    'PREQUEL' => 3,
+    'PARENT' => 4,
+    'SIDE_STORY' => 5,
+    'SPIN_OFF' => 6,
+    'ALTERNATIVE' || 'ALTERNATIVE_SETTING' || 'ALTERNATIVE_VERSION' => 7,
+    _ => 8,
+  };
+}
+
+/// Everything related to [name], resolved by title.
+///
+/// Two calls: one to turn a name into an id, one to ask what hangs off it.
+/// Both go through Kitsu, which answers without a key and is already the
+/// fallback the rest of discovery uses.
+Future<List<RelatedTitle>> fetchRelatedTitles(
+  String name,
+  ItemType itemType,
+) async {
+  // Kitsu knows anime and manga. A novel is looked up among manga, which is
+  // where Kitsu keeps it.
+  final lookupType = itemType == ItemType.anime
+      ? ItemType.anime
+      : ItemType.manga;
+
+  final mediaId = await kitsuSearchMediaId(lookupType, name);
+  if (mediaId == null) return const [];
+
+  final (_, relations) = await kitsuMediaWithRelations(lookupType, mediaId);
+  return orderRelations(relations, itemType);
+}

--- a/test/services/related_titles_test.dart
+++ b/test/services/related_titles_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/services/anilist_discovery.dart';
+import 'package:mangayomi/services/discovery/service_availability.dart';
+import 'package:mangayomi/services/related_titles.dart';
+
+DiscoveryRelation _relation(
+  String relationType, {
+  required String title,
+  String type = 'MANGA',
+  String? format,
+}) => DiscoveryRelation(
+  relationType: relationType,
+  media: DiscoveryMedia(
+    id: title.hashCode,
+    source: DiscoveryService.kitsu,
+    english: title,
+    type: type,
+    format: format,
+    genres: const [],
+  ),
+);
+
+void main() {
+  group('ordering', () {
+    test('an adaptation in the other medium leads', () {
+      // The reason this feature exists: from inside a manga there is no other
+      // way to find out an anime of it exists.
+      final ordered = orderRelations([
+        _relation('SIDE_STORY', title: 'Buddy Stories'),
+        _relation('SEQUEL', title: 'Part 2'),
+        _relation('ADAPTATION', title: 'Chainsaw Man', type: 'ANIME'),
+      ], ItemType.manga);
+
+      expect(ordered.first.title, 'Chainsaw Man');
+      expect(ordered.first.itemType, ItemType.anime);
+      expect(ordered.map((e) => e.relation), [
+        'ADAPTATION',
+        'SEQUEL',
+        'SIDE_STORY',
+      ]);
+    });
+
+    test('an adaptation within the same medium does not', () {
+      // A manga adaptation of a novel, read from the manga, is not the jump
+      // this is for, so the story order outranks it.
+      final ordered = orderRelations([
+        _relation('ADAPTATION', title: 'Same medium'),
+        _relation('SEQUEL', title: 'Part 2'),
+        _relation('ADAPTATION', title: 'The anime', type: 'ANIME'),
+      ], ItemType.manga);
+
+      expect(ordered.map((e) => e.title), [
+        'The anime',
+        'Same medium',
+        'Part 2',
+      ]);
+    });
+
+    test('keeps the whole story order in order', () {
+      final ordered = orderRelations([
+        _relation('SPIN_OFF', title: 'f'),
+        _relation('ALTERNATIVE', title: 'g'),
+        _relation('SIDE_STORY', title: 'e'),
+        _relation('PARENT', title: 'd'),
+        _relation('PREQUEL', title: 'c'),
+        _relation('SEQUEL', title: 'b'),
+        _relation('CHARACTER', title: 'h'),
+      ], ItemType.manga);
+
+      expect(ordered.map((e) => e.title), ['b', 'c', 'd', 'e', 'f', 'g', 'h']);
+    });
+
+    test('drops a repeat of the same title in the same medium', () {
+      // Both services list one work under more than one relation.
+      final ordered = orderRelations([
+        _relation('ADAPTATION', title: 'Chainsaw Man', type: 'ANIME'),
+        _relation('ALTERNATIVE', title: 'chainsaw man', type: 'ANIME'),
+      ], ItemType.manga);
+
+      expect(ordered, hasLength(1));
+      expect(ordered.single.relation, 'ADAPTATION');
+    });
+
+    test('keeps the same title when it is the other medium', () {
+      // A manga and its anime share a name, and both are worth showing.
+      final ordered = orderRelations([
+        _relation('ADAPTATION', title: 'Chainsaw Man', type: 'ANIME'),
+        _relation('SEQUEL', title: 'Chainsaw Man'),
+      ], ItemType.manga);
+
+      expect(ordered, hasLength(2));
+    });
+
+    test('drops an entry with no title rather than drawing a blank card', () {
+      final relations = [
+        DiscoveryRelation(
+          relationType: 'SEQUEL',
+          media: DiscoveryMedia(
+            id: 1,
+            source: DiscoveryService.kitsu,
+            genres: const [],
+          ),
+        ),
+        _relation('SEQUEL', title: 'real'),
+      ];
+
+      expect(orderRelations(relations, ItemType.manga).map((e) => e.title), [
+        'real',
+      ]);
+    });
+  });
+
+  group('which library an entry belongs to', () {
+    test('anime is anime', () {
+      final media = DiscoveryMedia(
+        id: 1,
+        source: DiscoveryService.kitsu,
+        type: 'ANIME',
+        format: 'TV',
+        genres: const [],
+      );
+      expect(relatedItemType(media), ItemType.anime);
+    });
+
+    test('a novel is a novel, not a manga', () {
+      // Kitsu has no novel type; it is a manga whose subtype says novel. Sent
+      // to the manga library it would search the wrong sources.
+      final media = DiscoveryMedia(
+        id: 1,
+        source: DiscoveryService.kitsu,
+        type: 'MANGA',
+        format: 'NOVEL',
+        genres: const [],
+      );
+      expect(relatedItemType(media), ItemType.novel);
+    });
+
+    test('anything else is a manga', () {
+      final media = DiscoveryMedia(
+        id: 1,
+        source: DiscoveryService.kitsu,
+        type: 'MANGA',
+        format: 'MANHWA',
+        genres: const [],
+      );
+      expect(relatedItemType(media), ItemType.manga);
+    });
+  });
+
+  test('crossesMedium is about video, not about the exact library', () {
+    const novel = RelatedTitle(
+      title: 'a',
+      relation: 'ADAPTATION',
+      itemType: ItemType.novel,
+    );
+    // A novel read from a manga is still reading, so it is not the jump.
+    expect(novel.crossesMedium(ItemType.manga), isFalse);
+    expect(novel.crossesMedium(ItemType.anime), isTrue);
+  });
+}

--- a/test/services/title_match_test.dart
+++ b/test/services/title_match_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/discovery/title_match.dart';
+
+/// A library title comes from whichever source it was added from, and those
+/// disagree with a metadata database about punctuation, romanisation and how
+/// much of a subtitle to keep. Taking the first search hit and trusting it is
+/// how a lookup ends up confidently describing a different series.
+void main() {
+  group('normalising', () {
+    test('case and punctuation do not count', () {
+      expect(normalizeTitle('Chainsaw Man!'), 'chainsaw man');
+      expect(normalizeTitle('Re:Zero'), 're zero');
+      expect(normalizeTitle('  Spy x  Family  '), 'spy x family');
+    });
+
+    test('a script without spaces survives as one token', () {
+      // Erasing it would score every Japanese title as empty.
+      expect(normalizeTitle('チェンソーマン'), 'チェンソーマン');
+    });
+  });
+
+  group('similarity', () {
+    test('the same title, differently punctuated, is the same title', () {
+      expect(titleSimilarity('Chainsaw Man', 'chainsaw-man'), 1);
+      expect(titleSimilarity('Re:Zero', 'Re Zero'), 1);
+    });
+
+    test('a subtitled entry scores below the title itself', () {
+      // The whole point: both share every word of the shorter one.
+      final exact = titleSimilarity('Chainsaw Man', 'Chainsaw Man');
+      final subtitled = titleSimilarity(
+        'Chainsaw Man',
+        'Chainsaw Man: Buddy Stories',
+      );
+      expect(subtitled, lessThan(exact));
+      expect(subtitled, greaterThan(0));
+    });
+
+    test('unrelated titles score nothing', () {
+      expect(titleSimilarity('Chainsaw Man', 'Just Listen to the Song'), 0);
+    });
+
+    test('an empty side scores nothing rather than throwing', () {
+      expect(titleSimilarity('', 'Chainsaw Man'), 0);
+      expect(titleSimilarity('!!!', 'Chainsaw Man'), 0);
+    });
+  });
+
+  group('picking a candidate', () {
+    test('the exact title wins over one that merely contains it', () {
+      // Kitsu returns the subtitled entries alongside the series itself.
+      final best = bestTitleMatch('Chainsaw Man', [
+        ['Chainsaw Man: Buddy Stories'],
+        ['Chainsaw Man', 'チェンソーマン'],
+      ]);
+      expect(best, 1);
+    });
+
+    test('a match on any of an entry alternate names counts', () {
+      // A library holding the Japanese title still finds the entry whose
+      // English title is different but which lists both.
+      final best = bestTitleMatch('Ore dake Level Up na Ken', [
+        ['Some other series'],
+        ['Solo Leveling', 'Ore dake Level Up na Ken'],
+      ]);
+      expect(best, 1);
+    });
+
+    test('nothing close enough is null, not the first hit', () {
+      // The reason this exists. Relations of the wrong series look exactly as
+      // confident as relations of the right one.
+      final best = bestTitleMatch('A Series Nobody Has', [
+        ['Chainsaw Man'],
+        ['Solo Leveling'],
+      ]);
+      expect(best, isNull);
+    });
+
+    test('an earlier candidate wins a tie', () {
+      // The search comes back in the database's relevance order, which is a
+      // better tiebreak than position in a loop.
+      final best = bestTitleMatch('Chainsaw Man', [
+        ['Chainsaw Man'],
+        ['Chainsaw Man'],
+      ]);
+      expect(best, 0);
+    });
+
+    test('no candidates is null', () {
+      expect(bestTitleMatch('anything', const []), isNull);
+    });
+
+    test('the floor can be relaxed by a caller that wants a guess', () {
+      const candidates = [
+        ['Chainsaw Man: Buddy Stories: Extra Long Subtitle Here'],
+      ];
+      expect(bestTitleMatch('Chainsaw Man', candidates), isNull);
+      expect(bestTitleMatch('Chainsaw Man', candidates, floor: 0.1), 0);
+    });
+  });
+}

--- a/test/widgets/related_format_test.dart
+++ b/test/widgets/related_format_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/manga/detail/widgets/related_screen.dart';
+
+/// Kitsu and AniList both hand formats over shouting: TV, OVA, ONE_SHOT,
+/// LIGHT_NOVEL. Title case reads better on a card, but naive title case turns
+/// TV into "Tv", which is what this is guarding.
+void main() {
+  test('an acronym keeps its case', () {
+    expect(prettyFormat('TV'), 'TV');
+    expect(prettyFormat('OVA'), 'OVA');
+    expect(prettyFormat('ONA'), 'ONA');
+  });
+
+  test('a word is title cased', () {
+    expect(prettyFormat('MOVIE'), 'Movie');
+    expect(prettyFormat('MANHWA'), 'Manhwa');
+    expect(prettyFormat('SPECIAL'), 'Special');
+  });
+
+  test('only the first word of a phrase is capitalised', () {
+    expect(prettyFormat('ONE_SHOT'), 'One shot');
+    expect(prettyFormat('LIGHT_NOVEL'), 'Light novel');
+  });
+
+  test('an acronym inside a phrase still keeps its case', () {
+    expect(prettyFormat('TV_SHORT'), 'TV short');
+  });
+
+  test('nothing sensible in, nothing thrown out', () {
+    expect(prettyFormat(''), '');
+    expect(prettyFormat('_'), '_');
+  });
+
+  test('the acronym set is upper case, since lookups upper case first', () {
+    for (final acronym in formatAcronyms) {
+      expect(acronym, acronym.toUpperCase());
+    }
+  });
+}


### PR DESCRIPTION
A manga's anime, and an anime's manga, cannot be reached from inside the app today. You have to already know the other one exists, then go and search for it by hand.

The data was already being fetched. `fetchMediaWithRelations` returns typed relation edges, `ADAPTATION` among them, with AniList primary and Kitsu behind it. Its only caller is the watch order builder, and nothing in `lib/modules` renders a relation. So this surfaces something the app already asks for and throws away, rather than adding a dependency.

### What it does

**Related** sits on the detail page beside Recommendations. Adaptations in the other medium come first, because that is the one thing you cannot find any other way from where you are standing. Then sequel, prequel, parent, side story, spin-off, alternative.

Opening one runs a global search in that medium, so an anime found from a manga lands on the sources you have installed rather than on a database page.

### Three details worth knowing

**A light novel is not a manga.** Kitsu has no novel type; it has a manga whose subtype is `novel`. Routed by type alone it would search manga sources for something no manga source has. `relatedItemType` reads the format and sends it to the novel library.

**One work is listed under more than one relation** by both services. A repeat within a medium is dropped, while the same name in the other medium is kept, because a manga and its anime share a title and both belong here.

**A failed lookup shows the real error with a retry**, not "no result". That distinction is already a live complaint about recommendations, and it is the difference between "nothing is related to this" and "the lookup did not run".

### Verification

Ordering and routing are pure functions, 10 tests covering the cross-medium rule, the story order, both dedup cases, the novel split and the empty-title drop.

Verified against live Kitsu. Chainsaw Man manga returns:

```
adaptation     anime  Chainsaw Man
adaptation     anime  Chainsaw Man: Reze-hen
adaptation     anime  Chainsaw Man: Shikaku-hen
sequel         manga  Chainsaw Man: Dai-2 Bu
side_story     manga  Chainsaw Man: Buddy Stories
```

`dart analyze lib/ test/` clean, full suite green, built and run on macOS.