### PR TITLE
feat: show which account a tracker is signed in to, and fix the id sent as a name

### DIFF
--- a/lib/models/track_preference.dart
+++ b/lib/models/track_preference.dart
@@ -8,6 +8,18 @@ class TrackPreference {
 
   String? username;
 
+  /// What the service calls this account when it shows it to a person.
+  ///
+  /// Kept apart from [username] because the two are not the same thing on
+  /// every service. AniList's [username] is a numeric viewer id, which two
+  /// queries parse as an int, so the readable name needs somewhere else to
+  /// live. On MyAnimeList, Simkl and Kitsu they are the same string.
+  String? displayName;
+
+  /// The account's avatar, as a URL. Null when the service has none or the
+  /// login predates this being stored.
+  String? avatarUrl;
+
   String? oAuth;
 
   String? prefs;
@@ -17,6 +29,8 @@ class TrackPreference {
   TrackPreference({
     this.syncId,
     this.username,
+    this.displayName,
+    this.avatarUrl,
     this.oAuth,
     this.prefs,
     this.refreshing,
@@ -25,6 +39,8 @@ class TrackPreference {
   TrackPreference.fromJson(Map<String, dynamic> json) {
     syncId = json['syncId'];
     username = json['username'];
+    displayName = json['displayName'];
+    avatarUrl = json['avatarUrl'];
     oAuth = json['oAuth'];
     prefs = json['prefs'];
   }
@@ -32,6 +48,8 @@ class TrackPreference {
   Map<String, dynamic> toJson() => {
     'syncId': syncId,
     'username': username,
+    'displayName': displayName,
+    'avatarUrl': avatarUrl,
     'oAuth': oAuth,
     'prefs': prefs,
   };

--- a/lib/models/track_preference.g.dart
+++ b/lib/models/track_preference.g.dart
@@ -17,15 +17,25 @@ const TrackPreferenceSchema = CollectionSchema(
   name: r'Track Preference',
   id: -7260395670212271073,
   properties: {
-    r'oAuth': PropertySchema(id: 0, name: r'oAuth', type: IsarType.string),
-    r'prefs': PropertySchema(id: 1, name: r'prefs', type: IsarType.string),
+    r'avatarUrl': PropertySchema(
+      id: 0,
+      name: r'avatarUrl',
+      type: IsarType.string,
+    ),
+    r'displayName': PropertySchema(
+      id: 1,
+      name: r'displayName',
+      type: IsarType.string,
+    ),
+    r'oAuth': PropertySchema(id: 2, name: r'oAuth', type: IsarType.string),
+    r'prefs': PropertySchema(id: 3, name: r'prefs', type: IsarType.string),
     r'refreshing': PropertySchema(
-      id: 2,
+      id: 4,
       name: r'refreshing',
       type: IsarType.bool,
     ),
     r'username': PropertySchema(
-      id: 3,
+      id: 5,
       name: r'username',
       type: IsarType.string,
     ),
@@ -53,6 +63,18 @@ int _trackPreferenceEstimateSize(
 ) {
   var bytesCount = offsets.last;
   {
+    final value = object.avatarUrl;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.displayName;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
     final value = object.oAuth;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
@@ -79,10 +101,12 @@ void _trackPreferenceSerialize(
   List<int> offsets,
   Map<Type, List<int>> allOffsets,
 ) {
-  writer.writeString(offsets[0], object.oAuth);
-  writer.writeString(offsets[1], object.prefs);
-  writer.writeBool(offsets[2], object.refreshing);
-  writer.writeString(offsets[3], object.username);
+  writer.writeString(offsets[0], object.avatarUrl);
+  writer.writeString(offsets[1], object.displayName);
+  writer.writeString(offsets[2], object.oAuth);
+  writer.writeString(offsets[3], object.prefs);
+  writer.writeBool(offsets[4], object.refreshing);
+  writer.writeString(offsets[5], object.username);
 }
 
 TrackPreference _trackPreferenceDeserialize(
@@ -92,11 +116,13 @@ TrackPreference _trackPreferenceDeserialize(
   Map<Type, List<int>> allOffsets,
 ) {
   final object = TrackPreference(
-    oAuth: reader.readStringOrNull(offsets[0]),
-    prefs: reader.readStringOrNull(offsets[1]),
-    refreshing: reader.readBoolOrNull(offsets[2]),
+    avatarUrl: reader.readStringOrNull(offsets[0]),
+    displayName: reader.readStringOrNull(offsets[1]),
+    oAuth: reader.readStringOrNull(offsets[2]),
+    prefs: reader.readStringOrNull(offsets[3]),
+    refreshing: reader.readBoolOrNull(offsets[4]),
     syncId: id,
-    username: reader.readStringOrNull(offsets[3]),
+    username: reader.readStringOrNull(offsets[5]),
   );
   return object;
 }
@@ -113,8 +139,12 @@ P _trackPreferenceDeserializeProp<P>(
     case 1:
       return (reader.readStringOrNull(offset)) as P;
     case 2:
-      return (reader.readBoolOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 3:
+      return (reader.readStringOrNull(offset)) as P;
+    case 4:
+      return (reader.readBoolOrNull(offset)) as P;
+    case 5:
       return (reader.readStringOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -220,6 +250,324 @@ extension TrackPreferenceQueryWhere
 
 extension TrackPreferenceQueryFilter
     on QueryBuilder<TrackPreference, TrackPreference, QFilterCondition> {
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'avatarUrl'),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'avatarUrl'),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlEqualTo(String? value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'avatarUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'avatarUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'avatarUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'avatarUrl',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'avatarUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlEndsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'avatarUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'avatarUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'avatarUrl',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'avatarUrl', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  avatarUrlIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'avatarUrl', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'displayName'),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'displayName'),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameEqualTo(String? value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'displayName',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'displayName',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'displayName',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'displayName',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'displayName',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameEndsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'displayName',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'displayName',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'displayName',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'displayName', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
+  displayNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'displayName', value: ''),
+      );
+    });
+  }
+
   QueryBuilder<TrackPreference, TrackPreference, QAfterFilterCondition>
   oAuthIsNull() {
     return QueryBuilder.apply(this, (query) {
@@ -806,6 +1154,34 @@ extension TrackPreferenceQueryLinks
 
 extension TrackPreferenceQuerySortBy
     on QueryBuilder<TrackPreference, TrackPreference, QSortBy> {
+  QueryBuilder<TrackPreference, TrackPreference, QAfterSortBy>
+  sortByAvatarUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'avatarUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterSortBy>
+  sortByAvatarUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'avatarUrl', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterSortBy>
+  sortByDisplayName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'displayName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterSortBy>
+  sortByDisplayNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'displayName', Sort.desc);
+    });
+  }
+
   QueryBuilder<TrackPreference, TrackPreference, QAfterSortBy> sortByOAuth() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'oAuth', Sort.asc);
@@ -863,6 +1239,34 @@ extension TrackPreferenceQuerySortBy
 
 extension TrackPreferenceQuerySortThenBy
     on QueryBuilder<TrackPreference, TrackPreference, QSortThenBy> {
+  QueryBuilder<TrackPreference, TrackPreference, QAfterSortBy>
+  thenByAvatarUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'avatarUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterSortBy>
+  thenByAvatarUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'avatarUrl', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterSortBy>
+  thenByDisplayName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'displayName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QAfterSortBy>
+  thenByDisplayNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'displayName', Sort.desc);
+    });
+  }
+
   QueryBuilder<TrackPreference, TrackPreference, QAfterSortBy> thenByOAuth() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'oAuth', Sort.asc);
@@ -933,6 +1337,20 @@ extension TrackPreferenceQuerySortThenBy
 
 extension TrackPreferenceQueryWhereDistinct
     on QueryBuilder<TrackPreference, TrackPreference, QDistinct> {
+  QueryBuilder<TrackPreference, TrackPreference, QDistinct>
+  distinctByAvatarUrl({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'avatarUrl', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<TrackPreference, TrackPreference, QDistinct>
+  distinctByDisplayName({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'displayName', caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<TrackPreference, TrackPreference, QDistinct> distinctByOAuth({
     bool caseSensitive = true,
   }) {
@@ -970,6 +1388,19 @@ extension TrackPreferenceQueryProperty
   QueryBuilder<TrackPreference, int, QQueryOperations> syncIdProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'syncId');
+    });
+  }
+
+  QueryBuilder<TrackPreference, String?, QQueryOperations> avatarUrlProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'avatarUrl');
+    });
+  }
+
+  QueryBuilder<TrackPreference, String?, QQueryOperations>
+  displayNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'displayName');
     });
   }
 

