### PR TITLE
fix(downloads): preserve queue and select the next unread chapters

### DIFF
--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:mangayomi/services/download_manager/next_downloads.dart';
+
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -270,8 +272,10 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
     if (chaptersToDownload.isEmpty) return;
 
     for (final chapter in chaptersToDownload) {
-      await ref.read(addDownloadToQueueProvider(chapter: chapter).future);
+      await downloadRepository.enqueue(chapter);
     }
+    if (!mounted) return;
+    ref.invalidate(processDownloadsProvider());
     ref.read(processDownloadsProvider());
   }
 
@@ -512,49 +516,20 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                               },
                               onSelected: (value) async {
                                 final chapters = widget.manga!
-                                    .getSortedFilteredChapters();
-                                final chaptersToDownload = <Chapter>[];
-                                if (value == 0 ||
-                                    value == 1 ||
-                                    value == 2 ||
-                                    value == 3) {
-                                  final lastChapterReadIndex = chapters
-                                      .lastIndexWhere(
-                                        (element) => element.isRead == true,
-                                      );
-                                  if (lastChapterReadIndex == -1 ||
-                                      chapters.length == 1) {
-                                    if (chapters.isNotEmpty) {
-                                      chaptersToDownload.add(chapters.first);
-                                    }
-                                  } else {
-                                    final length = switch (value) {
-                                      0 => 1,
-                                      1 => 5,
-                                      2 => 10,
-                                      _ => 25,
-                                    };
-                                    for (var i = 1; i < length + 1; i++) {
-                                      if (chapters.length > 1 &&
-                                          chapters.elementAtOrNull(
-                                                lastChapterReadIndex + i,
-                                              ) !=
-                                              null) {
-                                        final chapter =
-                                            chapters[lastChapterReadIndex + i];
-                                        chaptersToDownload.add(chapter);
-                                      }
-                                    }
-                                  }
-                                } else if (value == 4) {
-                                  chaptersToDownload.addAll(
-                                    chapters.where(
-                                      (element) => !(element.isRead ?? false),
-                                    ),
-                                  );
-                                } else if (value == 5) {
-                                  chaptersToDownload.addAll(chapters);
-                                }
+                                    .getFilteredChapters();
+                                final chaptersToDownload = value <= 3
+                                    ? selectNextDownloads(
+                                        chapters,
+                                        count: [1, 5, 10, 25][value],
+                                        downloads: downloadRepository.getAll(),
+                                      )
+                                    : chapters
+                                          .where(
+                                            (chapter) =>
+                                                value == 5 ||
+                                                chapter.isRead != true,
+                                          )
+                                          .toList();
                                 await _downloadChaptersWithDestination(
                                   context,
                                   chaptersToDownload,

--- a/lib/modules/manga/detail/providers/state_providers.dart
+++ b/lib/modules/manga/detail/providers/state_providers.dart
@@ -347,15 +347,12 @@ class ChapterSetDownloadState extends _$ChapterSetDownloadState {
 
   Future<void> set() async {
     ref.read(isLongPressedStateProvider.notifier).update(false);
-    await downloadRepository.transaction(() {
-      for (var chapter in ref.watch(chaptersListStateProvider)) {
-        final entry = downloadRepository.getByChapterId(chapter.id);
-        if (entry == null || !entry.isDownload!) {
-          ref.watch(addDownloadToQueueProvider(chapter: chapter));
-        }
-      }
-    });
-
+    for (final chapter in ref.read(chaptersListStateProvider).toList()) {
+      await downloadRepository.enqueue(chapter);
+    }
+    if (!ref.mounted) return;
+    ref.invalidate(processDownloadsProvider());
+    ref.read(processDownloadsProvider());
     ref.read(chaptersListStateProvider.notifier).clear();
   }
 }

--- a/lib/modules/manga/download/download_page_widget.dart
+++ b/lib/modules/manga/download/download_page_widget.dart
@@ -20,18 +20,12 @@ class ChapterPageDownload extends ConsumerWidget {
 
   const ChapterPageDownload({super.key, required this.chapter});
 
-  void _startDownload(
-    bool? useWifi,
-    int? downloadId,
-    WidgetRef ref,
-  ) async {
-    _cancelTasks(downloadId: downloadId);
-    ref.read(
-      downloadChapterProvider(
-        chapter: chapter,
-        useWifi: useWifi,
-      ),
-    );
+  void _startDownload(bool? useWifi, int? downloadId, WidgetRef ref) async {
+    if (isDownloadScheduled(chapter.id)) return;
+    await downloadRepository.enqueue(chapter);
+    if (!ref.context.mounted) return;
+    ref.invalidate(downloadChapterProvider(chapter: chapter, useWifi: useWifi));
+    ref.read(downloadChapterProvider(chapter: chapter, useWifi: useWifi));
   }
 
   void _sendFile(BuildContext context) async {

--- a/lib/modules/manga/download/providers/download_provider.dart
+++ b/lib/modules/manga/download/providers/download_provider.dart
@@ -13,7 +13,6 @@ import 'package:mangayomi/models/page.dart';
 import 'package:mangayomi/repositories/download_repository.dart';
 import 'package:mangayomi/repositories/settings_repository.dart';
 import 'package:mangayomi/models/chapter.dart';
-import 'package:mangayomi/models/download.dart';
 import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/video.dart';
 import 'package:mangayomi/modules/library/providers/file_scanner.dart';
@@ -34,7 +33,6 @@ import 'package:mangayomi/services/download_manager/m3u8/m3u8_downloader.dart';
 import 'package:mangayomi/services/download_manager/m3u8/models/download.dart';
 import 'package:mangayomi/utils/chapter_recognition.dart';
 import 'package:mangayomi/utils/downloaded_page_file.dart';
-import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
 import 'package:mangayomi/utils/extensions/string_extensions.dart';
 import 'package:mangayomi/utils/headers.dart';
 import 'package:mangayomi/utils/localized_message.dart';
@@ -46,19 +44,12 @@ part 'download_provider.g.dart';
 
 @riverpod
 Future<void> addDownloadToQueue(Ref ref, {required Chapter chapter}) async {
-  final download = downloadRepository.getById(chapter.id!);
-  if (download == null) {
-    final download = Download(
-      id: chapter.id,
-      succeeded: 0,
-      failed: 0,
-      total: 100,
-      isDownload: false,
-      isStartDownload: true,
-    );
-    downloadRepository.save(download..chapter.value = chapter);
-  }
+  await downloadRepository.enqueue(chapter);
 }
+
+final _scheduledDownloadIds = <int>{};
+
+bool isDownloadScheduled(int? id) => _scheduledDownloadIds.contains(id);
 
 @riverpod
 Future<void> downloadChapter(
@@ -67,40 +58,28 @@ Future<void> downloadChapter(
   bool? useWifi,
   VoidCallback? callback,
 }) async {
+  if (!_scheduledDownloadIds.add(chapter.id!)) return;
   final keepAlive = ref.keepAlive();
-
-  // Show the chapter as queued straight away, before it waits for a slot, so
-  // the download icon reacts to the tap immediately even while it sits in the
-  // gate behind other downloads.
-  if (downloadRepository.getById(chapter.id!) == null) {
-    downloadRepository.save(
-      Download(
-        id: chapter.id,
-        succeeded: 0,
-        failed: 0,
-        total: 100,
-        isDownload: false,
-        isStartDownload: true,
-      )..chapter.value = chapter,
-    );
-  }
 
   // Every download path funnels through here, so acquiring the shared gate is
   // what makes the concurrency limit, per-source serialization (#645) and the
   // start delay/jitter (#621) apply no matter how the download was started.
   final sourceKey = _chapterSourceKey(chapter);
-  final maxConcurrent = ref.read(allowConcurrentDownloadsStateProvider)
-      ? ref.read(concurrentDownloadsStateProvider)
-      : 1;
-  final delaySeconds = ref.read(downloadDelaySecondsStateProvider);
-  await _DownloadGate.instance.acquire(
-    id: chapter.id!,
-    sourceKey: sourceKey,
-    maxConcurrent: maxConcurrent,
-    delaySeconds: delaySeconds,
-  );
-
+  var acquired = false;
   try {
+    final maxConcurrent = ref.read(allowConcurrentDownloadsStateProvider)
+        ? ref.read(concurrentDownloadsStateProvider)
+        : 1;
+    final delaySeconds = ref.read(downloadDelaySecondsStateProvider);
+    await downloadRepository.enqueue(chapter);
+    if (downloadRepository.getById(chapter.id!)?.isDownload == true) return;
+    await _DownloadGate.instance.acquire(
+      id: chapter.id!,
+      sourceKey: sourceKey,
+      maxConcurrent: maxConcurrent,
+      delaySeconds: delaySeconds,
+    );
+    acquired = true;
     // Cancelled while it waited for a slot in the gate? Its record was deleted,
     // so don't resurrect it.
     if (_downloadCancelled(chapter)) {
@@ -266,18 +245,10 @@ Future<void> downloadChapter(
       lastPersistedPercent = percent;
       lastPersistTime = now;
       final download = downloadRepository.getById(chapter.id!);
-      if (download == null) {
-        final download = Download(
-          id: chapter.id,
-          succeeded: percent,
-          failed: 0,
-          total: 100,
-          isDownload: progress.isCompleted,
-          isStartDownload: true,
-        );
-        downloadRepository.save(download..chapter.value = chapter);
-      } else if (progress.total != 0) {
-        downloadRepository.save(
+      // Cancellation deletes the queue record. A late progress callback must
+      // not recreate it and make a cancelled item reappear.
+      if (download != null && progress.total != 0) {
+        await downloadRepository.save(
           download
             ..succeeded = percent
             ..total = 100
@@ -418,7 +389,7 @@ Future<void> downloadChapter(
 
     if (!isOk) {
       botToast(startFailure ?? "Couldn't start the download");
-      _markDownloadFailed(chapter);
+      await _markDownloadFailed(chapter);
       if (callback != null) callback();
       keepAlive.close();
       return;
@@ -582,12 +553,14 @@ Future<void> downloadChapter(
   } catch (e) {
     // Surface the failure instead of swallowing it — a silent catch here is
     // exactly how "downloads just don't start" stays invisible.
-    botToast("Download failed: $e");
-    _markDownloadFailed(chapter);
+    if (!_downloadCancelled(chapter)) botToast("Download failed: $e");
+    await _markDownloadFailed(chapter);
     if (callback != null) callback();
     keepAlive.close();
   } finally {
-    _DownloadGate.instance.release(sourceKey);
+    if (acquired) _DownloadGate.instance.release(sourceKey);
+    _scheduledDownloadIds.remove(chapter.id);
+    keepAlive.close();
   }
 }
 
@@ -607,10 +580,10 @@ Duration _downloadStartDelay(int baseSeconds) {
 /// Reset a failed/aborted download to a plain, tappable "not downloaded" state
 /// so it shows a retry-able icon instead of a progress bar frozen at its last
 /// value. Any partial file is cleaned up on the next attempt.
-void _markDownloadFailed(Chapter chapter) {
+Future<void> _markDownloadFailed(Chapter chapter) async {
   final record = downloadRepository.getById(chapter.id!);
   if (record == null || (record.isDownload ?? false)) return;
-  downloadRepository.save(
+  await downloadRepository.save(
     record
       ..isStartDownload = false
       ..succeeded = 0
@@ -743,6 +716,7 @@ Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
     final ongoingDownloads = DownloadQueueOrder.sorted(
       await downloadRepository.getPendingStarted(),
     );
+    if (!ref.mounted) return;
     // Kick off every pending download. The shared _DownloadGate enforces the
     // concurrency limit, per-source serialization (#645), the start delay
     // (#621) and the manual order (#514), so they can all be fired at once and
@@ -756,10 +730,16 @@ Future<void> processDownloads(Ref ref, {bool? useWifi}) async {
       }
       final chapter = downloadItem.chapter.value;
       if (chapter == null) continue;
-      chapter.cancelDownloads(downloadItem.id);
-      ref.read(downloadChapterProvider(chapter: chapter, useWifi: useWifi));
+      if (_scheduledDownloadIds.contains(chapter.id)) continue;
+      final provider = downloadChapterProvider(
+        chapter: chapter,
+        useWifi: useWifi,
+      );
+      ref.invalidate(provider);
+      ref.read(provider);
     }
-  } catch (_) {
+  } catch (error) {
+    botToast('Could not start download queue: $error');
   } finally {
     keepAlive.close();
   }

--- a/lib/modules/more/download_queue/download_queue_screen.dart
+++ b/lib/modules/more/download_queue/download_queue_screen.dart
@@ -29,7 +29,7 @@ class _DownloadQueueScreenState extends ConsumerState<DownloadQueueScreen> {
       // No explicit sort: the natural (insertion) id order is the stable base
       // the manual queue order is applied on top of, so rows don't reshuffle as
       // download progress ticks.
-      stream: downloadRepository.watchPendingStarted(),
+      stream: downloadRepository.watchPending(),
       builder: (context, snapshot) {
         if (!snapshot.hasData || snapshot.data!.isEmpty) {
           return Scaffold(
@@ -119,7 +119,15 @@ class _DownloadQueueScreenState extends ConsumerState<DownloadQueueScreen> {
           floatingActionButton: CustomFloatingActionBtn(
             isExtended: false,
             label: l10n.download_queue,
-            onPressed: () {
+            onPressed: () async {
+              for (final entry in entries) {
+                final chapter = entry.chapter.value;
+                if (chapter != null) {
+                  await downloadRepository.enqueue(chapter);
+                }
+              }
+              if (!mounted) return;
+              ref.invalidate(processDownloadsProvider());
               ref.read(processDownloadsProvider());
             },
           ),
@@ -160,7 +168,9 @@ class _DownloadQueueScreenState extends ConsumerState<DownloadQueueScreen> {
                       style: const TextStyle(fontSize: 16),
                     ),
                     Text(
-                      "${element.succeeded}/${element.total}",
+                      (element.failed ?? 0) > 0
+                          ? 'Failed — retry'
+                          : '${element.succeeded ?? 0}%',
                       style: const TextStyle(fontSize: 10),
                     ),
                   ],

--- a/lib/repositories/download_repository.dart
+++ b/lib/repositories/download_repository.dart
@@ -53,6 +53,12 @@ class DownloadRepository {
       .isStartDownloadEqualTo(true)
       .watch(fireImmediately: true);
 
+  Stream<List<Download>> watchPending() => isar.downloads
+      .filter()
+      .idIsNotNull()
+      .isDownloadEqualTo(false)
+      .watch(fireImmediately: true);
+
   Future<List<Download>> getPendingStarted() => isar.downloads
       .filter()
       .idIsNotNull()
@@ -61,6 +67,36 @@ class DownloadRepository {
       .findAll();
 
   // No updatedAt stamping - Download has no such field.
+  /// Atomically appends a chapter to the queue. Repeated requests preserve
+  /// completed and active entries, while failed entries become retryable.
+  Future<void> enqueue(Chapter chapter) => dbWriteQueue.run(() {
+    isar.writeTxnSync(() {
+      final existing = isar.downloads.getSync(chapter.id!);
+      if (existing?.isDownload == true || existing?.isStartDownload == true) {
+        return;
+      }
+      final download =
+          existing ??
+          Download(
+            id: chapter.id,
+            total: 100,
+            succeeded: 0,
+            failed: 0,
+            isDownload: false,
+            isStartDownload: true,
+          );
+      download
+        ..succeeded = 0
+        ..failed = 0
+        ..total = 100
+        ..isDownload = false
+        ..isStartDownload = true
+        ..chapter.value = chapter;
+      isar.downloads.putSync(download);
+      download.chapter.saveSync();
+    });
+  });
+
   Future<void> save(Download download) => dbWriteQueue.run(
     () => isar.writeTxnSync(() => isar.downloads.putSync(download)),
   );

--- a/lib/services/download_manager/next_downloads.dart
+++ b/lib/services/download_manager/next_downloads.dart
@@ -1,0 +1,26 @@
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/models/download.dart';
+
+/// Selects the next unread entries in reading order. Completed and already
+/// queued downloads do not consume a slot in the requested batch size.
+List<Chapter> selectNextDownloads(
+  List<Chapter> chapters, {
+  required int count,
+  required Iterable<Download> downloads,
+}) {
+  if (count <= 0) return [];
+  final unavailable = downloads
+      .where(
+        (download) =>
+            download.isDownload == true || download.isStartDownload == true,
+      )
+      .map((download) => download.id)
+      .toSet();
+  return chapters
+      .where(
+        (chapter) =>
+            chapter.isRead != true && !unavailable.contains(chapter.id),
+      )
+      .take(count)
+      .toList();
+}

--- a/test/modules/more/download_queue/download_queue_persistence_test.dart
+++ b/test/modules/more/download_queue/download_queue_persistence_test.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart' as app;
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/models/download.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/models/source.dart';
+import 'package:mangayomi/modules/manga/download/providers/download_provider.dart';
+import 'package:mangayomi/repositories/db_write_queue.dart';
+import 'package:mangayomi/repositories/download_repository.dart';
+
+void main() {
+  late Directory databaseDirectory;
+  late Isar database;
+
+  setUpAll(() async {
+    await Isar.initializeIsarCore(download: true);
+  });
+
+  setUp(() async {
+    databaseDirectory = await Directory.systemTemp.createTemp(
+      'mangayomi-download-queue-',
+    );
+    database = await Isar.open(
+      [MangaSchema, ChapterSchema, DownloadSchema, SettingsSchema, SourceSchema],
+      directory: databaseDirectory.path,
+      name: 'download_queue_test',
+    );
+    app.isar = database;
+    database.writeTxnSync(() => database.settings.putSync(Settings(id: 227)));
+  });
+
+  tearDown(() async {
+    await database.close(deleteFromDisk: true);
+    if (await databaseDirectory.exists()) {
+      await databaseDirectory.delete(recursive: true);
+    }
+  });
+
+  test('enqueue waits for persistence and preserves queue entries', () async {
+    final first = Chapter(id: 316, mangaId: 1, name: 'Episode 316');
+    final second = Chapter(id: 1211, mangaId: 2, name: 'Episode 1211');
+    database.writeTxnSync(() => database.chapters.putAllSync([first, second]));
+    await downloadRepository.enqueue(first);
+    final active = downloadRepository.getById(316)!..succeeded = 42;
+    await downloadRepository.save(active);
+
+    final release = Completer<void>();
+    final blocked = dbWriteQueue.run(() => release.future);
+    var saved = false;
+    final pending = downloadRepository.enqueue(second).then((_) => saved = true);
+    await Future<void>.delayed(Duration.zero);
+    expect(saved, isFalse);
+    release.complete();
+    await blocked;
+    await pending;
+
+    await Future.wait([
+      downloadRepository.enqueue(first),
+      downloadRepository.enqueue(second),
+    ]);
+    expect(downloadRepository.getAll(), hasLength(2));
+    expect(downloadRepository.getById(316)?.succeeded, 42);
+  });
+
+  test('starting the queue never deletes existing entries', () async {
+    final chapters = [
+      Chapter(id: 316, mangaId: 1, name: 'Episode 316'),
+      Chapter(id: 1, mangaId: 2, name: 'Episode 1'),
+    ];
+    database.writeTxnSync(() => database.chapters.putAllSync(chapters));
+    for (final chapter in chapters) {
+      await downloadRepository.enqueue(chapter);
+    }
+    final started = <int>[];
+    final container = ProviderContainer(
+      overrides: [
+        downloadChapterProvider.overrideWith((ref, argument) async {
+          started.add(argument.chapter.id!);
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(processDownloadsProvider().future);
+    await dbWriteQueue.run(() {});
+    expect(started.toSet(), {1, 316});
+    expect(downloadRepository.getAll(), hasLength(2));
+    expect(await downloadRepository.getPendingStarted(), hasLength(2));
+  });
+
+  test('enqueue retries failures without resetting completed entries', () async {
+    final chapter = Chapter(id: 1, mangaId: 1, name: 'Episode 1');
+    database.writeTxnSync(() => database.chapters.putSync(chapter));
+    await downloadRepository.enqueue(chapter);
+    await downloadRepository.save(
+      downloadRepository.getById(1)!
+        ..failed = 1
+        ..isStartDownload = false,
+    );
+    await downloadRepository.enqueue(chapter);
+    expect(downloadRepository.getById(1)?.failed, 0);
+    expect(downloadRepository.getById(1)?.isStartDownload, true);
+
+    await downloadRepository.save(
+      downloadRepository.getById(1)!
+        ..succeeded = 100
+        ..isDownload = true,
+    );
+    await downloadRepository.enqueue(chapter);
+    expect(downloadRepository.getById(1)?.isDownload, true);
+    expect(downloadRepository.getById(1)?.succeeded, 100);
+  });
+}

--- a/test/services/download_manager/next_downloads_test.dart
+++ b/test/services/download_manager/next_downloads_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/models/download.dart';
+import 'package:mangayomi/services/download_manager/next_downloads.dart';
+
+void main() {
+  List<Chapter> episodes({int watched = 0}) => List.generate(
+    25,
+    (index) => Chapter(
+      id: index + 1,
+      mangaId: 1,
+      name: 'Episode ${index + 1}',
+      isRead: index < watched,
+    ),
+  );
+
+  Download queued(int id, {bool completed = false, bool failed = false}) =>
+      Download(
+        id: id,
+        succeeded: 0,
+        failed: failed ? 1 : 0,
+        total: 100,
+        isDownload: completed,
+        isStartDownload: !failed,
+      );
+
+  test('next downloads skip watched entries wherever they appear', () {
+    final chapters = List.generate(20, (index) {
+      final number = 316 + index;
+      return Chapter(
+        id: number,
+        mangaId: 1,
+        name: 'Episode $number',
+        isRead: number <= 320 || (number >= 326 && number <= 331),
+      );
+    });
+    expect(
+      selectNextDownloads(chapters, count: 10, downloads: []).map((c) => c.id),
+      [321, 322, 323, 324, 325, 332, 333, 334, 335],
+    );
+  });
+
+  test('repeated batches advance past queued and completed entries', () {
+    expect(
+      selectNextDownloads(
+        episodes(watched: 5),
+        count: 5,
+        downloads: [
+          for (var id = 6; id <= 10; id++) queued(id),
+          queued(11, completed: true),
+        ],
+      ).map((chapter) => chapter.id),
+      [12, 13, 14, 15, 16],
+    );
+  });
+
+  test('failed entries can be retried and the series end is bounded', () {
+    expect(
+      selectNextDownloads(
+        episodes(watched: 23),
+        count: 25,
+        downloads: [queued(24, failed: true)],
+      ).map((chapter) => chapter.id),
+      [24, 25],
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- persist queue additions atomically so adding another title cannot drop existing entries
- stop the queue runner from deleting each item immediately before scheduling it
- deduplicate active providers, keep cancellations cancelled, and make failed entries retryable
- make Next 1/5/10/25 skip read and already queued/downloaded chapters while still filling the requested batch
- await batch persistence before starting the queue

## Tests
- flutter test test/modules/more/download_queue/download_queue_persistence_test.dart test/services/download_manager/next_downloads_test.dart
- targeted dart analyze on all changed Dart files

Extracted from Mangatan's generic download fixes; no OCR, dictionary, Jimaku, mining, or other immersion-specific code is included.