### PR TITLE
fix: keep Discord chapter presence current

### DIFF
--- a/lib/modules/manga/reader/reader_view.dart
+++ b/lib/modules/manga/reader/reader_view.dart
@@ -175,6 +175,7 @@ class _MangaChapterPageGalleryState
   );
 
   final Stopwatch _readingStopwatch = Stopwatch();
+  int? _discordReaderSession;
 
   /// Flag to prevent fullscreen from being disabled when navigating between
   /// chapters via pushReplacement. The old widget's dispose runs after the new
@@ -207,7 +208,10 @@ class _MangaChapterPageGalleryState
     } else {
       restoreSystemUI();
     }
-    discordRpc?.showIdleText();
+    final discordReaderSession = _discordReaderSession;
+    if (discordReaderSession != null) {
+      unawaited(discordRpc?.endReaderSession(discordReaderSession));
+    }
     final actualIdx = _pageViewToActualIndexSync(_currentIndex!);
     final index = pages[actualIdx].index;
     if (index != null) {
@@ -302,6 +306,7 @@ class _MangaChapterPageGalleryState
       extendedController: _extendedController,
     );
     _initCurrentIndex();
+    _discordReaderSession = discordRpc?.beginReaderSession();
     discordRpc?.showChapterDetails(ref, chapter);
     WidgetsBinding.instance.addObserver(this);
     _initWakelock();

--- a/lib/modules/novel/novel_reader_view.dart
+++ b/lib/modules/novel/novel_reader_view.dart
@@ -88,6 +88,7 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
   bool get _ttsSupported => !Platform.isLinux;
 
   final Stopwatch _readingStopwatch = Stopwatch();
+  int? _discordReaderSession;
 
   void onScroll() {
     if (_scrollController.hasClients) {
@@ -122,7 +123,10 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
     } else {
       restoreSystemUI();
     }
-    discordRpc?.showIdleText();
+    final discordReaderSession = _discordReaderSession;
+    if (discordReaderSession != null) {
+      unawaited(discordRpc?.endReaderSession(discordReaderSession));
+    }
     super.dispose();
   }
 
@@ -159,6 +163,7 @@ class _NovelWebViewState extends ConsumerState<NovelWebView>
       });
     });
     if (!isDesktop) SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
+    _discordReaderSession = discordRpc?.beginReaderSession();
     discordRpc?.showChapterDetails(ref, chapter);
 
     _ttsIndexSub = NovelTtsService.instance.paragraphIndexStream.listen((i) {

--- a/lib/utils/discord_rpc.dart
+++ b/lib/utils/discord_rpc.dart
@@ -21,6 +21,9 @@ class DiscordRPC {
   /// Temp var
   bool rpcShowReadingWatchingProgress = false;
 
+  int _nextReaderSession = 0;
+  int? _activeReaderSession;
+
   /// Instance of the current RPC activity
   final RpcActivity activity = RpcActivity(
     assets: const RPCAssets(largeImage: "app-icon", largeText: "Mangayomi"),
@@ -77,6 +80,20 @@ class DiscordRPC {
       state: "-----",
       assets: const RPCAssets(largeImage: "app-icon", largeText: "Mangayomi"),
     );
+  }
+
+  /// Marks a reader as the current owner of chapter presence updates.
+  int beginReaderSession() {
+    final session = ++_nextReaderSession;
+    _activeReaderSession = session;
+    return session;
+  }
+
+  /// Returns to idle only if no newer reader has replaced this one.
+  Future<void> endReaderSession(int session) async {
+    if (_activeReaderSession != session) return;
+    _activeReaderSession = null;
+    await showIdleText();
   }
 
   Future<void> showChapterDetails(WidgetRef ref, Chapter chapter) async {

--- a/test/utils/discord_rpc_test.dart
+++ b/test/utils/discord_rpc_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/utils/discord_rpc.dart';
+
+void main() {
+  test('an outgoing reader cannot reset a newer chapter presence', () async {
+    final rpc = _RecordingDiscordRPC();
+    final outgoingReader = rpc.beginReaderSession();
+    final incomingReader = rpc.beginReaderSession();
+
+    await rpc.endReaderSession(outgoingReader);
+
+    expect(rpc.idleCalls, 0);
+
+    await rpc.endReaderSession(incomingReader);
+
+    expect(rpc.idleCalls, 1);
+  });
+}
+
+class _RecordingDiscordRPC extends DiscordRPC {
+  _RecordingDiscordRPC() : super(applicationId: 'test');
+
+  int idleCalls = 0;
+
+  @override
+  Future<void> showIdleText() async {
+    idleCalls++;
+  }
+}


### PR DESCRIPTION
## Summary

- give each manga or novel reader instance a Discord presence session
- ignore idle cleanup from an outgoing reader after a replacement reader has taken ownership
- preserve the existing Idle update when the active reader is actually closed
- cover the route-replacement lifecycle race with a regression test

## Root cause

Chapter changes replace the reader route. The incoming reader publishes the new chapter, but the outgoing reader then runs dispose and publishes Idle, which can overwrite the newer presence update.

Fixes #595

## Verification

- flutter test test/utils/discord_rpc_test.dart test/modules/novel_ref_after_dispose_test.dart test/modules/player_after_dispose_test.dart (6 tests passed)
- flutter analyze lib/utils/discord_rpc.dart lib/modules/manga/reader/reader_view.dart lib/modules/novel/novel_reader_view.dart test/utils/discord_rpc_test.dart (no issues)