--- a/lib/modules/manga/detail/widgets/watch_order_screen.dart
+++ b/lib/modules/manga/detail/widgets/watch_order_screen.dart
@@ -115,7 +115,10 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
             .filter()
             .syncIdEqualTo(TrackerProviders.anilist.syncId)
             .findFirst();
-        final data = await fetchSequels(mal?.username, anilist?.username);
+        // chiaki.site is sent `user=` and looks it up by handle, so AniList
+        // has to pass its display name here. Its `username` is a numeric
+        // viewer id, which the lookup silently answers nothing for.
+        final data = await fetchSequels(mal?.username, anilist?.displayName);
         sequels = data
             .where((e) => e.reason.any((r) => r.id == mediaId))
             .toList();

--- a/lib/modules/more/settings/track/manage_trackers/manage_trackers.dart
+++ b/lib/modules/more/settings/track/manage_trackers/manage_trackers.dart
@@ -4,6 +4,7 @@ import 'package:isar_community/isar.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/modules/widgets/gridview_widget.dart';
+import 'package:mangayomi/modules/widgets/tracker_account_avatar.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/constant.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
@@ -36,6 +37,7 @@ class _ManageTrackersScreenState extends State<ManageTrackersScreen> {
         itemCount: trackPreferences.length,
         itemBuilder: (context, index) {
           final trackerPref = trackPreferences[index];
+          final accountLabel = trackerPref.accountLabel;
           return Padding(
             padding: const EdgeInsets.all(8.0),
             child: MaterialButton(
@@ -70,7 +72,7 @@ class _ManageTrackersScreenState extends State<ManageTrackersScreen> {
                     ),
                   ),
                   Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 10),
+                    padding: const EdgeInsets.only(top: 10),
                     child: Text(
                       trackerPref.syncId == -1
                           ? 'Local'
@@ -81,6 +83,35 @@ class _ManageTrackersScreenState extends State<ManageTrackersScreen> {
                       ),
                     ),
                   ),
+                  // Which account, not just which service. Four services can
+                  // be connected at once and nothing here said whose lists
+                  // were being shown.
+                  if (accountLabel != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 10),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          TrackerAccountAvatar(
+                            preference: trackerPref,
+                            radius: 10,
+                          ),
+                          const SizedBox(width: 6),
+                          Flexible(
+                            child: Text(
+                              accountLabel,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontSize: 13,
+                                color: context.secondaryColor,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    )
+                  else
+                    const SizedBox(height: 10),
                 ],
               ),
             ),

