### PR TITLE
fix: say why a global search had nothing to search

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1273,5 +1273,17 @@
       }
     }
   },
+  "global_search_no_sources": "No {itemType} sources are installed.",
+  "@global_search_no_sources": {
+    "placeholders": {"itemType": {"type": "String"}}
+  },
+  "global_search_no_sources_hint": "Add a repository under Browse, then install an extension for it.",
+  "global_search_only_pinned": "You have {count, plural, =1{1 source} other{{count} sources}} for this, but only pinned ones are searched.",
+  "@global_search_only_pinned": {
+    "placeholders": {"count": {"type": "int"}}
+  },
+  "global_search_only_pinned_hint": "Pin one, or turn off \"Only include pinned sources\" in Browse settings.",
+  "global_search_all_nsfw": "Every source you have for this is marked NSFW, and those are hidden.",
+  "global_search_all_nsfw_hint": "Turn on NSFW sources in Browse settings to search them.",
   "missing_source_check_result_message": "These library entries point at a source that isn't installed on this device. Tap one to migrate it to an installed source, install the matching extension, or use \"Delete a source & its manga\" to remove them."
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -5777,6 +5777,42 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 source missing} other{{count} sources missing}}'**
   String missing_source_check_result_title(int count);
 
+  /// No description provided for @global_search_no_sources.
+  ///
+  /// In en, this message translates to:
+  /// **'No {itemType} sources are installed.'**
+  String global_search_no_sources(String itemType);
+
+  /// No description provided for @global_search_no_sources_hint.
+  ///
+  /// In en, this message translates to:
+  /// **'Add a repository under Browse, then install an extension for it.'**
+  String get global_search_no_sources_hint;
+
+  /// No description provided for @global_search_only_pinned.
+  ///
+  /// In en, this message translates to:
+  /// **'You have {count, plural, =1{1 source} other{{count} sources}} for this, but only pinned ones are searched.'**
+  String global_search_only_pinned(int count);
+
+  /// No description provided for @global_search_only_pinned_hint.
+  ///
+  /// In en, this message translates to:
+  /// **'Pin one, or turn off \"Only include pinned sources\" in Browse settings.'**
+  String get global_search_only_pinned_hint;
+
+  /// No description provided for @global_search_all_nsfw.
+  ///
+  /// In en, this message translates to:
+  /// **'Every source you have for this is marked NSFW, and those are hidden.'**
+  String get global_search_all_nsfw;
+
+  /// No description provided for @global_search_all_nsfw_hint.
+  ///
+  /// In en, this message translates to:
+  /// **'Turn on NSFW sources in Browse settings to search them.'**
+  String get global_search_all_nsfw_hint;
+
   /// No description provided for @missing_source_check_result_message.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -3206,6 +3206,38 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'تشير هذه العناصر إلى مصادر غير مثبتة. اضغط لنقلها أو ثبت الإضافة.';
 }

--- a/lib/l10n/generated/app_localizations_as.dart
+++ b/lib/l10n/generated/app_localizations_as.dart
@@ -3205,6 +3205,38 @@ class AppLocalizationsAs extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'এই এণ্ট্ৰিসমূহ ইনষ্টল নথকা উৎসৰ সৈতে জড়িত। স্থানান্তৰ কৰিবলৈ টিপক বা এক্সটেনচন ইনষ্টল কৰক।';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -3237,6 +3237,38 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'Diese Einträge verweisen auf nicht installierte Quellen. Tippe auf einen Eintrag zur Migration oder installiere die Erweiterung.';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -3204,6 +3204,38 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'These library entries point at a source that isn\'t installed on this device. Tap one to migrate it to an installed source, install the matching extension, or use \"Delete a source & its manga\" to remove them.';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -3250,6 +3250,38 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'Estas entradas apuntan a una fuente no instalada en este dispositivo. Toca una para migrarla a una fuente instalada, instala la extensión correspondiente o usa \"Eliminar fuente y sus mangas\".';
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -3257,6 +3257,38 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'Ces entrées de bibliothèque pointent vers une source non installée sur cet appareil. Touchez-en une pour la migrer vers une source installée, installez l\'extension correspondante ou utilisez « Supprimer une source et ses mangas » pour les retirer.';
 }

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -3209,6 +3209,38 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'ये प्रविष्टियां ऐसे स्रोत की ओर इशारा करती हैं जो स्थापित नहीं है। माइग्रेट करने के लिए टैप करें या एक्सटेंशन स्थापित करें।';
 }

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -3216,6 +3216,38 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'Entri ini mengarah ke sumber yang tidak terpasang. Ketuk untuk memigrasikan atau pasang ekstensi.';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -3244,6 +3244,38 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'Queste voci puntano a sorgenti non installate. Tocca per migrare o installare l\'estensione.';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -3132,6 +3132,38 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'これらの作品のソースがインストールされていません。移行するか拡張機能をインストールしてください。';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -3241,6 +3241,38 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'Estas entradas apontam para fontes não instaladas. Toque para migrar ou instale a extensão.';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -3256,6 +3256,38 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'Эти тайтлы привязаны к неустановленным источникам. Нажмите для миграции или установите расширение.';
 }

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -3193,6 +3193,38 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'รายการเหล่านี้เชื่อมโยงกับแหล่งที่มาที่ไม่ได้ติดตั้ง แตะเพื่อย้ายหรือติดตั้งส่วนขยาย';
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -3218,6 +3218,38 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       'Bu girdiler yüklü olmayan kaynaklara işaret ediyor. Taşımak için dokunun veya eklentiyi yükleyin.';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -3090,6 +3090,38 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String global_search_no_sources(String itemType) {
+    return 'No $itemType sources are installed.';
+  }
+
+  @override
+  String get global_search_no_sources_hint =>
+      'Add a repository under Browse, then install an extension for it.';
+
+  @override
+  String global_search_only_pinned(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sources',
+      one: '1 source',
+    );
+    return 'You have $_temp0 for this, but only pinned ones are searched.';
+  }
+
+  @override
+  String get global_search_only_pinned_hint =>
+      'Pin one, or turn off \"Only include pinned sources\" in Browse settings.';
+
+  @override
+  String get global_search_all_nsfw =>
+      'Every source you have for this is marked NSFW, and those are hidden.';
+
+  @override
+  String get global_search_all_nsfw_hint =>
+      'Turn on NSFW sources in Browse settings to search them.';
+
+  @override
   String get missing_source_check_result_message =>
       '这些条目关联的图源未安装。点击可进行迁移或安装对应扩展。';
 }

