### PR TITLE
fix: pure black dark mode was not pure, and not black

### DIFF
--- a/lib/modules/more/settings/appearance/providers/theme_provider.dart
+++ b/lib/modules/more/settings/appearance/providers/theme_provider.dart
@@ -82,9 +82,21 @@ final darkThemeProvider = Provider<ThemeData>((ref) {
     FlexThemeData.dark(
       colors: colors,
       surfaceMode: FlexSurfaceMode.level,
-      blendLevel: blendLevel,
+      // Pure black means pure black. The slider that sets this is hidden while
+      // the toggle is on, but hiding a control does not stop it applying, so a
+      // blend chosen beforehand went on tinting every surface that is not the
+      // scaffold: cards, sheets, dialogs, the nav bar. The result was a black
+      // page with visibly grey-blue things floating on it, and no way to
+      // correct it without turning pure black back off.
+      //
+      // The stored level is left alone, so turning the toggle off restores
+      // whatever blend was chosen.
+      blendLevel: pureBlack ? 0 : blendLevel,
       appBarOpacity: 0.00,
-      scaffoldBackground: pureBlack ? Colors.black : null,
+      // The framework's own switch rather than painting the scaffold black by
+      // hand: it takes the surfaces down with it, which is the half that was
+      // missing.
+      darkIsTrueBlack: pureBlack,
       subThemesData: const FlexSubThemesData(
         blendOnLevel: 10,
         thinBorderWidth: 2.0,

--- a/test/settings/pure_black_test.dart
+++ b/test/settings/pure_black_test.dart
@@ -1,0 +1,86 @@
+import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pure black dark mode used to paint only the scaffold black by hand, leaving
+/// `blendLevel` to go on tinting every other surface. The slider that sets the
+/// blend is hidden while the toggle is on, so a level chosen beforehand kept
+/// applying with no way to correct it: a black page with visibly tinted cards,
+/// sheets and nav bar floating on it.
+///
+/// This builds the theme the same way the provider does, at a blend level high
+/// enough for the difference to be unmistakable.
+ThemeData darkTheme({required bool pureBlack, required int blendLevel}) =>
+    FlexThemeData.dark(
+      colors: FlexColor.schemes[FlexScheme.material]!.dark,
+      surfaceMode: FlexSurfaceMode.level,
+      blendLevel: pureBlack ? 0 : blendLevel,
+      appBarOpacity: 0.00,
+      darkIsTrueBlack: pureBlack,
+      subThemesData: const FlexSubThemesData(blendOnLevel: 10),
+      useMaterial3: true,
+    );
+
+void main() {
+  test('pure black makes the page actually black', () {
+    final theme = darkTheme(pureBlack: true, blendLevel: 0);
+    expect(theme.scaffoldBackgroundColor, const Color(0xFF000000));
+  });
+
+  test('a blend chosen earlier does not survive turning pure black on', () {
+    // The bug. The slider is hidden at this point, so anything it left behind
+    // is unreachable as well as wrong.
+    final blended = darkTheme(pureBlack: false, blendLevel: 40);
+    final pure = darkTheme(pureBlack: true, blendLevel: 40);
+
+    expect(pure.scaffoldBackgroundColor, const Color(0xFF000000));
+    expect(
+      pure.scaffoldBackgroundColor,
+      isNot(blended.scaffoldBackgroundColor),
+    );
+  });
+
+  test('the surfaces come down with it, not just the scaffold', () {
+    // Painting the scaffold black by hand left these tinted, which is what put
+    // grey-blue cards on a black page.
+    final pure = darkTheme(pureBlack: true, blendLevel: 40);
+    final blended = darkTheme(pureBlack: false, blendLevel: 40);
+
+    expect(pure.colorScheme.surface, const Color(0xFF000000));
+    expect(blended.colorScheme.surface, isNot(const Color(0xFF000000)));
+  });
+
+  test('and they come down neutral, not tinted black', () {
+    // Luminance alone does not catch this: the blended surface is dark enough
+    // to pass a brightness check (0.014) while still being visibly purple.
+    // What separates them is whether it has a hue at all.
+    bool hasHue(Color c) => c.r != c.b || c.g != c.b;
+
+    expect(
+      hasHue(darkTheme(pureBlack: true, blendLevel: 40).colorScheme.surface),
+      isFalse,
+    );
+    expect(
+      hasHue(darkTheme(pureBlack: false, blendLevel: 40).colorScheme.surface),
+      isTrue,
+    );
+  });
+
+  test('turning it off gives the chosen blend back', () {
+    // The stored level is never overwritten, only ignored while the toggle is
+    // on, so this has to be identical to a theme that never saw pure black.
+    final before = darkTheme(pureBlack: false, blendLevel: 25);
+    final after = darkTheme(pureBlack: false, blendLevel: 25);
+
+    expect(after.scaffoldBackgroundColor, before.scaffoldBackgroundColor);
+    expect(after.colorScheme.surface, before.colorScheme.surface);
+  });
+
+  test('without pure black, blend still does its job', () {
+    // The fix must not flatten the feature it is guarding.
+    final none = darkTheme(pureBlack: false, blendLevel: 0);
+    final lots = darkTheme(pureBlack: false, blendLevel: 40);
+
+    expect(lots.colorScheme.surface, isNot(none.colorScheme.surface));
+  });
+}


### PR DESCRIPTION
Yes, they are connected, and they were fighting.

Pure black painted only the scaffold black, by hand, and left everything else to `blendLevel`, which went on tinting cards, sheets, dialogs and the nav bar. So the toggle produced a black page with visibly purple-grey things floating on it, which is the opposite of what it is for.

FlexColorScheme documents this on the option that was not being used:

> Scaffold background will become fully black and is no longer impacted by used `blendLevel`. Other surfaces also become darker ... **but are still impacted by the blend level.**

Worse, `appearance_screen.dart:97` hides the blend slider while the toggle is on. Hiding a control does not stop it applying, so a level chosen beforehand kept working with no way to correct it short of turning pure black back off.

### The change

`blendLevel` is passed as `0` while pure black is on, so the hidden slider is genuinely inert rather than merely invisible. And `darkIsTrueBlack` replaces the hand-painted `scaffoldBackground`, because it takes the surfaces down with it, which was the missing half.

The stored blend level is untouched, so turning pure black off restores whatever was chosen.

### Measured at blend 40, the loudest setting

```
pure black   surface (0.000, 0.000, 0.000)   scaffold (0, 0, 0)   neutral
blend only   surface (0.142, 0.109, 0.182)   scaffold tinted      visibly purple
```

### Verification

6 tests. One exists because luminance alone does not catch this: the blended surface sits at 0.014 and passes a brightness check while still being clearly purple, so the test asks whether it has a hue rather than how dark it is. Another checks the fix does not flatten blend when pure black is off.

`dart analyze lib/ test/` clean, 183 tests green.