--- a/lib/modules/tracker_library/tracker_library_screen.dart
+++ b/lib/modules/tracker_library/tracker_library_screen.dart
@@ -14,6 +14,7 @@ import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/models/track_search.dart';
 import 'package:mangayomi/modules/library/widgets/search_text_form_field.dart';
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
+import 'package:mangayomi/modules/more/settings/track/providers/track_providers.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_section.dart';
 import 'package:mangayomi/modules/widgets/tracker_account_avatar.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_section_screen.dart';
@@ -714,20 +715,18 @@ class _TrackerLibraryScreenState extends ConsumerState<TrackerLibraryScreen> {
 /// The app bar title for a tracker's library: the service and item type, with
 /// the account underneath it.
 ///
-/// The account is read here rather than passed in so the title updates when a
-/// login completes without the screen being rebuilt from above.
-class _TrackerLibraryTitle extends StatelessWidget {
+/// Watches the preference rather than reading it once, so signing out drops
+/// the account from the title instead of leaving a stale name above an empty
+/// list.
+class _TrackerLibraryTitle extends ConsumerWidget {
   const _TrackerLibraryTitle({required this.text, required this.syncId});
 
   final String text;
   final int syncId;
 
   @override
-  Widget build(BuildContext context) {
-    final preference = isar.trackPreferences
-        .filter()
-        .syncIdEqualTo(syncId)
-        .findFirstSync();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final preference = ref.watch(tracksProvider(syncId: syncId));
     final label = preference?.accountLabel;
 
     if (preference == null || label == null) return Text(text);

--- a/lib/modules/tracker_library/tracker_library_screen.dart
+++ b/lib/modules/tracker_library/tracker_library_screen.dart
@@ -15,6 +15,7 @@ import 'package:mangayomi/models/track_search.dart';
 import 'package:mangayomi/modules/library/widgets/search_text_form_field.dart';
 import 'package:mangayomi/modules/manga/detail/providers/track_state_providers.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_library_section.dart';
+import 'package:mangayomi/modules/widgets/tracker_account_avatar.dart';
 import 'package:mangayomi/modules/tracker_library/tracker_section_screen.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/constant.dart';
@@ -89,11 +90,13 @@ class _TrackerLibraryScreenState extends ConsumerState<TrackerLibraryScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          (trackerProvider.syncId == TrackerProviders.simkl.syncId ||
+        title: _TrackerLibraryTitle(
+          text:
+              (trackerProvider.syncId == TrackerProviders.simkl.syncId ||
                   trackerProvider.syncId == TrackerProviders.trakt.syncId)
               ? trackerProvider.name
               : "${trackerProvider.name} | ${itemType.localized(l10n)}",
+          syncId: trackerProvider.syncId,
         ),
         leading: !_isSearch ? null : Container(),
         actions: [
@@ -704,6 +707,53 @@ class _TrackerLibraryScreenState extends ConsumerState<TrackerLibraryScreen> {
           }
         },
       ),
+    );
+  }
+}
+
+/// The app bar title for a tracker's library: the service and item type, with
+/// the account underneath it.
+///
+/// The account is read here rather than passed in so the title updates when a
+/// login completes without the screen being rebuilt from above.
+class _TrackerLibraryTitle extends StatelessWidget {
+  const _TrackerLibraryTitle({required this.text, required this.syncId});
+
+  final String text;
+  final int syncId;
+
+  @override
+  Widget build(BuildContext context) {
+    final preference = isar.trackPreferences
+        .filter()
+        .syncIdEqualTo(syncId)
+        .findFirstSync();
+    final label = preference?.accountLabel;
+
+    if (preference == null || label == null) return Text(text);
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TrackerAccountAvatar(preference: preference, radius: 14),
+        const SizedBox(width: 10),
+        Flexible(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(text, overflow: TextOverflow.ellipsis),
+              Text(
+                label,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/modules/widgets/tracker_account_avatar.dart
+++ b/lib/modules/widgets/tracker_account_avatar.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:mangayomi/models/track_preference.dart';
+import 'package:mangayomi/utils/cached_network.dart';
+
+/// The account behind a tracker, as a circle.
+///
+/// Falls back to the first letter of the name, then to a generic person, so
+/// this draws something for every service and for logins made before an
+/// avatar was stored.
+class TrackerAccountAvatar extends StatelessWidget {
+  const TrackerAccountAvatar({
+    super.key,
+    required this.preference,
+    this.radius = 16,
+  });
+
+  final TrackPreference preference;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    final url = preference.avatarUrl;
+    final name = preference.accountLabel;
+    final background = Theme.of(context).colorScheme.surfaceContainerHighest;
+
+    if (url == null || url.isEmpty) {
+      return CircleAvatar(
+        radius: radius,
+        backgroundColor: background,
+        child: name == null
+            ? Icon(Icons.person_rounded, size: radius)
+            : Text(
+                name.characters.first.toUpperCase(),
+                style: TextStyle(fontSize: radius, fontWeight: FontWeight.bold),
+              ),
+      );
+    }
+
+    return CircleAvatar(
+      radius: radius,
+      backgroundColor: background,
+      // A resized provider rather than the full image: these are drawn at
+      // 32-48px and the services serve them much larger than that.
+      backgroundImage: coverProvider(url),
+    );
+  }
+}
+
+extension TrackerAccountLabel on TrackPreference {
+  /// What to call this account on screen, or null when nothing readable is
+  /// stored.
+  ///
+  /// [username] is not a fallback for every service: on AniList, Simkl and
+  /// Kitsu it holds a numeric id, which is worse than showing nothing. Only
+  /// MyAnimeList keeps a name there, and it now fills [displayName] too, so a
+  /// null here means the login predates this and will fill in on next sign-in.
+  String? get accountLabel {
+    final name = displayName;
+    return name == null || name.isEmpty ? null : name;
+  }
+}

--- a/lib/services/trackers/anilist.dart
+++ b/lib/services/trackers/anilist.dart
@@ -17,6 +17,7 @@ import 'package:mangayomi/utils/localized_message.dart';
 import 'package:mangayomi/services/discovery/service_availability.dart';
 
 import 'base_tracker.dart';
+import 'tracker_account.dart';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'anilist.g.dart';
@@ -77,7 +78,9 @@ class Anilist extends _$Anilist implements BaseTracker {
           .login(
             TrackPreference(
               syncId: syncId,
-              username: currenUser.$1,
+              username: currenUser.$1.id,
+              displayName: currenUser.$1.name,
+              avatarUrl: currenUser.$1.avatarUrl,
               prefs: jsonEncode({"scoreFormat": currenUser.$2}),
               oAuth: jsonEncode(aLOAuth.toJson()),
             ),
@@ -416,11 +419,20 @@ class Anilist extends _$Anilist implements BaseTracker {
     return data;
   }
 
-  Future<(String, String)> _getCurrentUser(String accessToken) async {
+  /// The viewer's account, and the score format stored alongside it.
+  ///
+  /// The id and the name are both needed and are not interchangeable. Two
+  /// queries here parse the id as an int, while chiaki.site's sequel lookup
+  /// wants the name, so storing only one of them makes the other caller wrong.
+  Future<(TrackerAccount, String)> _getCurrentUser(String accessToken) async {
     const query = '''
     query User {
       Viewer {
         id
+        name
+        avatar {
+          large
+        }
         mediaListOptions {
           scoreFormat
         }
@@ -440,9 +452,9 @@ class Anilist extends _$Anilist implements BaseTracker {
     );
     final data = json.decode(response.body);
 
-    final viewer = data['data']['Viewer'];
+    final viewer = data['data']['Viewer'] as Map<String, dynamic>;
     return (
-      viewer['id'].toString(),
+      anilistAccount(viewer),
       viewer['mediaListOptions']['scoreFormat'].toString(),
     );
   }

--- a/lib/services/trackers/anilist.g.dart
+++ b/lib/services/trackers/anilist.g.dart
@@ -58,7 +58,7 @@ final class AnilistProvider extends $NotifierProvider<Anilist, void> {
   }
 }
 
-String _$anilistHash() => r'6b31944db716bc946f1a832866102e6a01fff5e5';
+String _$anilistHash() => r'9c10c45dfe066ca37b7dcb1dc5e19a0cd503aa34';
 
 final class AnilistFamily extends $Family
     with

--- a/lib/services/trackers/kitsu.dart
+++ b/lib/services/trackers/kitsu.dart
@@ -11,7 +11,9 @@ import 'package:mangayomi/modules/more/settings/track/myanimelist/model.dart';
 import 'package:mangayomi/modules/more/settings/track/providers/track_providers.dart';
 import 'package:mangayomi/services/http/m_client.dart';
 import 'package:mangayomi/utils/localized_message.dart';
+
 import 'base_tracker.dart';
+import 'tracker_account.dart';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'kitsu.g.dart';
@@ -71,7 +73,9 @@ class Kitsu extends _$Kitsu implements BaseTracker {
           .read(tracksProvider(syncId: syncId).notifier)
           .login(
             TrackPreference(
-              username: currentUser.$1,
+              username: currentUser.$1.id,
+              displayName: currentUser.$1.name,
+              avatarUrl: currentUser.$1.avatarUrl,
               syncId: syncId,
               prefs: jsonEncode({"ratingSystem": currentUser.$2}),
               oAuth: jsonEncode(aKOAuth.toJson()),
@@ -348,13 +352,17 @@ class Kitsu extends _$Kitsu implements BaseTracker {
       ..finishedReadingDate = _parseDate(attributes["finishedAt"]);
   }
 
-  Future<(String, String)> _getCurrentUser(String accessToken) async {
+  /// The account, and the rating system stored alongside it.
+  ///
+  /// As on AniList and Simkl the id is what the rest of this file needs, so
+  /// the readable name is returned beside it rather than in place of it.
+  Future<(TrackerAccount, String)> _getCurrentUser(String accessToken) async {
     final url = Uri.parse('${_baseUrl}users?filter[self]=true');
     Response response = await _makeGetRequest(url, accessToken);
-    final data = json.decode(response.body)['data'][0];
+    final data = json.decode(response.body)['data'][0] as Map<String, dynamic>;
     return (
-      data['id'].toString(),
-      data['attributes']['ratingSystem'].toString(),
+      kitsuAccount(data),
+      (data['attributes'] as Map<String, dynamic>)['ratingSystem'].toString(),
     );
   }
 

--- a/lib/services/trackers/kitsu.g.dart
+++ b/lib/services/trackers/kitsu.g.dart
@@ -58,7 +58,7 @@ final class KitsuProvider extends $NotifierProvider<Kitsu, void> {
   }
 }
 
-String _$kitsuHash() => r'4ab8850f17c417a9c523cf9076e3d6035a02b6be';
+String _$kitsuHash() => r'139edde83284c07f60acdb989eff2840388a1733';
 
 final class KitsuFamily extends $Family
     with

--- a/lib/services/trackers/myanimelist.dart
+++ b/lib/services/trackers/myanimelist.dart
@@ -17,6 +17,7 @@ import 'package:mangayomi/utils/localized_message.dart';
 import 'package:mangayomi/utils/log/logger.dart';
 
 import 'base_tracker.dart';
+import 'tracker_account.dart';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'myanimelist.g.dart';
@@ -126,13 +127,15 @@ class MyAnimeList extends _$MyAnimeList implements BaseTracker {
       ..clientId = clientId;
   }
 
-  void _saveOAuth(String username, OAuth oAuth) {
+  void _saveOAuth(TrackerAccount user, OAuth oAuth) {
     widgetRef
         .read(tracksProvider(syncId: syncId).notifier)
         .login(
           TrackPreference(
             syncId: syncId,
-            username: username,
+            username: user.id,
+            displayName: user.name,
+            avatarUrl: user.avatarUrl,
             prefs: "",
             oAuth: jsonEncode(oAuth.toJson()),
           ),
@@ -365,12 +368,16 @@ class MyAnimeList extends _$MyAnimeList implements BaseTracker {
     return jsonDecode(response.body);
   }
 
-  Future<String> _getUserName(String accessToken) async {
+  /// The account behind the token.
+  ///
+  /// `/users/@me` already answers with `picture`, so the avatar costs nothing
+  /// beyond reading a field that was being thrown away.
+  Future<TrackerAccount> _getUserName(String accessToken) async {
     final response = await _makeGetRequest(
       Uri.parse('$_baseApiUrl/users/@me'),
       accessToken,
     );
-    return jsonDecode(response.body)['name'];
+    return malAccount(jsonDecode(response.body) as Map<String, dynamic>);
   }
 
   @override

--- a/lib/services/trackers/myanimelist.g.dart
+++ b/lib/services/trackers/myanimelist.g.dart
@@ -58,7 +58,7 @@ final class MyAnimeListProvider extends $NotifierProvider<MyAnimeList, void> {
   }
 }
 
-String _$myAnimeListHash() => r'98f4bdc4dc2ae294982973b4d630e99ef65ec18d';
+String _$myAnimeListHash() => r'a40cd05811066b46bb9afd18612a4904e9c9c25e';
 
 final class MyAnimeListFamily extends $Family
     with

--- a/lib/services/trackers/simkl.dart
+++ b/lib/services/trackers/simkl.dart
@@ -13,6 +13,7 @@ import 'package:mangayomi/modules/more/settings/track/providers/track_providers.
 import 'package:mangayomi/services/http/m_client.dart';
 
 import 'base_tracker.dart';
+import 'tracker_account.dart';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'simkl.g.dart';
@@ -367,25 +368,31 @@ class Simkl extends _$Simkl implements BaseTracker {
     return OAuth.fromJson(json)..clientId = clientId;
   }
 
-  void _saveOAuth(String username, OAuth oAuth) {
+  void _saveOAuth(TrackerAccount user, OAuth oAuth) {
     widgetRef
         .read(tracksProvider(syncId: syncId).notifier)
         .login(
           TrackPreference(
             syncId: syncId,
-            username: username,
+            username: user.id,
+            displayName: user.name,
+            avatarUrl: user.avatarUrl,
             prefs: "",
             oAuth: jsonEncode(oAuth.toJson()),
           ),
         );
   }
 
-  Future<String> _getUserName(String accessToken) async {
+  /// The account behind the token.
+  ///
+  /// Same split as AniList: the id is what other calls need, the name is what
+  /// a person recognises, and `/users/settings` answers with both already.
+  Future<TrackerAccount> _getUserName(String accessToken) async {
     final response = await _makeGetRequest(
       Uri.parse('$_baseApiUrl/users/settings'),
       accessToken,
     );
-    return "${jsonDecode(response.body)['account']['id']}";
+    return simklAccount(jsonDecode(response.body) as Map<String, dynamic>);
   }
 
   String _authUrl() {

--- a/lib/services/trackers/simkl.g.dart
+++ b/lib/services/trackers/simkl.g.dart
@@ -58,7 +58,7 @@ final class SimklProvider extends $NotifierProvider<Simkl, void> {
   }
 }
 
-String _$simklHash() => r'14dd96d4a31a0a3245a5847a7465000c06d41613';
+String _$simklHash() => r'de01a8fe9c7646b0504c7c13086aa5f9efe842cc';
 
 final class SimklFamily extends $Family
     with

--- a/lib/services/trackers/tracker_account.dart
+++ b/lib/services/trackers/tracker_account.dart
@@ -1,0 +1,76 @@
+/// Who a tracker login belongs to.
+///
+/// Every service answers this question in its own shape, and two of the fields
+/// are easy to confuse: [id] is what the service's own API wants back, [name]
+/// is what a person recognises. They are the same string on MyAnimeList and
+/// different everywhere else, which is why they are kept apart.
+class TrackerAccount {
+  const TrackerAccount({required this.id, this.name, this.avatarUrl});
+
+  /// The identifier the rest of the service's calls need. Held as a string
+  /// because that is how it is stored, even where it is a number.
+  final String id;
+
+  /// The handle the service shows, e.g. `RyanYuuki`. Null when the response
+  /// carried none.
+  final String? name;
+
+  /// An absolute URL, or null when the account has no picture set.
+  final String? avatarUrl;
+}
+
+/// `Viewer` from AniList's GraphQL API.
+///
+/// The id is numeric and two queries parse it back with `int.parse`, so it
+/// stays the stored id and the name goes beside it.
+TrackerAccount anilistAccount(Map<String, dynamic> viewer) => TrackerAccount(
+  id: viewer['id'].toString(),
+  name: _text(viewer['name']),
+  avatarUrl: _text((viewer['avatar'] as Map<String, dynamic>?)?['large']),
+);
+
+/// `/users/@me` from MyAnimeList.
+///
+/// The only service where the id is the name. `picture` was already in this
+/// response and was being discarded.
+TrackerAccount malAccount(Map<String, dynamic> user) {
+  final name = user['name'] as String;
+  return TrackerAccount(
+    id: name,
+    name: name,
+    avatarUrl: _text(user['picture']),
+  );
+}
+
+/// `/users/settings` from Simkl, which splits the account from the person:
+/// `account.id` identifies, `user.name` and `user.avatar` describe.
+TrackerAccount simklAccount(Map<String, dynamic> settings) {
+  final user = settings['user'] as Map<String, dynamic>?;
+  return TrackerAccount(
+    id: '${(settings['account'] as Map<String, dynamic>)['id']}',
+    name: _text(user?['name']),
+    avatarUrl: _text(user?['avatar']),
+  );
+}
+
+/// One entry of `users?filter[self]=true` from Kitsu.
+///
+/// Kitsu's `name` is optional and its `slug` is not, so the slug stands in
+/// rather than showing the numeric id.
+TrackerAccount kitsuAccount(Map<String, dynamic> data) {
+  final attributes = data['attributes'] as Map<String, dynamic>;
+  return TrackerAccount(
+    id: data['id'].toString(),
+    name: _text(attributes['name']) ?? _text(attributes['slug']),
+    avatarUrl: _text(
+      (attributes['avatar'] as Map<String, dynamic>?)?['original'],
+    ),
+  );
+}
+
+/// A non-empty string, or null. Services return `""` and `null` for the same
+/// thing and an empty avatar URL would draw a broken image.
+String? _text(Object? value) {
+  if (value is! String || value.isEmpty) return null;
+  return value;
+}

--- a/test/services/tracker_account_test.dart
+++ b/test/services/tracker_account_test.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/trackers/tracker_account.dart';
+
+/// Every service answers "who am I" in its own shape, and before this the app
+/// kept one string per login and called it `username`. On MyAnimeList that was
+/// a name; on AniList, Simkl and Kitsu it was a numeric id. Nothing showed it,
+/// so the mismatch went unnoticed until chiaki.site's sequel lookup, which is
+/// given `user=` and matches by handle, was handed an AniList id.
+void main() {
+  group('AniList', () {
+    test('keeps the id and the name apart', () {
+      final viewer = jsonDecode('''
+        {
+          "id": 123456,
+          "name": "RyanYuuki",
+          "avatar": {"large": "https://s4.anilist.co/file/avatar/123456.png"},
+          "mediaListOptions": {"scoreFormat": "POINT_10"}
+        }
+      ''') as Map<String, dynamic>;
+
+      final account = anilistAccount(viewer);
+
+      // The id stays a string because two queries parse it back with
+      // int.parse, and it must survive that round trip.
+      expect(account.id, '123456');
+      expect(int.parse(account.id), 123456);
+      expect(account.name, 'RyanYuuki');
+      expect(account.avatarUrl, endsWith('123456.png'));
+    });
+
+    test('survives an account with no avatar set', () {
+      final account = anilistAccount({
+        'id': 7,
+        'name': 'someone',
+        'avatar': null,
+      });
+
+      expect(account.id, '7');
+      expect(account.name, 'someone');
+      expect(account.avatarUrl, isNull);
+    });
+  });
+
+  group('MyAnimeList', () {
+    test('is the one service where the id is the name', () {
+      final account = malAccount({
+        'id': 999,
+        'name': 'someone',
+        'picture': 'https://api-cdn.myanimelist.net/images/userimages/1.jpg',
+      });
+
+      expect(account.id, 'someone');
+      expect(account.name, 'someone');
+      expect(account.avatarUrl, contains('userimages'));
+    });
+
+    test('reads no picture as no picture rather than an empty URL', () {
+      // An empty string here would be handed to an image provider and drawn
+      // as a broken image.
+      expect(malAccount({'name': 'someone', 'picture': ''}).avatarUrl, isNull);
+      expect(malAccount({'name': 'someone'}).avatarUrl, isNull);
+    });
+  });
+
+  group('Simkl', () {
+    test('takes the id from account and the name from user', () {
+      final settings = jsonDecode('''
+        {
+          "user": {
+            "name": "Someone",
+            "joined_at": "2020-01-01T00:00:00Z",
+            "avatar": "https://simkl.in/avatars/1_male.jpg"
+          },
+          "account": {"id": 4242, "timezone": "Europe/Paris", "type": "free"}
+        }
+      ''') as Map<String, dynamic>;
+
+      final account = simklAccount(settings);
+
+      expect(account.id, '4242');
+      expect(account.name, 'Someone');
+      expect(account.avatarUrl, contains('simkl.in'));
+    });
+
+    test('still logs in when the user block is missing', () {
+      final account = simklAccount({
+        'account': {'id': 1},
+      });
+
+      expect(account.id, '1');
+      expect(account.name, isNull);
+    });
+  });
+
+  group('Kitsu', () {
+    test('falls back to the slug, which is readable, not the numeric id', () {
+      final account = kitsuAccount({
+        'id': '55555',
+        'attributes': {
+          'slug': 'some-one',
+          'name': null,
+          'ratingSystem': 'simple',
+          'avatar': {'original': 'https://media.kitsu.io/users/avatars/1.png'},
+        },
+      });
+
+      expect(account.id, '55555');
+      expect(account.name, 'some-one');
+      expect(account.avatarUrl, contains('kitsu.io'));
+    });
+
+    test('prefers the name when there is one', () {
+      final account = kitsuAccount({
+        'id': '1',
+        'attributes': {'slug': 'some-one', 'name': 'Some One'},
+      });
+
+      expect(account.name, 'Some One');
+      expect(account.avatarUrl, isNull);
+    });
+  });
+
+  test('no service reports an id it cannot give back', () {
+    // The stored id is what the service's own API is called with, so an empty
+    // one would silently break every later request rather than the login.
+    final accounts = [
+      anilistAccount({'id': 1, 'name': 'a'}),
+      malAccount({'name': 'b'}),
+      simklAccount({
+        'account': {'id': 2},
+      }),
+      kitsuAccount({
+        'id': '3',
+        'attributes': {'slug': 'c'},
+      }),
+    ];
+
+    for (final account in accounts) {
+      expect(account.id, isNotEmpty);
+    }
+  });
+}


### PR DESCRIPTION
Four services can be connected at once and nothing said whose lists were on screen. Manage trackers drew a grid of logos; the tracker library titled itself "AniList | Manga" whoever was signed in.

Looking at why turned up something worse.

### The bug

Each login stored one string called `username`, but it does not hold the same thing on each service:

| Service | what `username` actually held |
|---|---|
| MyAnimeList | the name |
| AniList | numeric viewer id |
| Simkl | numeric account id |
| Kitsu | numeric user id |

That is deliberate for three of them, since their later calls need the id back and there was nowhere else to put it. `anilist.dart` parses it with `int.parse` in two places.

But the watch order screen sends `user=` to chiaki.site, which matches **by handle**, and passed `anilist?.username` whenever no MyAnimeList account was connected:

```dart
final data = await fetchSequels(mal?.username, anilist?.username);
```

chiaki was being asked about a user named `123456`. It answered with nothing, and the screen showed an empty sequel list rather than an error. Anyone tracking on AniList only has never seen that feature work.

### The fix

`TrackPreference` gains `displayName` and `avatarUrl` beside `username`. Both nullable, so an existing login keeps working and fills in on next sign-in; the Isar schema change is additive.

Each service's "who am I" response is now parsed by one function in `tracker_account.dart` returning an id, a name and an avatar, instead of a tuple whose meaning changed per service.

**No service costs an extra request.** AniList's `Viewer` query gains two fields. The other three already carried the name and picture in responses that were being read for one value and discarded.

### Where it shows

Manage trackers cards, and the tracker library app bar. The title watches `tracksProvider` rather than reading Isar once, so signing out drops the account instead of leaving a stale name above an empty list.

### Notes

Kitsu has no required name, so its `slug` stands in. Both are readable; the numeric id is not.

9 tests over real response shapes from all four services, including the empty-avatar cases that would otherwise be handed to an image provider as `""`.

`dart analyze lib/ test/` clean, full suite green, built and run on macOS.