--- a/lib/modules/browse/global_search/global_search_screen.dart
+++ b/lib/modules/browse/global_search/global_search_screen.dart
@@ -14,6 +14,7 @@ import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/services/search.dart';
 import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/utils/item_type_localization.dart';
 import 'package:mangayomi/utils/constant.dart';
 import 'package:mangayomi/utils/headers.dart';
 import 'package:mangayomi/utils/language.dart';
@@ -38,18 +39,22 @@ class _GlobalSearchScreenState extends ConsumerState<GlobalSearchScreen> {
   String _query = "";
   final _textEditingController = TextEditingController();
   late final bool _showNSFW = ref.read(showNSFWStateProvider);
+
+  /// Every installed source for this item type, before the pinned-only and
+  /// NSFW settings are applied.
+  ///
+  /// Kept so an empty result can say which of the three reasons it is: none
+  /// installed, none pinned, or all of them hidden as NSFW. They need
+  /// different things done about them.
+  late final List<Source> _installedSources = isar.sources
+      .where()
+      .itemTypeIsAddedEqualTo(widget.itemType, true)
+      .findAllSync();
+
   late final List<Source> sourceList = () {
     final sources = ref.read(onlyIncludePinnedSourceStateProvider)
-        ? isar.sources
-              .filter()
-              .isPinnedEqualTo(true)
-              .and()
-              .itemTypeEqualTo(widget.itemType)
-              .findAllSync()
-        : isar.sources
-              .where()
-              .itemTypeIsAddedEqualTo(widget.itemType, true)
-              .findAllSync();
+        ? _installedSources.where((e) => e.isPinned ?? false).toList()
+        : _installedSources;
     if (_showNSFW) return sources;
     return sources.where((e) => !(e.isNsfw ?? false)).toList();
   }();
@@ -110,7 +115,12 @@ class _GlobalSearchScreenState extends ConsumerState<GlobalSearchScreen> {
           ),
         ],
       ),
-      body: _query.isNotEmpty || widget.search != null
+      body: sourceList.isEmpty
+          // Without this the screen is a search field over a blank page, which
+          // reads as "nothing matched" when the truth is that nothing was
+          // searched.
+          ? _noSources(context)
+          : _query.isNotEmpty || widget.search != null
           // Every row is built rather than lazily. A source that fails or finds
           // nothing collapses to zero height, and a lazy list that estimates
           // extents cannot cope with that: scrolling up builds more rows, they
@@ -136,6 +146,66 @@ class _GlobalSearchScreenState extends ConsumerState<GlobalSearchScreen> {
               ),
             )
           : Container(),
