### PR TITLE
fix: raise the two things sitting under a minimum

### DIFF
--- a/lib/modules/library/tv_home/tv_anime_home_view.dart
+++ b/lib/modules/library/tv_home/tv_anime_home_view.dart
@@ -1556,7 +1556,7 @@ class _TvHomeCard extends ConsumerWidget {
                   source,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(fontSize: 9),
+                  style: const TextStyle(fontSize: 12),
                 ),
               ),
             ),

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -1517,15 +1517,20 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                       popUpAnimationStyle: popupAnimationStyle,
                                       itemBuilder: (context) {
                                         return [
+                                          // 48 rather than 40: these are the
+                                          // only two menu rows in the app that
+                                          // set their own height, and 40 is
+                                          // under the minimum target on both
+                                          // Material and Apple.
                                           PopupMenuItem<int>(
-                                            height: 40,
+                                            height: 48,
                                             value: 0,
                                             child: Text(
                                               context.l10n.genre_search_library,
                                             ),
                                           ),
                                           PopupMenuItem<int>(
-                                            height: 40,
+                                            height: 48,
                                             value: 1,
                                             child: Text(
                                               context.l10n.genre_search_source,

--- a/lib/modules/manga/detail/tv/tv_anime_detail_view.dart
+++ b/lib/modules/manga/detail/tv/tv_anime_detail_view.dart
@@ -950,7 +950,7 @@ class _EpisodeRowState extends State<_EpisodeRow> {
                   child: Text(
                     'FILLER',
                     style: TextStyle(
-                      fontSize: 9,
+                      fontSize: 12,
                       color: Theme.of(context).hintColor,
                     ),
                   ),


### PR DESCRIPTION
Two things in the app sit under a documented minimum. This raises both, and nothing else.

**9px on the television.** Two labels, in `tv_anime_home_view` and `tv_anime_detail_view`. Nothing below 11 is legible from across a room, and those are the screens read from there. Both are now 12.

**Menu rows under the tap floor.** Two `PopupMenuItem`s set `height: 40`, under the minimum target on both Material (48) and Apple (44). They are the only menu rows in the app that set their own height; every other one takes the default, which already clears the floor. Both are now 48.

### Why it is only four lines

An earlier audit counted seven `height: 40` boxes. Checking each one individually was worth more than fixing them: five are not tap targets at all.

| site | what it is |
|---|---|
| `list_tile_widget` x2 | a leading icon's box inside a `ListTile`, which supplies its own 48 |
| `chapter_list_tile_widget` | a 2px wide read-indicator bar |
| `restore.dart` | an `Image.asset` height |
| `more_screen` | commented out |
| `manga_detail_view` x2 | **real**, the two menu rows above |

So the tap floor debt was four sevenths smaller than the count suggested, and after this it is clear.

Deliberately not in here: the alpha ladder and the icon size set, which are the parts that need a design direction agreed first. These two are floors rather than taste, so they stand on their own.

`dart analyze lib/ test/` clean, full suite green.
