### PR TITLE
fix: the novel reader's controller is gone by the time dispose needs it

### DIFF
--- a/lib/modules/novel/novel_reader_view.dart
+++ b/lib/modules/novel/novel_reader_view.dart
@@ -67,9 +67,14 @@ class NovelWebView extends ConsumerStatefulWidget {
 
 class _NovelWebViewState extends ConsumerState<NovelWebView>
     with TickerProviderStateMixin, WidgetsBindingObserver {
-  late final NovelReaderController _readerController = ref.read(
-    novelReaderControllerProvider(chapter: chapter).notifier,
-  );
+  /// Resolved in [initState], not lazily.
+  ///
+  /// As a `late` field with an initialiser this was read for the first time
+  /// by whatever touched it first, and on a reader closed before its first
+  /// build got that far, that was `dispose()`. Riverpod forbids `ref` there:
+  /// it needs the BuildContext, and the element is already deactivated. See
+  /// issue #949, reported from the novel reader on 0.8.9.
+  late final NovelReaderController _readerController;
   final _scrollController = ScrollController(
     initialScrollOffset: 0,
     keepScrollOffset: true,
@@ -137,6 +142,11 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
   @override
   void initState() {
     super.initState();
+    // Before anything that can fail, so the controller dispose() needs is
+    // always there: this is the whole point of not leaving it lazy.
+    _readerController = ref.read(
+      novelReaderControllerProvider(chapter: chapter).notifier,
+    );
     WidgetsBinding.instance.addObserver(this);
     _readingStopwatch.start();
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/test/modules/novel_ref_after_dispose_test.dart
+++ b/test/modules/novel_ref_after_dispose_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// #949 is `Bad state: Using "ref" when a widget is about to or has been
+/// unmounted is unsafe.`, thrown from `_NovelWebViewState.dispose()`.
+///
+/// The novel reader held its controller as a `late` field with an initialiser:
+///
+/// ```dart
+/// late final NovelReaderController _readerController = ref.read(
+///   novelReaderControllerProvider(chapter: chapter).notifier,
+/// );
+/// ```
+///
+/// A `late` field is resolved by whoever reads it first. Every ordinary path
+/// reads it during `build`, which is safe. But `dispose()` also uses it, to
+/// write the scroll offset and the history entry, and a reader closed before
+/// its first build got that far leaves `dispose()` as the first reader — at
+/// which point the element is deactivated and `ref` is gone.
+///
+/// These cover the shape of that, since the real widget needs isar, a chapter
+/// and a loaded source to build at all.
+void main() {
+  final probeProvider = Provider<int>((ref) => 1);
+
+  testWidgets('a late field read first by dispose reaches for a dead ref', (
+    tester,
+  ) async {
+    // The premise. If this did not throw there would be nothing to fix.
+    Object? thrown;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: _Probe(
+            provider: probeProvider,
+            onDisposeError: (e) {
+              thrown = e;
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Never built anything that touched the field, which is the case a reader
+    // closed during loading hits.
+    await tester.pumpWidget(const ProviderScope(child: SizedBox()));
+
+    expect(thrown, isStateError);
+    expect(
+      (thrown as StateError).message,
+      contains('unmounted'),
+      reason: 'this is the exact error #949 reports',
+    );
+  });
+
+  testWidgets('resolving it in initState leaves dispose something to use', (
+    tester,
+  ) async {
+    // The shape the fix uses.
+    Object? thrown;
+    int? seenInDispose;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: _Probe(
+            provider: probeProvider,
+            eager: true,
+            onDisposeError: (e) {
+              thrown = e;
+            },
+            onDisposeValue: (v) {
+              seenInDispose = v;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(const ProviderScope(child: SizedBox()));
+
+    expect(thrown, isNull);
+    expect(
+      seenInDispose,
+      1,
+      reason: 'dispose still gets the real value, not a fallback',
+    );
+  });
+}
+
+class _Probe extends ConsumerStatefulWidget {
+  const _Probe({
+    required this.provider,
+    required this.onDisposeError,
+    this.onDisposeValue,
+    this.eager = false,
+  });
+
+  final Provider<int> provider;
+  final void Function(Object) onDisposeError;
+  final void Function(int)? onDisposeValue;
+
+  /// Whether to resolve the field while the widget is still alive.
+  final bool eager;
+
+  @override
+  ConsumerState<_Probe> createState() => _ProbeState();
+}
+
+class _ProbeState extends ConsumerState<_Probe> {
+  late final int _lazy = ref.read(widget.provider);
+  int? _eager;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.eager) _eager = ref.read(widget.provider);
+  }
+
+  @override
+  void dispose() {
+    // The reader writes its scroll offset and history entry from here, so it
+    // has to read the field whether or not anything else already did.
+    try {
+      final value = widget.eager ? _eager! : _lazy;
+      widget.onDisposeValue?.call(value);
+    } catch (e) {
+      widget.onDisposeError(e);
+    }
+    super.dispose();
+  }
+
+  // Deliberately does not touch the field: that is the path that breaks.
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}


### PR DESCRIPTION
Closes #949.

`Bad state: Using "ref" when a widget is about to or has been unmounted is unsafe.`, thrown from `_NovelWebViewState.dispose()` on 0.8.9.

### Why

The controller was a `late` field with an initialiser:

```dart
late final NovelReaderController _readerController = ref.read(
  novelReaderControllerProvider(chapter: chapter).notifier,
);
```

A `late` field is resolved by whichever code reads it first. Every ordinary path reads it during `build`, which is safe. But `dispose()` uses it too — it writes the scroll offset and the history entry — and a reader closed *before its first build got that far* leaves `dispose()` as the first reader. By then the element is deactivated and `ref` will not answer.

That is the path in the report: the reader was closed while the chapter was still loading.

### The fix

Resolved in `initState()` instead, before anything that can fail.

The value is identical. The `chapter` it keys on is `late Chapter chapter = widget.chapter`, assigned once and never reassigned, so an eagerly resolved controller is the same controller the lazy one would have produced — only it now exists before `dispose()` needs it.

### Testing

The test covers the shape rather than the widget, which needs isar, a chapter and a loaded source to build at all. Same approach as `test/modules/player_after_dispose_test.dart` from #931.

Two cases. The second shows the fix leaves `dispose()` a real value. The first asserts the **premise** — that a `late` field read first by `dispose()` really does throw, with the message this issue quotes — so the test would start failing if that ever stopped being true.

`dart analyze` clean, full suite green.
