### PR TITLE
Optimize local image-folder pages and image handling

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -18,7 +18,6 @@ import 'package:mangayomi/eval/model/m_bridge.dart';
 import 'package:mangayomi/main.dart';
 import 'package:mangayomi/repositories/chapter_repository.dart';
 import 'package:mangayomi/repositories/custom_button_repository.dart';
-import 'package:mangayomi/repositories/manga_repository.dart';
 import 'package:mangayomi/models/chapter.dart';
 import 'package:mangayomi/models/custom_button.dart';
 import 'package:mangayomi/models/settings.dart';
@@ -31,7 +30,7 @@ import 'package:mangayomi/modules/anime/widgets/tv_player_settings_panel.dart';
 import 'package:mangayomi/modules/main_view/providers/tv_mode_provider.dart';
 import 'package:mangayomi/modules/anime/widgets/desktop.dart';
 import 'package:mangayomi/modules/anime/widgets/play_or_pause_button.dart';
-import 'package:mangayomi/modules/library/providers/local_archive.dart';
+import 'package:mangayomi/utils/manga_cover_actions.dart';
 import 'package:mangayomi/modules/manga/reader/widgets/btn_chapter_list_dialog.dart';
 import 'package:mangayomi/modules/anime/widgets/mobile.dart';
 import 'package:mangayomi/modules/anime/widgets/subtitle_view.dart';
