### PR TITLE
fix: stop telling Linux to use a resolver it does not have

### DIFF
--- a/lib/services/http/m_client.dart
+++ b/lib/services/http/m_client.dart
@@ -274,14 +274,32 @@ class LoggerInterceptor extends InterceptorContract {
         Logger.add(LoggerLevel.info, content);
       }
       if (cloudflare) {
+        // The in-app resolver is disabled on Linux, and cookies cannot be read
+        // back from a webview there either, so the offer to solve it manually
+        // in one is an offer nobody on Linux can take. A proxy is the only
+        // thing that gets past this, so say that instead.
+        //
+        // This is also reached by sites nobody thinks of as "having
+        // Cloudflare": a plain proxied site answers every response with
+        // `server: cloudflare`, including a 403 raised for some other reason,
+        // and that is enough to land here.
+        final noResolverAvailable =
+            Platform.isLinux && CfProxyStore.url.trim().isEmpty;
         try {
           botToast(
-            "${response.statusCode} Failed to bypass Cloudflare",
-            hasCloudFlare: cloudflare,
+            noResolverAvailable
+                ? "${response.statusCode} blocked by Cloudflare. Set a "
+                      "FlareSolverr or Byparr URL in Settings > General to get "
+                      "past it on Linux."
+                : "${response.statusCode} Failed to bypass Cloudflare",
+            // The button opens the webview resolver, which does nothing here.
+            hasCloudFlare: cloudflare && !noResolverAvailable,
             url: response.request!.url.toString(),
           );
         } catch (e) {
-          throw "Failed to bypass Cloudflare.\n\n\nYou can try to bypass it manually in the webview \n\n\nstatusCode: ${response.statusCode}";
+          throw noResolverAvailable
+              ? "Blocked by Cloudflare.\n\n\nThe in-app resolver is not available on Linux. Set a FlareSolverr or Byparr URL in Settings > General.\n\n\nstatusCode: ${response.statusCode}"
+              : "Failed to bypass Cloudflare.\n\n\nYou can try to bypass it manually in the webview \n\n\nstatusCode: ${response.statusCode}";
         }
       }
     }


### PR DESCRIPTION
When a Cloudflare block is detected the app offers to solve it manually in a webview. On Linux that offer cannot be taken:

- `ResolveCloudFlareChallenge` returns `false` on `Platform.isLinux` before the resolver runs
- `MClient.setCookie`'s `CookieManager` branch is gated behind `!Platform.isLinux`, so a solved cookie could not be read back even if it did

So the one path that does work on Linux, a FlareSolverr or Byparr proxy, is the one thing the message never mentions. The button beside it opens that same unavailable resolver, so it is no longer offered on Linux when no proxy is configured.

### Why this is confusing to report

This is reached by sites nobody thinks of as "having Cloudflare".

A site merely proxied through Cloudflare answers **every** response with `server: cloudflare`, including a 403 raised for some entirely unrelated reason. Detection is that header plus a 403 or 503, and nothing more. So "this site does not have Cloudflare" and "the app says Cloudflare" are both true at the same time, and the platform split is only that other platforms have a resolver to get past it.

Reported against AniWorld on Linux, where library updates do nothing and the error comes back as Cloudflare. The same requests succeed on iOS because the webview resolver runs there.

### Scope

Only the message and the button change. Detection and bypass behaviour are untouched, and the text is unchanged wherever a resolver does exist.

This does not give Linux a bypass. It stops the app sending people somewhere that cannot work and points at the thing that can.

`dart analyze lib/` clean, 177 tests green.
