### PR TITLE
fix(player): persist completed episodes before navigation

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -356,20 +356,38 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
   bool get hasNextEpisode => _streamController.hasNextEpisode;
 
   late final StreamSubscription<bool> _completed = _player.stream.completed
-      .listen((val) {
-        if (hasNextEpisode && val && ref.read(autoPlayNextEpisodeProvider)) {
-          if (mounted) {
-            pushToNewEpisode(context, _streamController.getNextEpisode());
-          }
-        }
-        // If the last episode of an Anime has ended, exit fullscreen mode
-        final isFullScreen = ref.read(fullscreenProvider);
-        if (!hasNextEpisode && val && isDesktop && isFullScreen) {
-          setFullScreen(value: false);
-          ref.read(fullscreenProvider.notifier).state = false;
-          widget.desktopFullScreenPlayer.call(false);
-        }
-      });
+      .listen(_handlePlaybackCompleted);
+
+  Future<void> _handlePlaybackCompleted(bool completed) async {
+    if (!completed || !mounted) return;
+
+    _watchStopwatch.stop();
+    final reportedDuration = _currentTotalDuration.value;
+    final totalDuration =
+        reportedDuration != null && reportedDuration > Duration.zero
+        ? reportedDuration
+        : _player.state.duration;
+    await _streamController.completeEpisode(
+      totalDuration,
+      elapsedSeconds: _watchStopwatch.elapsed.inSeconds,
+    );
+    _watchStopwatch.reset();
+    if (!mounted) return;
+
+    final hasNext = hasNextEpisode;
+    if (hasNext && ref.read(autoPlayNextEpisodeProvider)) {
+      pushToNewEpisode(context, _streamController.getNextEpisode());
+      return;
+    }
+
+    // If the last episode of an Anime has ended, exit fullscreen mode.
+    final isFullScreen = ref.read(fullscreenProvider);
+    if (!hasNext && isDesktop && isFullScreen) {
+      setFullScreen(value: false);
+      ref.read(fullscreenProvider.notifier).state = false;
+      widget.desktopFullScreenPlayer.call(false);
+    }
+  }
 
   Future<void> _handleMpvEvents(Pointer<generated.mpv_event> event) async {
     try {

--- a/lib/modules/anime/providers/anime_player_controller_provider.dart
+++ b/lib/modules/anime/providers/anime_player_controller_provider.dart
@@ -82,11 +82,30 @@ class AnimeStreamController extends _$AnimeStreamController
       final ep = episode;
       ep.isRead = isWatch;
       ep.lastPageRead = (duration.inMilliseconds).toString();
+      if (totalDuration != null && totalDuration > Duration.zero) {
+        ep.duration = totalDuration.inMilliseconds.toString();
+      }
+      ep.updatedAt = DateTime.now().millisecondsSinceEpoch;
       chapterRepository.save(ep);
       if (isWatch) {
         episode.updateTrackChapterRead(ref);
       }
     }
+  }
+
+  /// Persists the terminal playback state before the player route is replaced.
+  /// Some backends emit `completed` before their final position event, so the
+  /// known total duration is the deterministic terminal position.
+  Future<void> completeEpisode(
+    Duration totalDuration, {
+    int elapsedSeconds = 0,
+  }) async {
+    if (incognitoMode) return;
+    final completedPosition = totalDuration > Duration.zero
+        ? totalDuration
+        : Duration(milliseconds: int.tryParse(episode.lastPageRead ?? '') ?? 0);
+    setCurrentPosition(completedPosition, totalDuration, save: true);
+    await setHistoryUpdate(elapsedSeconds: elapsedSeconds);
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/modules/manga/reader/mixins/chapter_controller_mixin.dart
+++ b/lib/modules/manga/reader/mixins/chapter_controller_mixin.dart
@@ -99,13 +99,13 @@ mixin ChapterControllerMixin {
   ///
   /// [elapsedSeconds] accumulates watch/reading time; pass 0 to skip that
   /// field (the caller is responsible for tracking wall-clock deltas).
-  void setHistoryUpdate({int elapsedSeconds = 0}) {
+  Future<void> setHistoryUpdate({int elapsedSeconds = 0}) async {
     if (incognitoMode) return;
     final manga = getManga();
 
     final m = chapter.manga.value!;
     m.lastRead = DateTime.now().millisecondsSinceEpoch;
-    mangaRepository.save(m);
+    await mangaRepository.save(m);
 
     final isEmpty = historyRepository.isEmptyForManga(manga.id);
 
@@ -128,6 +128,6 @@ mixin ChapterControllerMixin {
       history.readingTimeSeconds =
           (history.readingTimeSeconds ?? 0) + elapsedSeconds;
     }
-    historyRepository.save(history);
+    await historyRepository.save(history);
   }
 }

--- a/test/modules/anime/anime_player_position_test.dart
+++ b/test/modules/anime/anime_player_position_test.dart
@@ -1,0 +1,109 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart' as app;
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/models/history.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/models/source.dart';
+import 'package:mangayomi/models/track.dart';
+import 'package:mangayomi/modules/anime/providers/anime_player_controller_provider.dart';
+
+void main() {
+  late Directory databaseDirectory;
+  late Isar database;
+  late ProviderContainer container;
+
+  setUpAll(() async {
+    await Isar.initializeIsarCore(download: true);
+  });
+
+  setUp(() async {
+    databaseDirectory = await Directory.systemTemp.createTemp(
+      'mangayomi-anime-position-',
+    );
+    database = await Isar.open(
+      [
+        MangaSchema,
+        ChapterSchema,
+        HistorySchema,
+        SettingsSchema,
+        SourceSchema,
+        TrackSchema,
+      ],
+      directory: databaseDirectory.path,
+      name: 'anime_position_test',
+    );
+    app.isar = database;
+    await database.writeTxn(() => database.settings.put(Settings()));
+    container = ProviderContainer();
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await database.close(deleteFromDisk: true);
+    if (await databaseDirectory.exists()) {
+      await databaseDirectory.delete(recursive: true);
+    }
+  });
+
+  test('saving playback progress persists the total duration', () async {
+    final episode = Chapter(mangaId: 1, name: 'Episode 1', isRead: false);
+    await database.writeTxn(() => database.chapters.put(episode));
+
+    container
+        .read(animeStreamControllerProvider(episode: episode).notifier)
+        .setCurrentPosition(
+          const Duration(seconds: 49),
+          const Duration(minutes: 24),
+          save: true,
+        );
+    await Future<void>.delayed(Duration.zero);
+
+    final saved = await database.chapters.get(episode.id!);
+    expect(saved?.lastPageRead, '49000');
+    expect(saved?.duration, '1440000');
+  });
+
+  test('completion marks the episode seen and updates history', () async {
+    final manga = Manga(
+      source: 'Source',
+      author: '',
+      artist: '',
+      genre: const [],
+      imageUrl: null,
+      lang: 'en',
+      link: '/anime',
+      name: 'Anime',
+      status: Status.ongoing,
+      description: '',
+      sourceId: 1,
+    );
+    await database.writeTxn(() => database.mangas.put(manga));
+    final episode = Chapter(
+      mangaId: manga.id,
+      name: 'Episode 1',
+      isRead: false,
+    )..manga.value = manga;
+    await database.writeTxn(() async {
+      await database.chapters.put(episode);
+      await episode.manga.save();
+    });
+
+    await container
+        .read(animeStreamControllerProvider(episode: episode).notifier)
+        .completeEpisode(const Duration(minutes: 24), elapsedSeconds: 42);
+
+    final saved = await database.chapters.get(episode.id!);
+    final history = await database.historys.where().findFirst();
+    expect(saved?.isRead, isTrue);
+    expect(saved?.lastPageRead, '1440000');
+    expect(saved?.duration, '1440000');
+    expect(history?.mangaId, manga.id);
+    expect(history?.chapterId, episode.id);
+    expect(history?.readingTimeSeconds, 42);
+  });
+}


### PR DESCRIPTION
## Summary
- persist the final playback position and total duration when media emits completed
- await the history write before auto-playing the next episode or disposing the route
- retain accumulated watch time in history
- make chapter/history persistence awaitable so ordered writes cannot race navigation

Some backends emit completed before their final position event. Previously auto-play could replace the route before the last state was saved, leaving the episode unwatched or with stale progress.

## Tests
- flutter test test/modules/anime/anime_player_position_test.dart
- targeted dart analyze on changed files

This is an older generic Mangatan fix, isolated from immersion-specific player additions.