+    );
+  }
+
+  /// Why a search over no sources found nothing.
+  ///
+  /// Three different situations reach here and only one of them is "install
+  /// something": the other two are settings that filtered every source out,
+  /// and saying "no sources installed" to someone who has ten of them is
+  /// worse than saying nothing.
+  Widget _noSources(BuildContext context) {
+    final l10n = l10nLocalizations(context)!;
+    final pinnedOnly = ref.read(onlyIncludePinnedSourceStateProvider);
+
+    final (String message, String hint) = switch (noSourcesReason(
+      installed: _installedSources.length,
+      pinnedOnly: pinnedOnly,
+    )) {
+      NoSourcesReason.noneInstalled => (
+        l10n.global_search_no_sources(widget.itemType.localized(l10n)),
+        l10n.global_search_no_sources_hint,
+      ),
+      NoSourcesReason.nonePinned => (
+        l10n.global_search_only_pinned(_installedSources.length),
+        l10n.global_search_only_pinned_hint,
+      ),
+      NoSourcesReason.allNsfw => (
+        l10n.global_search_all_nsfw,
+        l10n.global_search_all_nsfw_hint,
+      ),
+    };
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.extension_off_outlined,
+              size: 44,
+              color: context.textColor.withValues(alpha: 0.4),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              hint,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 13,
+                color: context.textColor.withValues(alpha: 0.7),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 
@@ -533,4 +603,36 @@ class _MangaGlobalImageCardState extends ConsumerState<MangaGlobalImageCard>
 
   @override
   bool get wantKeepAlive => true;
+}
+
+/// Why a global search has nothing to search.
+///
+/// Only one of these means "install something". The other two are settings
+/// that filtered every source out, and telling someone with ten sources that
+/// they have none is worse than saying nothing at all.
+enum NoSourcesReason {
+  /// Nothing installed for this item type. The novel library on a device that
+  /// only ever installed manga extensions, for instance.
+  noneInstalled,
+
+  /// Sources exist, but "Only include pinned sources" is on and none of them
+  /// are pinned.
+  nonePinned,
+
+  /// Sources exist and are not excluded by the pinned setting, so the NSFW
+  /// filter is what removed them.
+  allNsfw,
+}
+
+/// Decides which of the three it is.
+///
+/// Called only once the searchable list is already known to be empty, so
+/// something removed every source and this works out what.
+NoSourcesReason noSourcesReason({
+  required int installed,
+  required bool pinnedOnly,
+}) {
+  if (installed == 0) return NoSourcesReason.noneInstalled;
+  if (pinnedOnly) return NoSourcesReason.nonePinned;
+  return NoSourcesReason.allNsfw;
 }

--- a/test/widgets/global_search_no_sources_test.dart
+++ b/test/widgets/global_search_no_sources_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/browse/global_search/global_search_screen.dart';
+
+/// A global search with no sources used to render a search field over a blank
+/// page, which reads as "nothing matched" when the truth is that nothing was
+/// searched. Reaching that state has three different causes and only one of
+/// them is solved by installing something.
+void main() {
+  test('nothing installed for this item type', () {
+    // Tapping a novel from a manga on a device that only ever installed manga
+    // extensions. This is the one that means "go and add a repository".
+    expect(
+      noSourcesReason(installed: 0, pinnedOnly: false),
+      NoSourcesReason.noneInstalled,
+    );
+  });
+
+  test('nothing installed still wins when the pinned filter is on', () {
+    // Otherwise someone with no sources is told to pin one.
+    expect(
+      noSourcesReason(installed: 0, pinnedOnly: true),
+      NoSourcesReason.noneInstalled,
+    );
+  });
+
+  test('sources exist but the pinned filter removed them', () {
+    expect(
+      noSourcesReason(installed: 12, pinnedOnly: true),
+      NoSourcesReason.nonePinned,
+    );
+  });
+
+  test(
+    'sources exist, nothing is filtering but NSFW, so that is the cause',
+    () {
+      // The list is only empty at this point because something removed every
+      // source, and with the pinned filter off the NSFW filter is what is left.
+      expect(
+        noSourcesReason(installed: 3, pinnedOnly: false),
+        NoSourcesReason.allNsfw,
+      );
+    },
+  );
+
+  test('every reason is reachable, so none of the messages is dead', () {
+    final reached = {
+      noSourcesReason(installed: 0, pinnedOnly: false),
+      noSourcesReason(installed: 1, pinnedOnly: true),
+      noSourcesReason(installed: 1, pinnedOnly: false),
+    };
+    expect(reached, NoSourcesReason.values.toSet());
+  });
+}


### PR DESCRIPTION
Searching an item type with no sources renders a search field over a blank page. That reads as "nothing matched", when the truth is that nothing was searched.

It is easy to hit: tap a novel from a device that only ever installed manga extensions, or open a global search for a library you have hidden.

### Three causes, three answers

Only one of them means install something, so they are told apart rather than sharing a line:

| state | what it says |
|---|---|
| nothing installed for this type | add a repository under Browse, then an extension |
| sources exist, none pinned | pin one, or turn off "Only include pinned sources" |
| sources exist, all NSFW and NSFW off | turn NSFW sources on |

Telling someone with twelve sources that they have none is worse than saying nothing, which is why this does not collapse to a single message.

### Incidental

Working out which it is needs the unfiltered list, so the sources are read once and the pinned and NSFW settings applied in memory. That is also one Isar query instead of two, and the pinned branch no longer runs a different query shape (`.filter().isPinnedEqualTo()`) from the unpinned one (`.where().itemTypeIsAddedEqualTo()`).

### Verification

The decision is a pure function, 5 tests: each cause, that nothing-installed still wins when the pinned filter is also on, and that every reason is reachable so none of the three messages is dead.

`dart analyze lib/ test/` clean, full suite green.