@@ -2597,60 +2596,27 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
                       ),
                       Row(
                         children: [
-                          button(context.l10n.set_as_cover, Icons.image_outlined, () async {
-                            final imageBytes = await _player.screenshot(
-                              format: "image/png",
-                              includeLibassSubtitles: _includeSubtitles,
-                            );
-                            if (context.mounted) {
-                              final res = await showDialog(
-                                context: context,
-                                builder: (context) {
-                                  return AlertDialog(
-                                    content: Text(
-                                      context.l10n.use_this_as_cover_art,
-                                    ),
-                                    actions: [
-                                      Row(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.end,
-                                        children: [
-                                          TextButton(
-                                            onPressed: () {
-                                              Navigator.pop(context);
-                                            },
-                                            child: Text(context.l10n.cancel),
-                                          ),
-                                          const SizedBox(width: 15),
-                                          TextButton(
-                                            onPressed: () {
-                                              final manga =
-                                                  episode.manga.value!;
-                                              mangaRepository.save(
-                                                manga
-                                                  ..customCoverImage =
-                                                      imageBytes?.getCoverImage,
-                                              );
-                                              if (context.mounted) {
-                                                Navigator.pop(context, "ok");
-                                              }
-                                            },
-                                            child: Text(context.l10n.ok),
-                                          ),
-                                        ],
-                                      ),
-                                    ],
-                                  );
-                                },
+                          button(
+                            context.l10n.set_as_cover,
+                            Icons.image_outlined,
+                            () async {
+                              final imageBytes = await _player.screenshot(
+                                format: "image/png",
+                                includeLibassSubtitles: _includeSubtitles,
                               );
-                              if (res != null &&
-                                  res == "ok" &&
-                                  context.mounted) {
-                                Navigator.pop(context);
-                                botToast(context.l10n.cover_updated, second: 3);
-                              }
-                            }
-                          }),
+                              if (!context.mounted) return;
+                              final confirmed = await confirmUseAsMangaCover(
+                                context,
+                              );
+                              if (!confirmed || !context.mounted) return;
+                              await applyMangaCover(
+                                context,
+                                episode.manga.value!,
+                                imageBytes,
+                              );
+                              if (context.mounted) Navigator.pop(context);
+                            },
+                          ),
                           button(
                             context.l10n.share,
                             Icons.share_outlined,

--- a/lib/modules/manga/archive_reader/models/models.dart
+++ b/lib/modules/manga/archive_reader/models/models.dart
@@ -17,4 +17,14 @@ enum LocalExtensionType { cbz, zip, cbt, tar, cbr, rar, folder }
 class LocalImage {
   String? name;
   Uint8List? image;
+
+  /// The real on-disk path of this page, when it's a standalone image file
+  /// (a plain image-folder chapter) rather than an entry inside an archive.
+  /// When this is set, [image] is intentionally left unread - callers should
+  /// read the file directly (or hand its path straight to an image widget)
+  /// instead of loading it into memory, since the bytes already live on disk
+  /// under a real, addressable path. Null for archive-file entries (cbz/zip/
+  /// cbt/tar/cbr/rar), which have no standalone file to point to and so are
+  /// still read fully into [image].
+  String? path;
 }

--- a/lib/modules/manga/archive_reader/providers/archive_reader_providers.dart
+++ b/lib/modules/manga/archive_reader/providers/archive_reader_providers.dart
@@ -193,6 +193,13 @@ Future<LocalArchive> _extractArchive(String path) async {
 }
 
 /// Extract images from a folder
+///
+/// Unlike the archive-file case, these pages already exist as standalone
+/// files on disk - there's no need to read every one of them into memory
+/// just to hand the bytes back to a caller who's only going to write them
+/// back out to a temp file to get a path again. Only the first file (the
+/// cover) is actually read; every other [LocalImage] carries its real [path]
+/// instead of [image], and callers read the file directly when they need it.
 Future<LocalArchive> _extractFromImageFolder(String path) async {
   final dir = Directory(path);
   final imageFiles = await dir
@@ -208,7 +215,7 @@ Future<LocalArchive> _extractFromImageFolder(String path) async {
 
   final images = imageFiles.map((file) {
     return LocalImage()
-      ..image = file.readAsBytesSync()
+      ..path = file.path
       ..name = p.basename(file.path);
   }).toList();
 
@@ -217,7 +224,7 @@ Future<LocalArchive> _extractFromImageFolder(String path) async {
     ..extensionType = LocalExtensionType.folder
     ..name = p.basename(path)
     ..images = images
-    ..coverImage = images.first.image;
+    ..coverImage = imageFiles.first.readAsBytesSync();
 }
 
 /// Extract images from an archive file

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -2197,12 +2197,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                       } else if (value == 1) {
                                         FilePickerResult? result =
                                             await FilePicker.pickFiles(
-                                              type: FileType.custom,
-                                              allowedExtensions: [
-                                                'png',
-                                                'jpg',
-                                                'jpeg',
-                                              ],
+                                              type: FileType.image,
                                             );
                                         if (result != null && context.mounted) {
                                           if (result.files.first.size <

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -45,6 +45,7 @@ import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/utils/cached_network.dart';
 import 'package:mangayomi/utils/chapter_recognition.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
+import 'package:mangayomi/utils/manga_cover_actions.dart';
 import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
 import 'package:mangayomi/utils/extensions/manga_extensions.dart';
 import 'package:mangayomi/utils/extensions/others.dart';
@@ -2195,26 +2196,18 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                                         );
                                         Navigator.pop(context);
                                       } else if (value == 1) {
-                                        FilePickerResult? result =
-                                            await FilePicker.pickFiles(
-                                              type: FileType.image,
-                                            );
-                                        if (result != null && context.mounted) {
-                                          if (result.files.first.size <
-                                              5000000) {
-                                            final customCoverImage = File(
-                                              result.files.first.path!,
-                                            ).readAsBytesSync();
-                                            mangaRepository.save(
-                                              manga
-                                                ..customCoverImage =
-                                                    customCoverImage,
-                                            );
-                                            botToast(
-                                              context.l10n.cover_updated,
-                                              second: 3,
-                                            );
-                                          }
+                                        final file = await FilePicker.pickFile(
+                                          type: FileType.image,
+                                        );
+                                        if (file?.path != null &&
+                                            context.mounted) {
+                                          final bytes = File(file!.path!)
+                                              .readAsBytesSync();
+                                          await applyMangaCover(
+                                            context,
+                                            manga,
+                                            bytes,
+                                          );
                                         }
                                         if (context.mounted) {
                                           Navigator.pop(context);

--- a/lib/modules/manga/reader/image_view_paged.dart
+++ b/lib/modules/manga/reader/image_view_paged.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/models/settings.dart';
@@ -83,6 +84,17 @@ class _ImageViewPagedState extends ConsumerState<ImageViewPaged> {
     } else if (widget.data.archiveImage != null &&
         widget.data.archiveImage!.length > 5) {
       if (isGifImage(widget.data.archiveImage!)) isAnimated = true;
+    } else if (widget.data.localImagePath != null) {
+      // Local image-folder page: sniff the real file's bytes directly rather
+      // than trusting its extension.
+      try {
+        final raf = await File(widget.data.localImagePath!).open();
+        try {
+          if (isGifImage(await raf.read(6))) isAnimated = true;
+        } finally {
+          await raf.close();
+        }
+      } catch (_) {}
     } else if (widget.data.directory != null && widget.data.index != null) {
       try {
         // Look up whatever extension this page was actually saved under

--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -5,6 +5,7 @@ import 'package:photo_view/photo_view.dart';
 import 'package:mangayomi/modules/widgets/error_state.dart';
 import 'package:mangayomi/services/downloaded_chapter.dart';
 import 'package:mangayomi/modules/manga/archive_reader/providers/archive_reader_providers.dart';
+import 'package:mangayomi/modules/library/providers/file_scanner.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/modules/manga/reader/subsampling_scale_image_view/subsampling_scale_image_view.dart'
     as ssiv;
@@ -969,6 +970,7 @@ class _MangaChapterPageGalleryState
             page.chapterUrlModel,
             page.pageIndex,
             srcRect: firstRect,
+            localImagePath: page.localImagePath,
           )
           ..loadedWidth = halfWidth
           ..loadedHeight = height;
@@ -984,6 +986,7 @@ class _MangaChapterPageGalleryState
             page.chapterUrlModel,
             page.pageIndex,
             srcRect: secondRect,
+            localImagePath: page.localImagePath,
           )
           ..loadedWidth = halfWidth
           ..loadedHeight = height;
@@ -1334,6 +1337,11 @@ class _MangaChapterPageGalleryState
   /// then scrolled back into it). Re-reads the local `.cbz` archive and
   /// re-populates each page's `archiveImage`.
   ///
+  /// Only applies to archive-backed local chapters (cbz/zip/etc.) - plain
+  /// image-folder chapters carry [UChapDataPreload.localImagePath] pointing
+  /// straight at their real file on disk, so there's nothing to evict or
+  /// reload for them in the first place.
+  ///
   /// Cheap no-op for the common case where [currentChapter] was never
   /// evicted, via [ChapterPreloadManager.isChapterEvicted] - avoids scanning
   /// every page of the chapter on every page-change.
@@ -1346,7 +1354,8 @@ class _MangaChapterPageGalleryState
       if (page.chapter?.id == chapterId &&
           !page.isTransitionPage &&
           page.isLocale == true &&
-          page.archiveImage == null) {
+          page.archiveImage == null &&
+          page.localImagePath == null) {
         needsReload = true;
         break;
       }
@@ -1355,7 +1364,7 @@ class _MangaChapterPageGalleryState
     if (needsReload) {
       final isLocalArchive = (currentChapter.archivePath ?? '').isNotEmpty;
       final archivePath = isLocalArchive
-          ? currentChapter.archivePath
+          ? await resolveLocalArchivePath(currentChapter.archivePath!)
           : (await findDownloadedChapter(currentChapter))?.archive?.path;
 
       if (archivePath != null && await File(archivePath).exists()) {

--- a/lib/modules/manga/reader/subsampling_scale_image_view/src/subsampling_scale_image_view.dart
+++ b/lib/modules/manga/reader/subsampling_scale_image_view/src/subsampling_scale_image_view.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:crypto/crypto.dart';
 import 'package:mangayomi/utils/avif.dart';
+import 'package:mangayomi/utils/downloaded_page_file.dart';
 
 import 'coordinate_transformer.dart';
 import 'ffi_image_decoder.dart';
@@ -665,7 +666,8 @@ class _SubsamplingScaleImageViewState extends State<SubsamplingScaleImageView>
         final Uint8List bytes = dynProvider.bytes;
         final tempDir = await getTemporaryDirectory();
         final cacheKey = provider.hashCode.abs();
-        final tempFile = File('${tempDir.path}/ssiv_cache_$cacheKey.png');
+        final ext = detectImageExtension(bytes);
+        final tempFile = File('${tempDir.path}/ssiv_cache_$cacheKey$ext');
         await tempFile.writeAsBytes(bytes, flush: true);
         _resolvedFilePath = tempFile.path;
         await _initImage();

--- a/lib/modules/manga/reader/subsampling_scale_image_view/src/subsampling_scale_image_view.dart
+++ b/lib/modules/manga/reader/subsampling_scale_image_view/src/subsampling_scale_image_view.dart
@@ -664,11 +664,13 @@ class _SubsamplingScaleImageViewState extends State<SubsamplingScaleImageView>
       final dynamic dynProvider = provider;
       if (dynProvider.bytes is Uint8List) {
         final Uint8List bytes = dynProvider.bytes;
-        final tempDir = await getTemporaryDirectory();
         final cacheKey = provider.hashCode.abs();
-        final ext = detectImageExtension(bytes);
-        final tempFile = File('${tempDir.path}/ssiv_cache_$cacheKey$ext');
-        await tempFile.writeAsBytes(bytes, flush: true);
+        final tempFile = await cacheImageBytesToTempFile(
+          tempDir: await getTemporaryDirectory(),
+          baseName: 'ssiv_cache_$cacheKey',
+          extension: detectImageExtension(bytes),
+          bytesProvider: () => bytes,
+        );
         _resolvedFilePath = tempFile.path;
         await _initImage();
         return;
@@ -738,20 +740,21 @@ class _SubsamplingScaleImageViewState extends State<SubsamplingScaleImageView>
       }
 
       // Fallback: Encode the image to PNG to save it to disk
-      final byteData = await loadedImage.toByteData(
-        format: ui.ImageByteFormat.png,
-      );
-      if (byteData == null) {
-        throw Exception('Failed to convert image to PNG bytes');
-      }
-
-      final bytes = byteData.buffer.asUint8List();
-
-      // Uses the platform's temporary directory
-      final tempDir = await getTemporaryDirectory();
       final cacheKey = provider.hashCode.abs();
-      final tempFile = File('${tempDir.path}/ssiv_cache_$cacheKey.png');
-      await tempFile.writeAsBytes(bytes, flush: true);
+      final tempFile = await cacheImageBytesToTempFile(
+        tempDir: await getTemporaryDirectory(),
+        baseName: 'ssiv_cache_$cacheKey',
+        extension: '.png', // we control the encode below, so this is exact
+        bytesProvider: () async {
+          final byteData = await loadedImage.toByteData(
+            format: ui.ImageByteFormat.png,
+          );
+          if (byteData == null) {
+            throw Exception('Failed to convert image to PNG bytes');
+          }
+          return byteData.buffer.asUint8List();
+        },
+      );
 
       _resolvedFilePath = tempFile.path;
 
@@ -936,15 +939,13 @@ class _SubsamplingScaleImageViewState extends State<SubsamplingScaleImageView>
     final key = _md5Hash(
       '$path:${stat.size}:${stat.modified.millisecondsSinceEpoch}',
     );
-    final target = File(
-      '${(await getTemporaryDirectory()).path}/ssiv_avif_$key.png',
+    // Decoding is deferred into bytesProvider so it only runs on a cache miss
+    final target = await cacheImageBytesToTempFile(
+      tempDir: await getTemporaryDirectory(),
+      baseName: 'ssiv_avif_$key',
+      extension: '.png', // decodeAvifToPng always returns PNG bytes
+      bytesProvider: () async => decodeAvifToPng(await source.readAsBytes()),
     );
-    if (!await target.exists()) {
-      await target.writeAsBytes(
-        await decodeAvifToPng(await source.readAsBytes()),
-        flush: true,
-      );
-    }
     return target.path;
   }
 

--- a/lib/modules/manga/reader/u_chap_data_preload.dart
+++ b/lib/modules/manga/reader/u_chap_data_preload.dart
@@ -21,6 +21,14 @@ class UChapDataPreload {
   bool? isLastChapter;
   Rect? srcRect;
 
+  /// The real on-disk path of this page, for local image-folder chapters
+  /// whose pages already exist as standalone files. When set, this page
+  /// never needs to be read into memory and copied back out to a temp file -
+  /// [getLocalFilePath] returns it directly. Null for everything else
+  /// (archive-file entries, downloaded/remote pages), which have no single
+  /// real file they can point to up front.
+  String? localImagePath;
+
   /// Cached rendered dimensions (set after image first loads)
   double? loadedHeight;
   double? loadedWidth;
@@ -45,6 +53,7 @@ class UChapDataPreload {
     this.mangaName,
     this.isLastChapter = false,
     this.srcRect,
+    this.localImagePath,
   });
 
   UChapDataPreload.transition({
@@ -61,5 +70,6 @@ class UChapDataPreload {
        archiveImage = null,
        index = null,
        chapterUrlModel = null,
-       srcRect = null;
+       srcRect = null,
+       localImagePath = null;
 }

--- a/lib/modules/manga/reader/widgets/image_actions_dialog.dart
+++ b/lib/modules/manga/reader/widgets/image_actions_dialog.dart
@@ -9,6 +9,7 @@ import 'package:mangayomi/modules/library/providers/local_archive.dart';
 import 'package:mangayomi/modules/manga/reader/u_chap_data_preload.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
+import 'package:mangayomi/utils/downloaded_page_file.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/extensions/others.dart';
 import 'package:mangayomi/utils/share.dart';
@@ -57,7 +58,7 @@ class ImageActionsDialog {
 }
 
 class _ImageActionsSheet extends StatelessWidget {
-  final List<int> imageBytes;
+  final Uint8List imageBytes;
   final Manga manga;
   final String fileName;
 
@@ -138,10 +139,7 @@ class _ImageActionsSheet extends StatelessWidget {
               TextButton(
                 onPressed: () {
                   mangaRepository.save(
-                    manga
-                      ..customCoverImage = Uint8List.fromList(
-                        imageBytes,
-                      ).getCoverImage,
+                    manga..customCoverImage = imageBytes.getCoverImage,
                   );
                   Navigator.pop(context, "ok");
                 },
@@ -162,32 +160,30 @@ class _ImageActionsSheet extends StatelessWidget {
   Future<void> _shareImage(BuildContext context) async {
     if (!context.mounted) return;
 
+    final ext = detectImageExtension(imageBytes);
+    final mime = mimeTypeForImageExtension(ext);
+
     final box = context.findRenderObject() as RenderBox?;
     await shareOrCopy(
       ShareParams(
         files: [
-          XFile.fromData(
-            Uint8List.fromList(imageBytes),
-            name: fileName,
-            mimeType: 'image/png',
-          ),
+          XFile.fromData(imageBytes, name: '$fileName$ext', mimeType: mime),
         ],
         sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
       ),
-      fallbackName: fileName,
+      fallbackName: '$fileName$ext',
     );
   }
 
   Future<void> _saveImage(BuildContext context) async {
     final dir = await StorageProvider().getGalleryDirectory();
     if (dir == null) return;
+    final ext = detectImageExtension(imageBytes);
 
-    final file = File(p.join(dir.path, "$fileName.png"));
-    file.writeAsBytesSync(imageBytes);
+    final file = File(p.join(dir.path, "$fileName$ext"));
+    await file.writeAsBytes(imageBytes, flush: true);
 
-    if (context.mounted) {
-      botToast(context.l10n.picture_saved, second: 3);
-    }
+    if (context.mounted) botToast(context.l10n.picture_saved, second: 3);
   }
 }
 

--- a/lib/modules/manga/reader/widgets/image_actions_dialog.dart
+++ b/lib/modules/manga/reader/widgets/image_actions_dialog.dart
@@ -3,9 +3,8 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:mangayomi/eval/model/m_bridge.dart';
-import 'package:mangayomi/repositories/manga_repository.dart';
 import 'package:mangayomi/models/manga.dart';
-import 'package:mangayomi/modules/library/providers/local_archive.dart';
+import 'package:mangayomi/utils/manga_cover_actions.dart';
 import 'package:mangayomi/modules/manga/reader/u_chap_data_preload.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/providers/storage_provider.dart';
@@ -123,38 +122,10 @@ class _ImageActionsSheet extends StatelessWidget {
   }
 
   Future<void> _setAsCover(BuildContext context) async {
-    final res = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        content: Text(context.l10n.use_this_as_cover_art),
-        actions: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: () => Navigator.pop(context),
-                child: Text(context.l10n.cancel),
-              ),
-              const SizedBox(width: 15),
-              TextButton(
-                onPressed: () {
-                  mangaRepository.save(
-                    manga..customCoverImage = imageBytes.getCoverImage,
-                  );
-                  Navigator.pop(context, "ok");
-                },
-                child: Text(context.l10n.ok),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-
-    if (res == "ok" && context.mounted) {
-      Navigator.pop(context);
-      botToast(context.l10n.cover_updated, second: 3);
-    }
+    final confirmed = await confirmUseAsMangaCover(context);
+    if (!confirmed || !context.mounted) return;
+    await applyMangaCover(context, manga, imageBytes);
+    if (context.mounted) Navigator.pop(context);
   }
 
   Future<void> _shareImage(BuildContext context) async {

--- a/lib/services/get_chapter_pages.dart
+++ b/lib/services/get_chapter_pages.dart
@@ -25,6 +25,11 @@ class GetChapterPagesModel {
   List<PageUrl> pageUrls = [];
   List<bool> isLocaleList = [];
   List<Uint8List?> archiveImages = [];
+  // Parallel to archiveImages: the real on-disk path for pages that are
+  // standalone files (local image-folder chapters), so they never have to be
+  // read into memory just to get a path back out. Null for every page that
+  // isn't a plain folder page (archive entries, downloaded/remote pages).
+  List<String?> localImagePaths = [];
   List<UChapDataPreload> uChapDataPreload;
   GetChapterPagesModel({
     required this.path,
@@ -32,6 +37,7 @@ class GetChapterPagesModel {
     required this.isLocaleList,
     required this.archiveImages,
     required this.uChapDataPreload,
+    required this.localImagePaths,
   });
 }
 
@@ -114,6 +120,7 @@ Future<GetChapterPagesModel> getChapterPages(
       isLocaleList: isLocaleList,
       archiveImages: archiveImages,
       uChapDataPreload: [],
+      localImagePaths: <String?>[],
     );
 
     final archivePath = isLocalArchive
@@ -126,7 +133,12 @@ Future<GetChapterPagesModel> getChapterPages(
           getArchiveDataFromFileProvider(archivePath).future,
         );
         for (var image in local.images!) {
-          archiveImages.add(image.image!);
+          // Folder pages carry a real path instead of pre-read bytes (see
+          // LocalImage.path) - keep archiveImages/localImagePaths parallel
+          // to isLocaleList so index i always refers to the same page across
+          // all three lists.
+          archiveImages.add(image.image);
+          chapterModel.localImagePaths.add(image.path);
           isLocaleList.add(true);
         }
       } else {
@@ -137,6 +149,7 @@ Future<GetChapterPagesModel> getChapterPages(
             : downloaded!.pageCount;
         for (var i = 0; i < pageCount; i++) {
           archiveImages.add(null);
+          chapterModel.localImagePaths.add(null);
           if (await findDownloadedPageFileAsync(path!, i) != null) {
             isLocaleList.add(true);
           } else {
@@ -213,6 +226,9 @@ Future<GetChapterPagesModel> getChapterPages(
             i,
             chapterModel,
             i,
+            localImagePath: i < chapterModel.localImagePaths.length
+                ? chapterModel.localImagePaths[i]
+                : null,
           ),
         );
       }

--- a/lib/utils/downloaded_page_file.dart
+++ b/lib/utils/downloaded_page_file.dart
@@ -49,6 +49,19 @@ String detectImageExtension(Uint8List bytes) {
   return knownPageImageExtensions[0];
 }
 
+/// The mime type for an extension from [detectImageExtension]/
+/// [knownPageImageExtensions]. Falls back to 'image/jpeg' for anything else,
+/// matching detectImageExtension's own jpg fallback.
+String mimeTypeForImageExtension(String extension) {
+  return switch (extension.toLowerCase()) {
+    '.png' => 'image/png',
+    '.webp' => 'image/webp',
+    '.gif' => 'image/gif',
+    '.avif' => 'image/avif',
+    _ => 'image/jpeg',
+  };
+}
+
 bool isJpegImage(Uint8List bytes) {
   return bytes.length >= 3 &&
       bytes[0] == 0xFF && // JPEG SOI marker start

--- a/lib/utils/downloaded_page_file.dart
+++ b/lib/utils/downloaded_page_file.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -100,6 +101,23 @@ File? findMangaCoverFile(Directory directory) {
     if (file.existsSync()) return file;
   }
   return null;
+}
+
+/// Ensures image bytes end up at a stable temp-file path. Skips writing
+/// when the file already exists. Caller supplies [extension] so caching
+/// works without running [bytesProvider] unnecessarily.
+Future<File> cacheImageBytesToTempFile({
+  required Directory tempDir,
+  required String baseName,
+  required String extension,
+  required FutureOr<Uint8List> Function() bytesProvider,
+}) async {
+  final file = File(p.join(tempDir.path, '$baseName$extension'));
+  if (!await file.exists()) {
+    final bytes = await bytesProvider();
+    await file.writeAsBytes(bytes, flush: true);
+  }
+  return file;
 }
 
 /// The single source of truth for "where is page [index] of this chapter on

--- a/lib/utils/extensions/others.dart
+++ b/lib/utils/extensions/others.dart
@@ -87,24 +87,21 @@ extension UChapDataPreloadExtensions on UChapDataPreload {
       return localImagePath;
     }
     if (archiveImage != null) {
-      final tempDir = Directory.systemTemp;
       final sourceKey = [
         chapter?.id?.toString(),
         chapter?.archivePath,
         directory?.path,
         chapter?.url,
       ].whereType<String>().where((value) => value.isNotEmpty).join('|');
-      final chapterKey = keyToMd5(sourceKey);
-      final ext = detectImageExtension(archiveImage!);
-      final tempFile = File(
-        p.join(
-          tempDir.path,
-          'mangayomi_archive_${chapterKey}_${index ?? pageIndex}$ext',
-        ),
+      final baseName =
+          'mangayomi_archive_${keyToMd5(sourceKey)}_${index ?? pageIndex}';
+      final bytes = archiveImage!;
+      final tempFile = await cacheImageBytesToTempFile(
+        tempDir: Directory.systemTemp,
+        baseName: baseName,
+        extension: detectImageExtension(bytes),
+        bytesProvider: () => bytes,
       );
-      if (!await tempFile.exists()) {
-        await tempFile.writeAsBytes(archiveImage!, flush: true);
-      }
       return tempFile.path;
     }
     if (isLocale == true && directory != null && index != null) {

--- a/lib/utils/extensions/others.dart
+++ b/lib/utils/extensions/others.dart
@@ -80,6 +80,12 @@ extension ImageProviderExtension on ImageProvider {
 extension UChapDataPreloadExtensions on UChapDataPreload {
   Future<String?> get getLocalFilePath async {
     if (isTransitionPage) return null;
+    if (localImagePath != null) {
+      // Local image-folder page: this already IS a real file on disk, so
+      // just hand back its path directly rather than reading it into memory
+      // and writing it back out to a temp file for no reason.
+      return localImagePath;
+    }
     if (archiveImage != null) {
       final tempDir = Directory.systemTemp;
       final sourceKey = [
@@ -89,14 +95,15 @@ extension UChapDataPreloadExtensions on UChapDataPreload {
         chapter?.url,
       ].whereType<String>().where((value) => value.isNotEmpty).join('|');
       final chapterKey = keyToMd5(sourceKey);
+      final ext = detectImageExtension(archiveImage!);
       final tempFile = File(
         p.join(
           tempDir.path,
-          'mangayomi_archive_${chapterKey}_${index ?? pageIndex}.jpg',
+          'mangayomi_archive_${chapterKey}_${index ?? pageIndex}$ext',
         ),
       );
-      if (!tempFile.existsSync()) {
-        tempFile.writeAsBytesSync(archiveImage!);
+      if (!await tempFile.exists()) {
+        await tempFile.writeAsBytes(archiveImage!, flush: true);
       }
       return tempFile.path;
     }
@@ -116,6 +123,8 @@ extension UChapDataPreloadExtensions on UChapDataPreload {
     Uint8List? imageBytes;
     if (archiveImage != null) {
       imageBytes = archiveImage;
+    } else if (localImagePath != null) {
+      imageBytes = await File(localImagePath!).readAsBytes();
     } else if (isLocale == true && directory != null && index != null) {
       final file = await findDownloadedPageFileAsync(directory!, index!);
       imageBytes = await file?.readAsBytes();
@@ -149,6 +158,8 @@ extension UChapDataPreloadExtensions on UChapDataPreload {
     return isLocale
         ? archiveImage != null
               ? MemoryImage(archiveImage)
+              : data.localImagePath != null
+              ? FileImage(File(data.localImagePath!))
               : FileImage(
                   findDownloadedPageFile(data.directory!, data.index!) ??
                       // Nothing found under any known extension - fall back

--- a/lib/utils/manga_cover_actions.dart
+++ b/lib/utils/manga_cover_actions.dart
@@ -1,0 +1,48 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:mangayomi/eval/model/m_bridge.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/modules/library/providers/local_archive.dart';
+import 'package:mangayomi/providers/l10n_providers.dart';
+import 'package:mangayomi/repositories/manga_repository.dart';
+
+/// Shows the "use this as cover" confirmation.
+/// Returns whether the user confirmed.
+Future<bool> confirmUseAsMangaCover(BuildContext context) async {
+  final res = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      content: Text(context.l10n.use_this_as_cover_art),
+      actions: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: Text(context.l10n.cancel),
+            ),
+            const SizedBox(width: 15),
+            TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: Text(context.l10n.ok),
+            ),
+          ],
+        ),
+      ],
+    ),
+  );
+  return res ?? false;
+}
+
+/// Applies [bytes] as [manga]'s custom cover and saves it
+Future<void> applyMangaCover(
+  BuildContext context,
+  Manga manga,
+  Uint8List? bytes,
+) async {
+  final coverImage = bytes?.getCoverImage;
+  if (coverImage == null) return;
+  await mangaRepository.save(manga..customCoverImage = coverImage);
+  if (context.mounted) botToast(context.l10n.cover_updated, second: 3);
+}

--- a/lib/utils/share.dart
+++ b/lib/utils/share.dart
@@ -105,6 +105,8 @@ String _fileName(XFile file, String? fallbackName, int index) {
     'image/png' => '.png',
     'image/jpeg' => '.jpg',
     'image/webp' => '.webp',
+    'image/avif' => '.avif',
+    'image/gif' => '.gif',
     _ => '',
   };
   if (extension.isNotEmpty && p.extension(name).toLowerCase() != extension) {


### PR DESCRIPTION
- Avoid loading local image-folder pages into memory when a real file path is already available.
- Pass local image paths through the chapter/page preload pipeline and use them directly in the reader.
- Centralize manga cover confirmation and update logic.
- Preserve the detected image format when saving or sharing images.
- Reuse a shared helper for caching image bytes to temporary files.

This reduces unnecessary memory usage and disk I/O for chapters stored as plain image folders. Previously, pages were read into memory and could subsequently be written back to temporary files just to obtain a file path. Folder-based pages can now use their existing filesystem path directly.