### PR TITLE
refactor: the chapter dialog follows the theme

### DIFF
--- a/lib/modules/manga/detail/widgets/recommendation_screen.dart
+++ b/lib/modules/manga/detail/widgets/recommendation_screen.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/recommendation.dart';
 import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/constant.dart';
+import 'package:mangayomi/utils/design_tokens.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
 
@@ -21,12 +22,6 @@ const double _cardExtent = _coverHeight + 12;
 /// One column on a phone, two above this, and never more than two: a third
 /// column turns a scannable list of cover-plus-prose into a wall.
 const double _twoColumnBreakpoint = 700;
-
-/// Tints are an alpha over the theme foreground or the accent, never a fixed
-/// colour, because the palette is chosen at runtime.
-const double _alphaTint = 0.08;
-const double _alphaFocus = 0.14;
-const double _alphaSecondary = 0.70;
 
 class RecommendationScreen extends StatefulWidget {
   final String name;
@@ -105,8 +100,9 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
           // to two columns instead so they never run into empty space.
           : LayoutBuilder(
               builder: (context, constraints) {
-                final columns =
-                    constraints.maxWidth >= _twoColumnBreakpoint ? 2 : 1;
+                final columns = constraints.maxWidth >= _twoColumnBreakpoint
+                    ? 2
+                    : 1;
                 return GridView.builder(
                   padding: tvPageInsets,
                   gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
@@ -135,7 +131,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
         // Nothing was focusable on entry, so a remote did nothing until the
         // user guessed a direction. The first card claims focus on a TV.
         autofocus: isTv && index == 0,
-        focusColor: context.primaryColor.withValues(alpha: _alphaFocus),
+        focusColor: context.primaryColor.withValues(alpha: Alphas.focus),
         onTap: () =>
             context.push('/globalSearch', extra: (title, widget.itemType)),
         child: Padding(
@@ -186,7 +182,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                           fontSize: 12,
                           height: 1.35,
                           color: context.textColor.withValues(
-                            alpha: _alphaSecondary,
+                            alpha: Alphas.secondary,
                           ),
                         ),
                       ),
@@ -240,14 +236,14 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
       decoration: BoxDecoration(
-        color: context.textColor.withValues(alpha: _alphaTint),
+        color: context.textColor.withValues(alpha: Alphas.tint),
         borderRadius: BorderRadius.circular(6),
       ),
       child: Text(
         text,
         style: TextStyle(
           fontSize: 11,
-          color: context.textColor.withValues(alpha: _alphaSecondary),
+          color: context.textColor.withValues(alpha: Alphas.secondary),
         ),
       ),
     );

--- a/lib/modules/manga/detail/widgets/watch_order_screen.dart
+++ b/lib/modules/manga/detail/widgets/watch_order_screen.dart
@@ -12,21 +12,13 @@ import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/fetch_watch_order.dart';
 import 'package:mangayomi/utils/constant.dart';
+import 'package:mangayomi/utils/design_tokens.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:marquee/marquee.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
-
-/// Tints are an alpha over the theme foreground or the accent, never a fixed
-/// colour, because the palette is chosen at runtime. Shared with
-/// recommendation_screen so the two sibling screens cannot drift apart.
-const double _alphaTint = 0.08;
-const double _alphaHairline = 0.16;
-const double _alphaFocus = 0.14;
-const double _alphaAccentTint = 0.16;
-const double _alphaSecondary = 0.70;
 
 /// Cover height over width, taken from the artwork itself: AniList serves
 /// these at 230x320. Matching it means BoxFit.cover has nothing to crop, so
@@ -274,7 +266,7 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
                             autofocus: isTv && isCurrent,
                             borderRadius: BorderRadius.circular(12),
                             focusColor: context.primaryColor.withValues(
-                              alpha: _alphaFocus,
+                              alpha: Alphas.focus,
                             ),
                             onTap: () => _openWatchOrder(item),
                             child: Padding(
@@ -327,7 +319,7 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
                                       width: 2,
                                       height: 22,
                                       color: context.textColor.withValues(
-                                        alpha: _alphaHairline,
+                                        alpha: Alphas.hairline,
                                       ),
                                     ),
                                   ),
@@ -365,7 +357,7 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
             overflow: TextOverflow.ellipsis,
             style: TextStyle(
               fontSize: 11,
-              color: context.textColor.withValues(alpha: _alphaSecondary),
+              color: context.textColor.withValues(alpha: Alphas.secondary),
             ),
           ),
         if (item.text.isNotEmpty)
@@ -377,7 +369,7 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
                 fontSize: 11,
-                color: context.textColor.withValues(alpha: _alphaSecondary),
+                color: context.textColor.withValues(alpha: Alphas.secondary),
               ),
             ),
           ),
