### PR TITLE
fix: triage error reports and resolve reported crashes

### DIFF
--- a/lib/modules/manga/detail/manga_details_view.dart
+++ b/lib/modules/manga/detail/manga_details_view.dart
@@ -153,11 +153,11 @@ class _MangaDetailsViewState extends ConsumerState<MangaDetailsView> {
                     backgroundColor: Theme.of(context).scaffoldBackgroundColor,
                     elevation: 0,
                   ),
-                  onPressed: () {
+                  onPressed: () async {
                     final model = widget.manga;
                     model.favorite = false;
                     model.dateAdded = 0;
-                    mangaRepository.save(model);
+                    await mangaRepository.save(model);
                   },
                   child: Column(
                     children: [
@@ -177,7 +177,7 @@ class _MangaDetailsViewState extends ConsumerState<MangaDetailsView> {
                   backgroundColor: Theme.of(context).scaffoldBackgroundColor,
                   elevation: 0,
                 ),
-                onPressed: () {
+                onPressed: () async {
                   final model = widget.manga;
                   final checkCategoryList = categoryRepository
                       .isNotEmptyByItemType(model.itemType);
@@ -191,7 +191,7 @@ class _MangaDetailsViewState extends ConsumerState<MangaDetailsView> {
                   } else {
                     model.favorite = true;
                     model.dateAdded = DateTime.now().millisecondsSinceEpoch;
-                    mangaRepository.save(model);
+                    await mangaRepository.save(model);
                   }
                 },
                 child: Column(

--- a/lib/modules/more/about/error_reports_screen.dart
+++ b/lib/modules/more/about/error_reports_screen.dart
@@ -79,6 +79,7 @@ class _ReportTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = l10nLocalizations(context)!;
     final cause = report.likelyCause;
+    final scope = crashReportScope(report);
 
     return ExpansionTile(
       title: Text(report.summary, maxLines: 3, overflow: TextOverflow.ellipsis),
@@ -91,7 +92,7 @@ class _ReportTile extends StatelessWidget {
       childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
       expandedCrossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (isExtensionFailure(report.error)) ...[
+        if (scope == CrashReportScope.extension) ...[
           // #914 was an extension bug filed here, because the screen offered a
           // Report button pointing at this repository and gave the reader no
           // way to know the difference.
@@ -106,7 +107,7 @@ class _ReportTile extends StatelessWidget {
           ),
           const SizedBox(height: 12),
         ],
-        if (isExpectedFailure(report.error)) ...[
+        if (scope == CrashReportScope.external) ...[
           // #915 and #916 were both filed through this screen for images that
           // failed to load. The likely-cause line was not enough on its own,
           // so say plainly that this one is probably not the app's fault.
@@ -148,7 +149,7 @@ class _ReportTile extends StatelessWidget {
             // Network and extension failures do not belong in this
             // repository, and a fault already sent does not need sending
             // twice (#917, #918).
-            if (isReportableFailure(report.error))
+            if (scope == CrashReportScope.app)
               FilledButton.icon(
                 onPressed: CrashReports.wasReported(report)
                     ? null

--- a/lib/modules/more/about/error_reports_screen.dart
+++ b/lib/modules/more/about/error_reports_screen.dart
@@ -84,7 +84,8 @@ class _ReportTile extends StatelessWidget {
       title: Text(report.summary, maxLines: 3, overflow: TextOverflow.ellipsis),
       subtitle: Text(
         '${report.time.toLocal()}'.split('.').first +
-            (report.screen == null ? '' : '  ·  ${report.screen}'),
+            (report.screen == null ? '' : '  ·  ${report.screen}') +
+            (report.occurrences > 1 ? '  ·  ×${report.occurrences}' : ''),
         style: TextStyle(color: context.secondaryColor, fontSize: 12),
       ),
       childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
@@ -144,9 +145,10 @@ class _ReportTile extends StatelessWidget {
         Wrap(
           spacing: 8,
           children: [
-            // An extension bug does not belong in this repository, and a
-            // fault already sent does not need sending twice (#917, #918).
-            if (!isExtensionFailure(report.error))
+            // Network and extension failures do not belong in this
+            // repository, and a fault already sent does not need sending
+            // twice (#917, #918).
+            if (isReportableFailure(report.error))
               FilledButton.icon(
                 onPressed: CrashReports.wasReported(report)
                     ? null

--- a/lib/modules/more/settings/browse/extension_server_screen.dart
+++ b/lib/modules/more/settings/browse/extension_server_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -14,6 +15,7 @@ import 'package:mangayomi/modules/more/settings/browse/extension_server/extensio
 import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/repositories/settings_repository.dart';
+import 'package:mangayomi/services/crash_report.dart';
 import 'package:mangayomi/services/fetch_sources_list.dart';
 import 'package:mangayomi/services/m_extension_server.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
@@ -52,8 +54,8 @@ class _ExtensionServerScreenState extends ConsumerState<ExtensionServerScreen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _refreshStatus();
-      _refreshRuntimeStatus();
+      unawaited(_refreshStatus());
+      unawaited(_refreshRuntimeStatus());
     });
   }
 
@@ -405,24 +407,50 @@ class _ExtensionServerScreenState extends ConsumerState<ExtensionServerScreen> {
     }
     final l10n = l10nLocalizations(context)!;
     _setCheckingState(true);
-    final configuredPaths = _readConfiguredPaths();
-    final fileState = await _resolveFileState(configuredPaths);
-    final releaseState = await _resolveLatestReleaseState(l10n, fileState);
+    try {
+      final configuredPaths = _readConfiguredPaths();
+      final fileState = await _resolveFileState(configuredPaths);
+      final releaseState = await _resolveLatestReleaseState(l10n, fileState);
+      if (!mounted) return;
+      final selectedInstallDirectory = await _resolveSelectedInstallDirectory(
+        configuredPaths,
+      );
+      _applyStatusState(
+        selectedInstallDirectory: selectedInstallDirectory,
+        configuredPaths: configuredPaths,
+        fileState: fileState,
+        releaseState: releaseState,
+      );
+    } on FileSystemException {
+      _applyStatusFailure(l10n.could_not_check_proxy_server_updates);
+    } catch (error, stack) {
+      // Expected storage failures are handled above. Anything else is still a
+      // genuine app failure and should remain actionable in the reporter.
+      CrashReports.record(
+        source: 'ExtensionServerStatus',
+        error: error,
+        stack: stack,
+      );
+      _applyStatusFailure(l10n.could_not_check_proxy_server_updates);
+    }
+  }
+
+  void _applyStatusFailure(String message) {
     if (!mounted) return;
-    final selectedInstallDirectory = await _resolveSelectedInstallDirectory(
-      configuredPaths,
-    );
-    _applyStatusState(
-      selectedInstallDirectory: selectedInstallDirectory,
-      configuredPaths: configuredPaths,
-      fileState: fileState,
-      releaseState: releaseState,
-    );
+    setState(() {
+      _isChecking = false;
+      _releaseCheckMessage = message;
+    });
   }
 
   Future<void> _refreshRuntimeStatus() async {
     if (!Platform.isIOS) return;
-    final running = await MExtensionServerPlatform(ref).checkLocalServer();
+    var running = false;
+    try {
+      running = await MExtensionServerPlatform(ref).checkLocalServer();
+    } catch (_) {
+      // A missing local runtime is a stopped server, not a global app crash.
+    }
     if (mounted) setState(() => _runtimeRunning = running);
   }
 
@@ -589,8 +617,7 @@ class _ExtensionServerScreenState extends ConsumerState<ExtensionServerScreen> {
 
   Future<Directory> _defaultInstallDirectory() async {
     final provider = StorageProvider();
-    final serverDirectory = await provider.getExtensionServerDirectory();
-    return serverDirectory!;
+    return provider.getExtensionServerDirectory();
   }
 
   Future<ExtensionServerRelease?> _fetchLatestRelease() async {
@@ -641,10 +668,10 @@ class _ExtensionServerScreenState extends ConsumerState<ExtensionServerScreen> {
   }
 
   _ConfiguredPaths _readConfiguredPaths() {
-    final settings = settingsRepository.current;
+    final settings = settingsRepository.currentOrNull;
     return _ConfiguredPaths(
-      jrePath: settings.jrePath ?? '',
-      extensionServerPath: settings.extensionServerPath ?? '',
+      jrePath: settings?.jrePath ?? '',
+      extensionServerPath: settings?.extensionServerPath ?? '',
     );
   }
 

--- a/lib/modules/more/settings/browse/providers/browse_state_provider.dart
+++ b/lib/modules/more/settings/browse/providers/browse_state_provider.dart
@@ -19,7 +19,8 @@ class AndroidProxyServerState extends _$AndroidProxyServerState {
   @override
   String build() {
     String proxyServer =
-        settingsRepository.current.androidProxyServer ?? "http://127.0.0.1:8080";
+        settingsRepository.currentOrNull?.androidProxyServer ??
+        "http://127.0.0.1:8080";
     if (!proxyServer.startsWith("http")) {
       proxyServer = "http://$proxyServer";
     }
@@ -43,7 +44,7 @@ class AutoStartExtensionServerOnLaunchState
     extends _$AutoStartExtensionServerOnLaunchState {
   @override
   bool build() {
-    return settingsRepository.current.autoStartExtensionServerOnLaunch ??
+    return settingsRepository.currentOrNull?.autoStartExtensionServerOnLaunch ??
         false;
   }
 

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -79,9 +79,12 @@ class StorageProvider {
     return await dir.exists() ? dir : null;
   }
 
-  Future<Directory?> getExtensionServerDirectory() async {
+  Future<Directory> getExtensionServerDirectory() async {
     final defaultDirectory = await getDefaultDirectory();
-    String dbDir = path.join(defaultDirectory!.path, 'extension_server');
+    if (defaultDirectory == null) {
+      throw StateError('The app storage directory is unavailable');
+    }
+    String dbDir = path.join(defaultDirectory.path, 'extension_server');
     await Directory(dbDir).create(recursive: true);
     return Directory(dbDir);
   }

--- a/lib/repositories/manga_repository.dart
+++ b/lib/repositories/manga_repository.dart
@@ -291,12 +291,12 @@ class MangaRepository {
 
   // Stamps updatedAt for callers that just want to persist a mutated Manga
   // they already hold, without setting the timestamp themselves.
-  Future<void> save(Manga manga) => dbWriteQueue.run(() {
-    isar.writeTxnSync(() {
+  Future<void> save(Manga manga) => dbWriteQueue.run(
+    () => isar.writeTxn(() async {
       manga.updatedAt = DateTime.now().millisecondsSinceEpoch;
-      isar.mangas.putSync(manga);
-    });
-  });
+      await isar.mangas.put(manga);
+    }),
+  );
 
   // Plain put, no updatedAt stamping — for callers that already set it (or
   // deliberately don't) and need the generated id back.

--- a/lib/repositories/settings_repository.dart
+++ b/lib/repositories/settings_repository.dart
@@ -22,7 +22,10 @@ class SettingsRepository {
 
   Future<void> update(void Function(Settings s) mutate) => dbWriteQueue.run(() {
     isar.writeTxnSync(() {
-      final s = current;
+      // A damaged/partially-created database must not turn every settings
+      // control into a null-check crash. Recreate the singleton row with its
+      // model defaults and apply the requested change in the same transaction.
+      final s = currentOrNull ?? Settings();
       mutate(s);
       s.updatedAt = DateTime.now().millisecondsSinceEpoch;
       isar.settings.putSync(s);

--- a/lib/services/crash_report.dart
+++ b/lib/services/crash_report.dart
@@ -142,24 +142,38 @@ String? describeLikelyCause(String error) {
 bool isExpectedFailure(Object error) {
   final text = error.toString().toLowerCase();
   return text.contains('failed to load http') ||
+      text.contains('failed to load data:image') ||
+      text.contains('networkimageloadexception') ||
       text.contains('socketexception') ||
       text.contains('failed host lookup') ||
+      text.contains('no such host is known') ||
+      text.contains('name or service not known') ||
+      text.contains('temporary failure in name resolution') ||
+      text.contains('network is unreachable') ||
       text.contains('connection closed') ||
       text.contains('connection reset') ||
       text.contains('connection refused') ||
+      text.contains('connection aborted') ||
+      text.contains('broken pipe') ||
       text.contains('timeoutexception') ||
+      text.contains('timed out') ||
       text.contains('handshakeexception') ||
+      text.contains('cloudflare') ||
+      text.contains('ddos-guard') ||
       // What a half-downloaded or non-image response decodes to. #927 shows
       // the sequence plainly in its own recent-errors block: two failed
       // MangaDex page loads, then this, seconds apart. It is the same failure
       // one step further along, not a separate bug.
       text.contains('could not decompress image') ||
       text.contains('invalid image data') ||
+      text.contains('could not instantiate image codec') ||
+      text.contains('imagecodecexception') ||
       // The Rust HTTP stack's transport errors, which are the same network
       // failures one layer down. #933 is one of these.
       text.contains('rhttpunknownexception') ||
       text.contains('hyper_util') ||
-      text.contains('statuscode: 5');
+      RegExp(r'(?:http\s*)?status(?:\s*code)?\s*[:=]?\s*[45]\d\d')
+          .hasMatch(text);
 }
 
 /// Whether [error] came from an extension rather than from the app.
@@ -172,12 +186,18 @@ bool isExpectedFailure(Object error) {
 /// d4rt prefixes everything it raises with "Runtime Error:", and wraps
 /// failures inside bridged calls with a recognisable phrase, so this can be
 /// told apart from an app bug with reasonable confidence.
-bool isExtensionFailure(Object error) {
+bool isExtensionFailure(Object error, {String? source, String? stack}) {
   final text = error.toString();
-  return
-  // d4rt, the Dart interpreter
-  text.startsWith('Runtime Error:') ||
+  final stackText = stack ?? '';
+  return source == 'updateMangaDetail' ||
+      stackText.contains('package:mangayomi/eval/') ||
+      stackText.contains('package:d4rt/') ||
+      stackText.contains('package:flutter_qjs/') ||
+      // d4rt, the Dart interpreter
+      text.startsWith('Runtime Error:') ||
       text.startsWith('SourceCodeException:') ||
+      text.startsWith('JavaScriptError:') ||
+      text.startsWith('JSException:') ||
       text.contains('Native error during bridged method call') ||
       text.contains('Undefined property or method') ||
       // Mihon extensions, which are Kotlin and fail their own way. #935 is a
@@ -192,13 +212,33 @@ bool isExtensionFailure(Object error) {
       text.contains('returned a novel with no path');
 }
 
-/// Whether this failure belongs in Mangayomi's issue tracker.
+enum CrashReportScope { app, extension, external }
+
+/// Decides who can act on a report using all the context the recorder kept.
+///
+/// Text alone is not enough: #961 is a generic [FormatException], but its
+/// `updateMangaDetail` source tag says it came from extension output. Stack
+/// markers cover interpreter failures that reach a global error handler and
+/// therefore have a generic source tag.
+CrashReportScope crashReportScope(CrashReport report) {
+  if (isExtensionFailure(
+    report.error,
+    source: report.source,
+    stack: report.stack,
+  )) {
+    return CrashReportScope.extension;
+  }
+  if (isExpectedFailure(report.error)) return CrashReportScope.external;
+  return CrashReportScope.app;
+}
+
+/// Whether this report belongs in Mangayomi's issue tracker.
 ///
 /// Network/image failures need retry or source-specific help, while extension
 /// failures belong to the extension. Offering either a Mangayomi bug button
 /// creates reports that cannot lead to an app fix.
-bool isReportableFailure(Object error) =>
-    !isExpectedFailure(error) && !isExtensionFailure(error);
+bool isReportableFailure(CrashReport report) =>
+    crashReportScope(report) == CrashReportScope.app;
 
 /// A stable key for "this same thing went wrong again".
 ///
@@ -353,9 +393,9 @@ class CrashReports {
       );
       _recordOccurrence(_reports, report);
       if (!_loaded) _recordOccurrence(_pending, report);
-      // Kept, but it does not raise the banner: nothing here needs the
-      // reader's attention or a bug report.
-      if (!isExpectedFailure(error)) _seen = false;
+      // Kept for diagnostics, but only an app failure can raise a future
+      // notice or be offered to the app's issue tracker.
+      if (isReportableFailure(report)) _seen = false;
       _trim();
       _flush();
     } catch (_) {}

--- a/lib/services/crash_report.dart
+++ b/lib/services/crash_report.dart
@@ -17,6 +17,7 @@ class CrashReport {
     required this.error,
     this.stack,
     this.screen,
+    this.occurrences = 1,
   });
 
   /// When it was caught, local time.
@@ -35,6 +36,9 @@ class CrashReport {
   /// navigation.
   final String? screen;
 
+  /// How many identical errors were folded into this entry.
+  final int occurrences;
+
   /// A plain sentence naming the likely cause, or null when the error does not
   /// match anything recognisable.
   String? get likelyCause => describeLikelyCause(error);
@@ -51,6 +55,7 @@ class CrashReport {
     'error': error,
     if (stack != null) 'stack': stack,
     if (screen != null) 'screen': screen,
+    if (occurrences > 1) 'occurrences': occurrences,
   };
 
   static CrashReport? fromJson(Map<String, dynamic> json) {
@@ -63,6 +68,10 @@ class CrashReport {
       error: error,
       stack: json['stack'] as String?,
       screen: json['screen'] as String?,
+      occurrences:
+          (json['occurrences'] is int && (json['occurrences'] as int) > 0)
+          ? json['occurrences'] as int
+          : 1,
     );
   }
 }
@@ -183,6 +192,14 @@ bool isExtensionFailure(Object error) {
       text.contains('returned a novel with no path');
 }
 
+/// Whether this failure belongs in Mangayomi's issue tracker.
+///
+/// Network/image failures need retry or source-specific help, while extension
+/// failures belong to the extension. Offering either a Mangayomi bug button
+/// creates reports that cannot lead to an app fix.
+bool isReportableFailure(Object error) =>
+    !isExpectedFailure(error) && !isExtensionFailure(error);
+
 /// A stable key for "this same thing went wrong again".
 ///
 /// The first line only, with digits flattened, so two runs of the same fault
@@ -290,7 +307,7 @@ class CrashReports {
         for (final entry in entries) {
           if (entry is! Map) continue;
           final report = CrashReport.fromJson(Map<String, dynamic>.from(entry));
-          if (report != null) _reports.add(report);
+          if (report != null) _recordOccurrence(_reports, report);
         }
         if (decoded is Map) {
           for (final f in (decoded['reported'] as List?) ?? const []) {
@@ -304,7 +321,9 @@ class CrashReports {
     }
     _seen = _reports.isEmpty;
     final hadPending = _pending.isNotEmpty;
-    _reports.addAll(_pending);
+    for (final report in _pending) {
+      _recordOccurrence(_reports, report);
+    }
     _pending.clear();
     _loaded = true;
     _trim();
@@ -332,8 +351,8 @@ class CrashReports {
         // has to say where it was rather than where we are now.
         screen: screen ?? _screen,
       );
-      _reports.add(report);
-      if (!_loaded) _pending.add(report);
+      _recordOccurrence(_reports, report);
+      if (!_loaded) _recordOccurrence(_pending, report);
       // Kept, but it does not raise the banner: nothing here needs the
       // reader's attention or a bug report.
       if (!isExpectedFailure(error)) _seen = false;
@@ -383,6 +402,33 @@ class CrashReports {
     if (_reports.length > _max) {
       _reports.removeRange(0, _reports.length - _max);
     }
+  }
+
+  /// Keeps the newest context for a repeated error without letting one noisy
+  /// image or callback occupy the whole ten-entry history.
+  static void _recordOccurrence(List<CrashReport> reports, CrashReport report) {
+    final existingIndex = reports.indexWhere(
+      (existing) =>
+          existing.source == report.source &&
+          existing.screen == report.screen &&
+          existing.error == report.error,
+    );
+    if (existingIndex == -1) {
+      reports.add(report);
+      return;
+    }
+
+    final existing = reports.removeAt(existingIndex);
+    reports.add(
+      CrashReport(
+        time: report.time,
+        source: report.source,
+        error: report.error,
+        stack: report.stack ?? existing.stack,
+        screen: report.screen,
+        occurrences: existing.occurrences + report.occurrences,
+      ),
+    );
   }
 
   static void _flush() {

--- a/lib/services/crash_report_issue.dart
+++ b/lib/services/crash_report_issue.dart
@@ -10,8 +10,10 @@ const _repo = 'kodjodevf/mangayomi';
 const _template = 'report_issue.yml';
 
 /// GitHub stops honouring prefilled values on very long URLs, so the body
-/// fields are capped well under where that starts to bite.
+/// fields and the final encoded URL are both capped. Per-field caps alone are
+/// not enough because URL encoding can make the finished link much larger.
 const _maxFieldLength = 2500;
+const _maxIssueUrlLength = 6000;
 
 Uri buildIssueUrl(
   CrashReport report, {
@@ -29,6 +31,9 @@ Uri buildIssueUrl(
     ..writeln('- Screen: ${report.screen ?? 'not recorded'}')
     ..writeln('- When: ${report.time.toIso8601String()}')
     ..writeln('- Caught by: ${report.source}');
+  if (report.occurrences > 1) {
+    whatHappened.writeln('- Occurrences captured: ${report.occurrences}');
+  }
 
   final actual = StringBuffer()
     ..writeln('```')
@@ -69,16 +74,17 @@ Uri buildIssueUrl(
       'report is written, so it does not carry titles or library contents.',
     );
 
-  return Uri.https('github.com', '/$_repo/issues/new', {
+  final query = <String, String>{
     'template': _template,
-    'title': '[Bug] ${report.summary}',
+    'title': _issueTitle(report),
     'reproduce-steps': _cap(whatHappened.toString()),
     'actual-behavior': _cap(actual.toString()),
     'expected-behavior': 'No error.',
     'mangayomi-version': appVersion,
     'device': device,
     'other-details': _cap(details.toString()),
-  });
+  };
+  return _fitIssueUrl(query);
 }
 
 /// The last few errors as plain text, for the "Recent errors" block and for
@@ -91,13 +97,61 @@ String recentErrorsText(List<CrashReport> reports, {int take = 5}) {
       .map(
         (r) =>
             '[${r.time.toIso8601String()}][${r.source}]'
-            '${r.screen == null ? '' : '[${r.screen}]'} ${r.error}',
+            '${r.screen == null ? '' : '[${r.screen}]'}'
+            '${r.occurrences > 1 ? '[x${r.occurrences}]' : ''} ${r.error}',
       )
       .join('\n');
 }
 
 String _cap(String value) {
+  return _capTo(value, _maxFieldLength);
+}
+
+String _capTo(String value, int limit) {
   final trimmed = value.trim();
-  if (trimmed.length <= _maxFieldLength) return trimmed;
-  return '${trimmed.substring(0, _maxFieldLength)}\n... truncated';
+  if (trimmed.length <= limit) return trimmed;
+  const suffix = '\n... truncated';
+  if (limit <= suffix.length) return suffix.substring(0, limit);
+  return '${trimmed.substring(0, limit - suffix.length)}$suffix';
+}
+
+String _issueTitle(CrashReport report) {
+  final rawContext = report.screen ?? report.source;
+  final context = _capTo(
+    rawContext.replaceAll(RegExp(r'\s+'), ' '),
+    40,
+  ).replaceAll('\n', '');
+  return _capTo('[Bug][$context] ${report.summary}', 180).replaceAll('\n', '');
+}
+
+Uri _fitIssueUrl(Map<String, String> query) {
+  Uri build() => Uri.https('github.com', '/$_repo/issues/new', query);
+
+  var url = build();
+  // Preserve the diagnostic first. Stack/log details are reduced before the
+  // actual error, and ordinary device/title text only in pathological cases.
+  const floors = <String, int>{
+    'other-details': 240,
+    'reproduce-steps': 160,
+    'actual-behavior': 300,
+    'device': 80,
+    'title': 100,
+  };
+  while (url.toString().length > _maxIssueUrlLength) {
+    var changed = false;
+    for (final entry in floors.entries) {
+      final value = query[entry.key]!;
+      if (value.length <= entry.value) continue;
+      final reduction = value.length ~/ 4 < 64 ? 64 : value.length ~/ 4;
+      final nextLength = value.length - reduction < entry.value
+          ? entry.value
+          : value.length - reduction;
+      query[entry.key] = _capTo(value, nextLength);
+      changed = true;
+      break;
+    }
+    if (!changed) break;
+    url = build();
+  }
+  return url;
 }

--- a/lib/services/crash_report_issue.dart
+++ b/lib/services/crash_report_issue.dart
@@ -21,6 +21,13 @@ Uri buildIssueUrl(
   required String device,
   String? logs,
 }) {
+  if (!isReportableFailure(report)) {
+    throw ArgumentError.value(
+      report,
+      'report',
+      'Only Mangayomi app failures can be filed in this repository',
+    );
+  }
   final cause = report.likelyCause;
 
   final whatHappened = StringBuffer()

--- a/test/repositories/manga_repository_test.dart
+++ b/test/repositories/manga_repository_test.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart';
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/repositories/manga_repository.dart';
+
+void main() {
+  late Directory directory;
+
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final overrides = HttpOverrides.current;
+    HttpOverrides.global = null;
+    try {
+      await Isar.initializeIsarCore(download: true);
+    } finally {
+      HttpOverrides.global = overrides;
+    }
+  });
+
+  setUp(() async {
+    directory = Directory.systemTemp.createTempSync('manga_repository');
+    isar = await Isar.open(
+      [MangaSchema, ChapterSchema],
+      directory: directory.path,
+      name: 'manga_repository_${directory.path.hashCode}',
+    );
+  });
+
+  tearDown(() async {
+    await isar.close(deleteFromDisk: true);
+    if (directory.existsSync()) directory.deleteSync(recursive: true);
+  });
+
+  test('save queues behind an active async Isar write', () async {
+    final transactionStarted = Completer<void>();
+    final releaseTransaction = Completer<void>();
+    final activeTransaction = isar.writeTxn(() async {
+      transactionStarted.complete();
+      await releaseTransaction.future;
+    });
+    await transactionStarted.future;
+
+    final manga = Manga(
+      source: 'test',
+      author: 'author',
+      artist: 'artist',
+      genre: const [],
+      imageUrl: '',
+      lang: 'en',
+      link: '/test',
+      name: 'Test',
+      status: Status.unknown,
+      description: '',
+      sourceId: 1,
+    )..favorite = true;
+
+    final save = mangaRepository.save(manga);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    releaseTransaction.complete();
+    await activeTransaction;
+    await save;
+
+    expect(manga.id, isNotNull);
+    expect(isar.mangas.getSync(manga.id!)?.favorite, true);
+  });
+}

--- a/test/services/crash_report_test.dart
+++ b/test/services/crash_report_test.dart
@@ -118,6 +118,36 @@ void main() {
       },
     );
 
+    test('identical errors are folded into one useful entry', () {
+      for (var i = 0; i < 3; i++) {
+        CrashReports.record(
+          source: 'FlutterError',
+          error: 'Bad state: Failed to load https://example.test/image.jpg',
+          screen: '/browse',
+        );
+      }
+
+      expect(CrashReports.reports, hasLength(1));
+      expect(CrashReports.latest!.occurrences, 3);
+      final stored = jsonDecode(file().readAsStringSync()) as Map;
+      expect((stored['reports'] as List).single['occurrences'], 3);
+    });
+
+    test('the same generic message on different screens stays separate', () {
+      CrashReports.record(
+        source: 'FlutterError',
+        error: 'Null check operator used on a null value',
+        screen: '/library',
+      );
+      CrashReports.record(
+        source: 'FlutterError',
+        error: 'Null check operator used on a null value',
+        screen: '/extensionServer',
+      );
+
+      expect(CrashReports.reports, hasLength(2));
+    });
+
     test('an error is offered once, then stays quiet', () {
       CrashReports.record(source: 'test', error: 'once');
 
@@ -299,6 +329,27 @@ void main() {
     });
   });
 
+  group('a reportable failure', () {
+    test('must be an app failure rather than network or extension noise', () {
+      expect(
+        isReportableFailure('Null check operator used on a null value'),
+        true,
+      );
+      expect(
+        isReportableFailure(
+          'Bad state: Failed to load https://cdn.jsdelivr.net/...',
+        ),
+        false,
+      );
+      expect(
+        isReportableFailure(
+          "Runtime Error: Undefined property or method 'toList'",
+        ),
+        false,
+      );
+    });
+  });
+
   group('reporting the same fault twice', () {
     late Directory directory;
 
@@ -377,6 +428,7 @@ void main() {
       expect(url.queryParameters['mangayomi-version'], '0.8.8');
       expect(url.queryParameters['device'], 'Pixel 5');
       expect(url.queryParameters['title'], contains('SocketException'));
+      expect(url.queryParameters['title'], contains('/browse'));
     });
 
     test('says what happened and what the app thinks caused it', () {
@@ -415,5 +467,28 @@ void main() {
         expect(url.queryParameters['other-details'], contains('truncated'));
       },
     );
+
+    test('the complete encoded link stays within GitHub-safe bounds', () {
+      final huge = CrashReport(
+        time: DateTime.utc(2026),
+        source: 'test',
+        error: List.filled(500, 'failure with punctuation: []').join(' '),
+        stack: List.filled(500, '#0 a very long frame indeed').join('\n'),
+      );
+      final logs = List.filled(
+        500,
+        '[time][source] another long diagnostic line',
+      ).join('\n');
+
+      final url = buildIssueUrl(
+        huge,
+        appVersion: '1',
+        device: 'desktop',
+        logs: logs,
+      );
+
+      expect(url.toString().length, lessThanOrEqualTo(6000));
+      expect(url.queryParameters['actual-behavior'], contains('failure'));
+    });
   });
 }

--- a/test/services/crash_report_test.dart
+++ b/test/services/crash_report_test.dart
@@ -205,7 +205,27 @@ void main() {
         isExpectedFailure("SocketException: Failed host lookup: 'x.test'"),
         true,
       );
+      expect(
+        isExpectedFailure('No such host is known (mangapill.comhttps)'),
+        true,
+      );
+      expect(
+        isExpectedFailure('Bad state: Failed to load data:image/gif;base64,x'),
+        true,
+      );
     });
+
+    test(
+      'source challenges and HTTP responses stay out of the app tracker',
+      () {
+        expect(isExpectedFailure('Cloudflare challenge did not pass'), true);
+        expect(isExpectedFailure('Request failed\nstatusCode: 403'), true);
+        expect(
+          isExpectedFailure('Request failed\nHTTP status code = 500'),
+          true,
+        );
+      },
+    );
 
     test('the Rust http stack failing is the same network failure', () {
       // #933, a transport error one layer below SocketException.
@@ -268,6 +288,23 @@ void main() {
 
       expect(CrashReports.hasUnseen, true);
     });
+
+    test(
+      'an extension failure is kept without becoming an unseen app bug',
+      () async {
+        final directory = Directory.systemTemp.createTempSync('extension');
+        addTearDown(() => directory.deleteSync(recursive: true));
+        await CrashReports.init(directory);
+
+        CrashReports.record(
+          source: 'updateMangaDetail',
+          error: 'FormatException: malformed source payload',
+        );
+
+        expect(CrashReports.reports, hasLength(1));
+        expect(CrashReports.hasUnseen, false);
+      },
+    );
   });
 
   group('an extension failure', () {
@@ -313,6 +350,29 @@ void main() {
       );
     });
 
+    test('uses the recorder source when the exception text is generic', () {
+      // #961: the message itself is a normal FormatException. The source tag
+      // is what proves the malformed value came back from an extension.
+      expect(
+        isExtensionFailure(
+          'FormatException: Scheme not starting with alphabetic character',
+          source: 'updateMangaDetail',
+        ),
+        true,
+      );
+    });
+
+    test('recognises interpreter frames caught by a global handler', () {
+      expect(
+        isExtensionFailure(
+          'Bad state: no element',
+          source: 'FlutterError',
+          stack: '#0 package:mangayomi/eval/javascript/service.dart:10',
+        ),
+        true,
+      );
+    });
+
     test('an app bug is not one', () {
       expect(
         isExtensionFailure('Null check operator used on a null value'),
@@ -332,22 +392,130 @@ void main() {
   group('a reportable failure', () {
     test('must be an app failure rather than network or extension noise', () {
       expect(
-        isReportableFailure('Null check operator used on a null value'),
+        isReportableFailure(
+          CrashReport(
+            time: DateTime.utc(2026),
+            source: 'FlutterError',
+            error: 'Null check operator used on a null value',
+          ),
+        ),
         true,
       );
       expect(
         isReportableFailure(
-          'Bad state: Failed to load https://cdn.jsdelivr.net/...',
+          CrashReport(
+            time: DateTime.utc(2026),
+            source: 'FlutterError',
+            error: 'Bad state: Failed to load https://cdn.jsdelivr.net/...',
+          ),
         ),
         false,
       );
       expect(
         isReportableFailure(
-          "Runtime Error: Undefined property or method 'toList'",
+          CrashReport(
+            time: DateTime.utc(2026),
+            source: 'updateMangaDetail',
+            error: 'FormatException: malformed source payload',
+          ),
         ),
         false,
       );
     });
+
+    test('extension context wins over a generic HTTP classification', () {
+      final report = CrashReport(
+        time: DateTime.utc(2026),
+        source: 'updateMangaDetail',
+        error: 'Source response failed\nstatusCode: 500',
+      );
+
+      expect(crashReportScope(report), CrashReportScope.extension);
+    });
+  });
+
+  group('recent tracker regressions', () {
+    final cases =
+        <({int issue, String source, String error, CrashReportScope scope})>[
+          (
+            issue: 966,
+            source: 'FlutterError',
+            error:
+                'IsarError: An async write transaction is already in progress',
+            scope: CrashReportScope.app,
+          ),
+          (
+            issue: 964,
+            source: 'runZonedGuarded',
+            error: 'Null check operator used on a null value',
+            scope: CrashReportScope.app,
+          ),
+          (
+            issue: 963,
+            source: 'updateMangaDetail',
+            error:
+                'No such host is known (mangapill.comhttps)\nstatusCode: 500',
+            scope: CrashReportScope.extension,
+          ),
+          (
+            issue: 962,
+            source: 'updateMangaDetail',
+            error: "Runtime Error: Undefined property or method 'toList'",
+            scope: CrashReportScope.extension,
+          ),
+          (
+            issue: 961,
+            source: 'updateMangaDetail',
+            error: 'FormatException: Scheme not starting with alphabetic character',
+            scope: CrashReportScope.extension,
+          ),
+          (
+            issue: 960,
+            source: 'FlutterError',
+            error: 'Bad state: Failed to load https://raw.githubusercontent.com/...',
+            scope: CrashReportScope.external,
+          ),
+          (
+            issue: 953,
+            source: 'FlutterError',
+            error: 'Bad state: Failed to load data:image/gif;base64,x',
+            scope: CrashReportScope.external,
+          ),
+          (
+            issue: 935,
+            source: 'updateMangaDetail',
+            error: "Field 'largeImage' is required for type with serial name",
+            scope: CrashReportScope.extension,
+          ),
+          (
+            issue: 933,
+            source: 'FlutterError',
+            error: '[RhttpUnknownException] hyper_util::client::legacy::Error',
+            scope: CrashReportScope.external,
+          ),
+          (
+            issue: 927,
+            source: 'FlutterError',
+            error: 'Exception: Could not decompress image.',
+            scope: CrashReportScope.external,
+          ),
+        ];
+
+    for (final sample in cases) {
+      test('#${sample.issue} is ${sample.scope.name}', () {
+        final report = CrashReport(
+          time: DateTime.utc(2026),
+          source: sample.source,
+          error: sample.error,
+        );
+
+        expect(crashReportScope(report), sample.scope);
+        expect(
+          isReportableFailure(report),
+          sample.scope == CrashReportScope.app,
+        );
+      });
+    }
   });
 
   group('reporting the same fault twice', () {
@@ -414,7 +582,7 @@ void main() {
     final report = CrashReport(
       time: DateTime.utc(2026, 8, 22, 21, 35),
       source: 'PlatformDispatcher',
-      error: "SocketException: Failed host lookup: 'example.test'",
+      error: 'RangeError: index 4 is outside a list of length 2',
       stack: '#0 somewhere\n#1 elsewhere',
       screen: '/browse',
     );
@@ -427,7 +595,7 @@ void main() {
       expect(url.queryParameters['template'], 'report_issue.yml');
       expect(url.queryParameters['mangayomi-version'], '0.8.8');
       expect(url.queryParameters['device'], 'Pixel 5');
-      expect(url.queryParameters['title'], contains('SocketException'));
+      expect(url.queryParameters['title'], contains('RangeError'));
       expect(url.queryParameters['title'], contains('/browse'));
     });
 
@@ -435,10 +603,7 @@ void main() {
       final url = buildIssueUrl(report, appVersion: '0.8.8', device: 'Pixel 5');
 
       expect(url.queryParameters['reproduce-steps'], contains('/browse'));
-      expect(
-        url.queryParameters['actual-behavior'],
-        contains('Failed host lookup'),
-      );
+      expect(url.queryParameters['actual-behavior'], contains('RangeError'));
       expect(url.queryParameters['actual-behavior'], contains('Likely cause'));
       expect(url.queryParameters['other-details'], contains('#0 somewhere'));
     });
@@ -449,6 +614,28 @@ void main() {
       // Everything travels as query parameters on a page the reader lands on
       // and can read before submitting.
       expect(url.queryParameters.keys, contains('actual-behavior'));
+    });
+
+    test('refuses to build links for external and extension failures', () {
+      final external = CrashReport(
+        time: DateTime.utc(2026),
+        source: 'FlutterError',
+        error: 'Bad state: Failed to load https://cdn.example/...',
+      );
+      final extension = CrashReport(
+        time: DateTime.utc(2026),
+        source: 'updateMangaDetail',
+        error: 'FormatException: malformed source payload',
+      );
+
+      expect(
+        () => buildIssueUrl(external, appVersion: '1', device: 'x'),
+        throwsArgumentError,
+      );
+      expect(
+        () => buildIssueUrl(extension, appVersion: '1', device: 'x'),
+        throwsArgumentError,
+      );
     });
 
     test(

--- a/test/settings/settings_clobber_test.dart
+++ b/test/settings/settings_clobber_test.dart
@@ -9,6 +9,7 @@ import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/source.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/flex_scheme_color_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/theme_mode_state_provider.dart';
+import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
 import 'package:mangayomi/repositories/settings_repository.dart';
 
 /// The appearance settings all live in one Settings row, and each setter reads
@@ -83,6 +84,26 @@ void main() {
   });
 
   group('settingsRepository.update', () {
+    test('recreates a missing settings row instead of null-crashing', () async {
+      isar.writeTxnSync(isar.settings.clearSync);
+
+      expect(
+        container.read(androidProxyServerStateProvider),
+        'http://127.0.0.1:8080',
+      );
+      expect(
+        container.read(autoStartExtensionServerOnLaunchStateProvider),
+        false,
+      );
+
+      await settingsRepository.update(
+        (settings) => settings.androidProxyServer = 'http://127.0.0.1:9000',
+      );
+
+      expect(stored().androidProxyServer, 'http://127.0.0.1:9000');
+      expect(stored().id, 227);
+    });
+
     test('keeps a change made after the caller last looked at the row', () async {
       // What every caller of this used to get wrong: hold the row, let
       // something else write, then write the held copy back over it.


### PR DESCRIPTION
## Summary

- fold identical caught errors into one entry with an occurrence count
- classify reports as app, extension, or external using the error, recorder source, and stack
- prevent extension runtime/payload failures and external network/source failures from reaching the Mangayomi report action
- enforce the same scope check in the issue-link builder so a UI regression cannot file out-of-scope reports
- add screen or source context to generated issue titles
- cap the complete encoded GitHub issue URL so prefilled issue bodies are retained
- make extension-server status loading tolerate a missing Settings row and expected storage/runtime failures
- keep unexpected extension-server failures actionable instead of leaking an unhandled post-frame future
- queue manga library saves with asynchronous Isar transactions

## Genuine app bugs

The extension-server null path now uses nullable Settings reads, recreates a missing singleton Settings row on the next update, removes the nullable storage unwrap, and contains post-frame failures. Manga library saves now use asynchronous transactions and are awaited by the detail-screen actions.

Fixes #964
Fixes #966

The following stale reports are duplicates of fixes already present on the current main base: #956 duplicates #949 and was fixed by #955; #957 duplicates #923 and was fixed by #930; #958 and #959 are the pre-repository transaction path fixed by #954.

Closes #956
Closes #957
Closes #958
Closes #959

## Out-of-scope tracker cleanup

These are reporter-created tickets for third-party extension failures. This PR does not claim to repair the extensions; it prevents Mangayomi from offering its issue tracker for them.

Closes #914
Closes #935
Closes #936
Closes #962
Closes #963

These are reporter-created network, CDN, or image-decoding failures. They remain available in local diagnostics but no longer raise an app-bug notice or offer a Mangayomi issue link.

Closes #915
Closes #916
Closes #927
Closes #933
Closes #934
Closes #937
Closes #944
Closes #953
Closes #960
Closes #965

## Regression coverage

The classifier includes examples from #927, #933, #935, #953, and #960-#966. Repository tests also reproduce an active async Isar transaction during a manga save and a missing Settings row on the extension-server route.

## Verification

- flutter test test/repositories/manga_repository_test.dart test/settings/settings_clobber_test.dart test/services/crash_report_test.dart test/services/crash_native_test.dart (62 tests passed)
- flutter analyze on all changed Dart files (no issues)