### PR TITLE
fix: a season is part of which chapter a chapter is

### DIFF
--- a/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
+++ b/lib/modules/manga/detail/providers/update_manga_detail_providers.dart
@@ -83,20 +83,20 @@ Future<dynamic> updateMangaDetail(
       final existingChapters = manga.chapters.toList();
       final recognition = ChapterRecognition();
 
-      // The exact number, not the sort key. parseChapterNumber truncates, so
-      // chapters 12, 12.1 and 12.5 all answer 12 and every use of this below
-      // treats them as the same chapter: the composite key drops two of the
-      // three before they reach the library, and read state carries across
-      // all three. rawSeasonAndNumber keeps the fraction, and answers null
-      // for a name with no number at all rather than folding every "Special"
-      // and "Prologue" onto zero.
-      double? numberOf(Chapter c) {
+      // Season and episode together, never the episode alone. The episode
+      // alone makes season 2 episode 1 the same chapter as season 1 episode 1,
+      // so whichever arrives second is dropped before it reaches the library
+      // and a two season show displays one season.
+      //
+      // Not parseChapterNumber either: that truncates, so 12, 12.1 and 12.5
+      // all answer 12 and two of the three are dropped the same way.
+      String? identityOf(Chapter c, {bool withScanlator = true}) {
         if (c.name == null) return null;
-        final (_, number) = recognition.rawSeasonAndNumber(
+        return recognition.chapterIdentityKey(
           manga.name ?? '',
           c.name!,
+          withScanlator ? (c.scanlator ?? '') : null,
         );
-        return (number ?? 0) > 0 ? number : null;
       }
 
       final existingByUrl = <String, Chapter>{};
@@ -105,8 +105,7 @@ Future<dynamic> updateMangaDetail(
       for (final c in existingChapters) {
         final u = c.url?.trim();
         final urlKey = (u == null || u.isEmpty) ? null : u.getUrlWithoutDomain;
-        final num = numberOf(c);
-        final compositeKey = num == null ? null : '$num::${c.scanlator ?? ''}';
+        final compositeKey = identityOf(c);
 
         final prior =
             (urlKey != null ? existingByUrl[urlKey] : null) ??
@@ -125,12 +124,15 @@ Future<dynamic> updateMangaDetail(
         }
       }
 
-      final readByNumber = <double, bool>{};
+      // Keyed without the scanlator: the same episode from a different group
+      // is still that episode, so read state carries. Keyed with the season
+      // for the same reason as above.
+      final readByEpisode = <String, bool>{};
       for (final c in existingChapters) {
-        final num = numberOf(c);
-        if (num != null) {
-          readByNumber[num] =
-              (readByNumber[num] ?? false) || (c.isRead ?? false);
+        final key = identityOf(c, withScanlator: false);
+        if (key != null) {
+          readByEpisode[key] =
+              (readByEpisode[key] ?? false) || (c.isRead ?? false);
         }
       }
 
@@ -143,13 +145,16 @@ Future<dynamic> updateMangaDetail(
         if (url == null || url.isEmpty) continue;
         final key = url.getUrlWithoutDomain;
 
-        final (_, chapNumber) = chap.name != null
-            ? recognition.rawSeasonAndNumber(manga.name!, chap.name!)
-            : (0, null);
-        final chapNum = chapNumber ?? 0;
-        final compositeKey = chapNum > 0
-            ? '$chapNum::${chap.scanlator ?? ''}'
-            : null;
+        final compositeKey = chap.name == null
+            ? null
+            : recognition.chapterIdentityKey(
+                manga.name!,
+                chap.name!,
+                chap.scanlator ?? '',
+              );
+        final episodeKey = chap.name == null
+            ? null
+            : recognition.chapterIdentityKey(manga.name!, chap.name!);
 
         if (!seenKeys.add(key)) continue;
         if (compositeKey != null && !seenKeys.add('c:$compositeKey')) {
@@ -161,7 +166,8 @@ Future<dynamic> updateMangaDetail(
             (compositeKey != null ? existingByComposite[compositeKey] : null);
 
         if (existing == null) {
-          final alreadyRead = chapNum > 0 && (readByNumber[chapNum] ?? false);
+          final alreadyRead =
+              episodeKey != null && (readByEpisode[episodeKey] ?? false);
 
           final newChapter = Chapter(
             name: chap.name!,

--- a/lib/utils/chapter_recognition.dart
+++ b/lib/utils/chapter_recognition.dart
@@ -36,6 +36,30 @@ class ChapterRecognition {
     return (ep ?? 0).toInt();
   }
 
+  /// The key that answers "are these two the same chapter".
+  ///
+  /// Season is part of the answer. Without it, episode 1 of season 2 is the
+  /// same chapter as episode 1 of season 1, and whichever arrives second is
+  /// dropped before it reaches the library. A show with two seasons then
+  /// displays one of them.
+  ///
+  /// Null when the name carries no number at all, because "Special" and
+  /// "Prologue" are not all the same chapter either. Callers skip the
+  /// composite check in that case rather than folding them together.
+  ///
+  /// [scanlator] is omitted by callers deciding whether read state carries
+  /// over, since the same episode from a different group is still that
+  /// episode.
+  String? chapterIdentityKey(
+    String mangaTitle,
+    String chapterName, [
+    String? scanlator,
+  ]) {
+    final (season, ep) = rawSeasonAndNumber(mangaTitle, chapterName);
+    if (ep == null || ep <= 0) return null;
+    return '$season::$ep::${scanlator ?? ''}';
+  }
+
   /// Raw (season, episode) pair, unbucketed — season is 0 if none matched.
   /// Episode keeps its fractional part (e.g. 12.5) so callers needing exact
   /// chapter identity (dedup, stable sort of split chapters) don't collide

--- a/test/utils/season_identity_test.dart
+++ b/test/utils/season_identity_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/utils/chapter_recognition.dart';
+
+/// Reported after updating 0.8.6 -> 0.8.9: whole seasons disappearing.
+///
+/// On AniWorld, "Clevatess" has season 1 with 12 episodes and season 2 with 8,
+/// and only season 1 survived a library update. "Code Geass" has 12 films plus
+/// 25 episodes in each of two seasons, and only season 2 survived.
+///
+/// Both are the same fault. The key deciding whether two chapters are the same
+/// chapter was built from the episode number alone, so season 2 episode 1 was
+/// season 1 episode 1, and whichever arrived second was skipped before it
+/// reached the library. Which half survives depends only on the order the
+/// source lists them in, which is why two shows lost opposite halves.
+void main() {
+  final recognition = ChapterRecognition();
+
+  String? identity(String show, String name, [String? scanlator]) =>
+      recognition.chapterIdentityKey(show, name, scanlator);
+
+  group('a season is part of a chapter identity', () {
+    test('the same episode number in two seasons is two chapters', () {
+      expect(
+        identity('Clevatess', 'Staffel 1 Folge 1'),
+        isNot(identity('Clevatess', 'Staffel 2 Folge 1')),
+      );
+    });
+
+    test('a shorter second season survives the first', () {
+      // Clevatess: 12 then 8. The 8 collided and vanished.
+      final keys = <String?>{
+        for (var e = 1; e <= 12; e++)
+          identity('Clevatess', 'Staffel 1 Folge $e'),
+        for (var e = 1; e <= 8; e++)
+          identity('Clevatess', 'Staffel 2 Folge $e'),
+      };
+      expect(keys, hasLength(20));
+    });
+
+    test('two full seasons of the same length both survive', () {
+      // Code Geass: 25 and 25. One of them vanished entirely.
+      final keys = <String?>{
+        for (var e = 1; e <= 25; e++)
+          identity('Code Geass', 'Season 1 Episode $e'),
+        for (var e = 1; e <= 25; e++)
+          identity('Code Geass', 'Season 2 Episode $e'),
+      };
+      expect(keys, hasLength(50));
+    });
+
+    test('de-duplication within one season still works', () {
+      // Or this trades one bug for another.
+      expect(
+        identity('Clevatess', 'Staffel 1 Folge 3'),
+        identity('Clevatess', 'Staffel 1 Folge 3'),
+      );
+    });
+  });
+
+  group('what the key refuses to answer', () {
+    test('a name with no number is not an identity', () {
+      // Otherwise every Special is the same chapter as every other one, which
+      // is the same bug in a different shape.
+      expect(identity('Code Geass', 'Special'), isNull);
+      expect(identity('Code Geass', 'Prologue'), isNull);
+    });
+
+    test('decimal chapters stay apart', () {
+      expect(
+        identity('One Piece', 'Chapter 12'),
+        isNot(identity('One Piece', 'Chapter 12.5')),
+      );
+    });
+
+    test('the scanlator separates releases, and is optional', () {
+      expect(
+        identity('One Piece', 'Chapter 12', 'A'),
+        isNot(identity('One Piece', 'Chapter 12', 'B')),
+      );
+      // Omitted when deciding whether read state carries over: the same
+      // episode from another group is still that episode.
+      expect(
+        identity('One Piece', 'Chapter 12'),
+        identity('One Piece', 'Chapter 12'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Reported after updating 0.8.6 to 0.8.9: whole seasons disappearing from the library.

On AniWorld, **Clevatess** has 12 episodes in season 1 and 8 in season 2, and only season 1 survived an update. **Code Geass** has 12 films plus 25 episodes in each of two seasons, and only season 2 survived.

Opposite halves lost, same fault.

### The key was season blind

`update_manga_detail_providers.dart` decided whether two chapters were the same chapter with:

```dart
final (_, chapNumber) = recognition.rawSeasonAndNumber(manga.name!, chap.name!);
final chapNum = chapNumber ?? 0;
final compositeKey = chapNum > 0 ? '$chapNum::${chap.scanlator ?? ''}' : null;
...
if (compositeKey != null && !seenKeys.add('c:$compositeKey')) continue;
```

`rawSeasonAndNumber` returns the season alongside the episode, and the season is discarded on the first line. So season 2 episode 1 keys identically to season 1 episode 1, and the second one to arrive hits that `continue` and never reaches the library.

Which half survives depends only on the order the source lists them in. That is why one show lost its second season and the other lost its first.

The irony is in `rawSeasonAndNumber`'s own doc comment, which says it exists so *"callers needing exact chapter identity (dedup...) don't collide"*.

### Three places, one concept

Read state carried by episode number alone as well, so reading season 1 episode 1 marked season 2 episode 1 as read.

The key now lives on `ChapterRecognition`, beside the two numbers it is built from, because the last time this went wrong it was a caller picking the wrong one of those. It takes an optional scanlator: de-duplication passes it, the read-state carry does not, since the same episode from another group is still that episode.

### Verification

7 tests, built from the two reported shows:

- 12 episodes plus 8 in a second season produce 20 identities, not 12
- 25 plus 25 produce 50, not 25
- de-duplication within one season still collapses
- a name with no number is still no identity, or every "Special" becomes the same chapter as every other one, which is this same bug in a different shape

`dart analyze lib/ test/` clean, 184 tests green.
