### PR TITLE
Fix cache collision via chapter hash in filename

### DIFF
--- a/lib/utils/extensions/others.dart
+++ b/lib/utils/extensions/others.dart
@@ -82,8 +82,18 @@ extension UChapDataPreloadExtensions on UChapDataPreload {
     if (isTransitionPage) return null;
     if (archiveImage != null) {
       final tempDir = Directory.systemTemp;
+      final sourceKey = [
+        chapter?.id?.toString(),
+        chapter?.archivePath,
+        directory?.path,
+        chapter?.url,
+      ].whereType<String>().where((value) => value.isNotEmpty).join('|');
+      final chapterKey = keyToMd5(sourceKey);
       final tempFile = File(
-        p.join(tempDir.path, 'mangayomi_archive_${index ?? pageIndex}.jpg'),
+        p.join(
+          tempDir.path,
+          'mangayomi_archive_${chapterKey}_${index ?? pageIndex}.jpg',
+        ),
       );
       if (!tempFile.existsSync()) {
         tempFile.writeAsBytesSync(archiveImage!);


### PR DESCRIPTION
Include the chapter identity in the filename:
page indexes are only unique within a chapter, and using the index alone causes page 0 from the first opened chapter to be reused for every other chapter.