### PR TITLE
perf(tv): show only the tab the television is on

### DIFF
--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -128,9 +128,21 @@ class RouterNotifier extends ChangeNotifier {
   List<RouteBase> get _routes => [
     // Each tab lives in its own StatefulShellBranch so switching tabs keeps
     // the other screens mounted (scroll position, queries, images preserved).
-    StatefulShellRoute.indexedStack(
+    //
+    // Except on a television, where that retention is not affordable. Measured
+    // on a Fire TV: every branch left mounted holds roughly 14 MB of GPU
+    // surfaces, three tabs took Graphics from 27 MB to 69 MB, and the box has
+    // around 300 MB free with most of its swap already spent. Off TV the
+    // trade is the other way round and IndexedStack stays.
+    StatefulShellRoute(
       builder: (context, state, navigationShell) =>
           MainScreen(child: navigationShell),
+      navigatorContainerBuilder: (context, navigationShell, children) => isTv
+          ? children[navigationShell.currentIndex]
+          : IndexedStack(
+              index: navigationShell.currentIndex,
+              children: children,
+            ),
       branches: [
         _branch(
           _genericRoute<String?>(

--- a/test/router/tv_branch_retention_test.dart
+++ b/test/router/tv_branch_retention_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/utils/platform_utils.dart';
+
+/// Measured on a Fire TV: every branch left mounted holds roughly 14 MB of GPU
+/// surfaces. Three tabs took Graphics from 27 MB to 69 MB on a box with about
+/// 300 MB free and most of its swap already spent.
+///
+/// So a television shows only the branch it is on, and everywhere else keeps
+/// the IndexedStack, where the trade runs the other way: retention buys scroll
+/// position and loaded images for memory that is not scarce.
+///
+/// This exercises the container builder's shape rather than a whole router,
+/// which would need every screen in the app to build.
+Widget container(
+  BuildContext context,
+  int currentIndex,
+  List<Widget> children,
+) => isTv
+    ? children[currentIndex]
+    : IndexedStack(index: currentIndex, children: children);
+
+void main() {
+  tearDown(() => debugIsTvOverride = null);
+
+  Future<void> pump(WidgetTester tester, int index) => tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) => container(context, index, const [
+          Text('branch 0'),
+          Text('branch 1'),
+          Text('branch 2'),
+        ]),
+      ),
+    ),
+  );
+
+  testWidgets('a television mounts only the branch it is showing', (
+    tester,
+  ) async {
+    debugIsTvOverride = true;
+
+    await pump(tester, 1);
+
+    expect(find.text('branch 1'), findsOneWidget);
+    expect(find.text('branch 0'), findsNothing, reason: 'not retained');
+    expect(find.text('branch 2'), findsNothing);
+    expect(find.byType(IndexedStack), findsNothing);
+  });
+
+  testWidgets('and drops the old one when the tab changes', (tester) async {
+    debugIsTvOverride = true;
+    await pump(tester, 0);
+    expect(find.text('branch 0'), findsOneWidget);
+
+    await pump(tester, 2);
+
+    expect(find.text('branch 2'), findsOneWidget);
+    expect(find.text('branch 0'), findsNothing);
+  });
+
+  testWidgets('everywhere else keeps every branch mounted', (tester) async {
+    debugIsTvOverride = false;
+
+    await pump(tester, 1);
+
+    expect(find.byType(IndexedStack), findsOneWidget);
+    // Offstage children are still in the tree, which is the point of them.
+    expect(find.text('branch 0', skipOffstage: false), findsOneWidget);
+    expect(find.text('branch 2', skipOffstage: false), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Measured on a Fire TV rather than guessed.

Every branch left mounted holds roughly 14 MB of GPU surfaces. Visiting three tabs took Graphics from 27 MB to 69 MB, on a box with about 300 MB available and 365 MB of its 500 MB swap already spent:

```
after launch (one branch)    Graphics  27,440 kB   TOTAL 302,670 kB
after ~3 tab switches        Graphics  70,800 kB   TOTAL 379,623 kB   SWAP 121,282 kB
```

The `IndexedStack` keeps every visited branch alive on purpose, so scroll position, queries and loaded images survive a tab switch. That is a good trade where memory is not scarce and a bad one here.

So a television mounts only the branch it is showing. Everything else keeps the `IndexedStack` unchanged. The cost on TV is that returning to a tab rebuilds it, which is the trade being made deliberately.

### Two things this is not

**Not lazy loading**, which already works. `StatefulShellBranch.preload` defaults to false and is never set here, so a tab nobody opens was never built. The cost is purely retention of tabs that have been visited.

**Not the image cache**, which was measured at 8% of the process and left alone.

### On the debug-build caveat

These numbers came from a debug build, where Code and Private Other are inflated by the JIT and the kernel blob. Graphics is not: those are GPU textures, and they are the same in release. The figure this change is based on is the one that survives.

Three widget tests over the container behaviour: a television mounts one branch, drops the old one on a tab change, and everywhere else keeps every branch in the tree.