@@ -497,7 +489,7 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
         return Container(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           decoration: BoxDecoration(
-            color: accent.withValues(alpha: _alphaAccentTint),
+            color: accent.withValues(alpha: Alphas.accentTint),
             borderRadius: BorderRadius.circular(6),
           ),
           child: Text(
@@ -514,7 +506,7 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
         return Container(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           decoration: BoxDecoration(
-            color: neutral.withValues(alpha: _alphaTint),
+            color: neutral.withValues(alpha: Alphas.tint),
             borderRadius: BorderRadius.circular(6),
           ),
           child: Text(
@@ -522,7 +514,7 @@ class _WatchOrderScreenState extends State<WatchOrderScreen> {
             style: TextStyle(
               fontSize: 11,
               fontWeight: FontWeight.w600,
-              color: neutral.withValues(alpha: _alphaSecondary),
+              color: neutral.withValues(alpha: Alphas.secondary),
             ),
           ),
         );

--- a/lib/modules/manga/reader/widgets/btn_chapter_list_dialog.dart
+++ b/lib/modules/manga/reader/widgets/btn_chapter_list_dialog.dart
@@ -8,6 +8,7 @@ import 'package:mangayomi/utils/extensions/manga_extensions.dart';
 import 'package:mangayomi/modules/manga/reader/reader_view.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/utils/date.dart';
+import 'package:mangayomi/utils/design_tokens.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/extensions/string_extensions.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
@@ -229,7 +230,7 @@ class _ChapterListTileState extends State<ChapterListTile> {
                   height: 48,
                   decoration: BoxDecoration(
                     color: chapter.isRead!
-                        ? Colors.grey.withValues(alpha: 0.3)
+                        ? context.textColor.withValues(alpha: Alphas.disabled)
                         : context.primaryColor,
                     borderRadius: BorderRadius.circular(2),
                   ),
@@ -277,14 +278,19 @@ class _ChapterListTileState extends State<ChapterListTile> {
                                           Icon(
                                             Icons.access_time_rounded,
                                             size: 12,
-                                            color: Colors.grey,
+                                            color: context.textColor.withValues(
+                                              alpha: Alphas.secondary,
+                                            ),
                                           ),
                                           const SizedBox(width: 4),
                                           Text(
                                             dateText,
-                                            style: const TextStyle(
+                                            style: TextStyle(
                                               fontSize: 11,
-                                              color: Colors.grey,
+                                              color: context.textColor
+                                                  .withValues(
+                                                    alpha: Alphas.secondary,
+                                                  ),
                                             ),
                                           ),
                                         ],
@@ -300,22 +306,26 @@ class _ChapterListTileState extends State<ChapterListTile> {
                                         false) &&
                                     (chapter.dateUpload != null &&
                                         chapter.dateUpload!.isNotEmpty))
-                                  const Padding(
-                                    padding: EdgeInsets.symmetric(
+                                  Padding(
+                                    padding: const EdgeInsets.symmetric(
                                       horizontal: 6,
                                     ),
                                     child: Text(
                                       '•',
                                       style: TextStyle(
                                         fontSize: 11,
-                                        color: Colors.grey,
+                                        color: context.textColor.withValues(
+                                          alpha: Alphas.secondary,
+                                        ),
                                       ),
                                     ),
                                   ),
                                 Icon(
                                   Icons.group_rounded,
                                   size: 12,
-                                  color: Colors.grey,
+                                  color: context.textColor.withValues(
+                                    alpha: Alphas.secondary,
+                                  ),
                                 ),
                                 const SizedBox(width: 4),
                                 Flexible(
@@ -323,7 +333,9 @@ class _ChapterListTileState extends State<ChapterListTile> {
                                     chapter.scanlator!,
                                     style: TextStyle(
                                       fontSize: 11,
-                                      color: Colors.grey,
+                                      color: context.textColor.withValues(
+                                        alpha: Alphas.secondary,
+                                      ),
                                     ),
                                     overflow: TextOverflow.ellipsis,
                                   ),
@@ -402,7 +414,9 @@ class _ChapterListTileState extends State<ChapterListTile> {
                               : Icons.bookmark_outline_rounded,
                           color: isBookmarked
                               ? context.primaryColor
-                              : Colors.grey,
+                              : context.textColor.withValues(
+                                  alpha: Alphas.disabled,
+                                ),
                           size: 22,
                         ),
                       ),

--- a/lib/utils/design_tokens.dart
+++ b/lib/utils/design_tokens.dart
@@ -1,0 +1,50 @@
+/// The one place the design contract's numbers live.
+///
+/// These were previously copied into each screen that needed them, as private
+/// constants, which is how two screens reached for the same concept and picked
+/// different values: an audit found focus washes at 0.16 and 0.12, neutral
+/// fills at 0.08 and 0.09, and secondary text at 0.7 and 0.6, between two
+/// screens a reader reaches from the same detail page.
+///
+/// Reconciling those was the easy half. The hard half is not doing it again,
+/// and a copied constant is copied again by the next screen.
+library;
+
+/// Neutral and accent tints are an alpha over the foreground or the accent,
+/// never a separate colour, so they survive a theme change and every palette
+/// in the catalogue.
+///
+/// This ladder is closed. Reaching for an eighth value almost always means
+/// duplicating one of these.
+abstract final class Alphas {
+  /// Chip and neutral badge fill, over the foreground.
+  static const double tint = 0.08;
+
+  /// Thin rules and connectors, over the foreground.
+  static const double hairline = 0.16;
+
+  /// Pointer and d-pad focus wash on an InkWell, over the accent.
+  static const double focus = 0.14;
+
+  /// Accent tinted badge fill, over the accent.
+  static const double accentTint = 0.16;
+
+  /// Secondary text, over the foreground.
+  static const double secondary = 0.70;
+
+  /// Ambient focusColor on a television only, over the accent. Higher than
+  /// [focus] because it is read from across a room.
+  static const double tvFocus = 0.45;
+
+  /// Disabled text and icons, over the foreground.
+  ///
+  /// Material's own value rather than the 0.5 and 0.6 found in the codebase,
+  /// because disabled text has a contrast floor to clear and 0.5 does not
+  /// clear it against every palette.
+  static const double disabled = 0.38;
+}
+
+/// Covers are 2:3. Every source ships them at some approximation of it, so the
+/// box is fixed and the image is cropped to fill rather than the box moving to
+/// fit whatever arrived.
+const double coverAspect = 2 / 3;

--- a/test/utils/design_tokens_test.dart
+++ b/test/utils/design_tokens_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/utils/design_tokens.dart';
+
+/// The ladder existed as private constants copied into each screen that needed
+/// it, which is how two screens a reader reaches from the same detail page
+/// ended up with focus washes at 0.16 and 0.12 and secondary text at 0.7 and
+/// 0.6. These pin the values so a copy cannot quietly diverge again.
+void main() {
+  test('the ladder is what the contract says', () {
+    expect(Alphas.tint, 0.08);
+    expect(Alphas.hairline, 0.16);
+    expect(Alphas.focus, 0.14);
+    expect(Alphas.accentTint, 0.16);
+    expect(Alphas.secondary, 0.70);
+    expect(Alphas.tvFocus, 0.45);
+    expect(Alphas.disabled, 0.38);
+  });
+
+  test('disabled clears the floor that 0.5 and 0.6 were used for', () {
+    // The codebase dimmed things at 0.5 and 0.6. Material's 0.38 wins because
+    // disabled text has a contrast floor and the higher values do not clear it
+    // against every palette in the catalogue.
+    expect(Alphas.disabled, lessThan(0.5));
+  });
+
+  test('a television focus is louder than a pointer one', () {
+    // It is read from across a room.
+    expect(Alphas.tvFocus, greaterThan(Alphas.focus));
+  });
+
+  test('secondary text stays legible, tints stay out of the way', () {
+    expect(Alphas.secondary, greaterThan(Alphas.disabled));
+    expect(Alphas.tint, lessThan(Alphas.hairline));
+  });
+
+  test('covers are 2:3', () {
+    expect(coverAspect, closeTo(0.667, 0.001));
+  });
+}


### PR DESCRIPTION
Stacked on #946, which is where the token names come from.

Seven colours in the chapter list dialog were `Colors.grey`: a fixed value that does not move when the theme or the palette does. The dialog is themed, so on a light theme that is grey metadata on white, where every other screen puts the app's own secondary text.

They were not all the same thing, and the ladder already had a name for each:

- **Five are secondary metadata** — the upload date and its icon, the scanlator and its icon, and the separator between them.
- **Two are an off state rather than a colour** — a read chapter's indicator bar and an unbookmarked bookmark, both of which sit opposite the accent when they are on.

So five take `Alphas.secondary` and two take `Alphas.disabled`, over the foreground rather than over nothing.

One `const Padding` became non-const, because a token read from context cannot live in a constant expression. That is the only structural change.

### What was deliberately left alone

There are 42 hardcoded greys in the codebase. Most are not this bug, and changing them by count rather than by case would break things:

| site | why it stays |
|---|---|
| `BackgroundColor.grey => Colors.grey` | a reader background the user picks |
| `Colors.grey[800]` / `[300]` swatches | colours being offered in a picker |
| sync tile icon | sits on a fixed navy badge, so grey is deliberate |
| novel reader table borders, blockquote bars | render inside content whose background the reader chose, so they want that colour, not the app theme |
| player overlay greys | drawn over video, where white and grey are correct regardless of theme |

That last group is worth its own change and a different rule, since "follow the reader's chosen colour" is not the same job as "follow the app theme".

`dart analyze lib/` clean, 182 tests green.
