### PR TITLE
fix: decode current VOE video payloads

### DIFF
--- a/lib/services/anime_extractors/voe_extractor.dart
+++ b/lib/services/anime_extractors/voe_extractor.dart
@@ -2,17 +2,17 @@ import 'dart:convert';
 
 import 'package:html/dom.dart';
 import 'package:html/parser.dart';
-import 'package:http_interceptor/http_interceptor.dart';
+import 'package:http/http.dart' as http;
 import 'package:mangayomi/models/video.dart';
 import 'package:mangayomi/services/http/m_client.dart';
 import 'package:mangayomi/utils/extensions/dom_extensions.dart';
 import 'package:mangayomi/utils/extensions/string_extensions.dart';
-import 'package:path/path.dart' as path;
 
 class VoeExtractor {
-  final InterceptedClient client = MClient.init(
-    reqcopyWith: {'useDartHttpClient': true},
-  );
+  VoeExtractor({http.Client? client})
+    : client = client ?? MClient.init(reqcopyWith: {'useDartHttpClient': true});
+
+  final http.Client client;
   final linkRegex = RegExp(
     r'(http|https)://([\w_-]+(?:\.[\w_-]+)+)([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])',
   );
@@ -37,7 +37,13 @@ class VoeExtractor {
           return [];
         }
         document = parse((await client.get(Uri.parse(originalUrl))).body);
+        url = originalUrl;
       }
+
+      final currentPlaylistUrl = await _currentPlaylistUrl(
+        document,
+        Uri.parse(url),
+      );
       var alternativeScript = document
           .select('script')
           ?.where((script) => scriptBase64Regex.hasMatch(script.text))
@@ -46,16 +52,19 @@ class VoeExtractor {
       Element? script = document.selectFirst(
         "script:contains(const sources), script:contains(var sources), script:contains(wc0)",
       );
-      if (script == null) {
+      if (currentPlaylistUrl == null && script == null) {
         if (alternativeScript?.isNotEmpty ?? false) {
           script = alternativeScript!.first;
         } else {
           return [];
         }
       }
-      final scriptContent = script.text;
-      String playlistUrl = "";
-      if (scriptContent.contains('sources')) {
+      final scriptContent = script?.text ?? '';
+      String playlistUrl = currentPlaylistUrl ?? "";
+      if (playlistUrl.isNotEmpty) {
+        // The current VOE payload is decoded above. Keep the legacy branches
+        // below for mirrors that still serve the older inline formats.
+      } else if (scriptContent.contains('sources')) {
         final link = scriptContent
             .substringAfter("hls': '")
             .substringBefore("'");
@@ -75,7 +84,6 @@ class VoeExtractor {
         return [];
       }
       final uri = Uri.parse(playlistUrl);
-      final m3u8Host = "${uri.scheme}://${uri.host}${path.dirname(uri.path)}";
       final masterPlaylistResponse = await client.get(uri);
       final masterPlaylist = masterPlaylistResponse.body;
 
@@ -86,13 +94,78 @@ class VoeExtractor {
         final resolution =
             "${it.substringAfter("RESOLUTION=").substringBefore("\n").substringAfter("x").substringBefore(",")}p";
         final line = it.substringAfter("\n").substringBefore("\n");
-        final videoUrl = line.startsWith("http")
-            ? line
-            : "$m3u8Host/${line.replaceFirst("/", "")}";
+        final videoUrl = uri.resolve(line).toString();
         return Video(videoUrl, '${prefix ?? ""}Voe: $resolution', videoUrl);
       }).toList();
     } catch (_) {
       return [];
     }
+  }
+
+  Future<String?> _currentPlaylistUrl(Document document, Uri pageUri) async {
+    final payloadElement = document.selectFirst(
+      'script[type="application/json"]',
+    );
+    final loaderElement = document.selectFirst(
+      'script[type="application/json"] + script[src]',
+    );
+    final loaderSource = loaderElement?.attributes['src'];
+    if (payloadElement == null || loaderSource == null) {
+      return null;
+    }
+
+    final payload = json.decode(payloadElement.text);
+    if (payload is! List || payload.isEmpty || payload.first is! String) {
+      return null;
+    }
+
+    final loader = await client.get(pageUri.resolve(loaderSource));
+    final lookupTableMatch = RegExp(r"\[(?:'\W{2}'\s*(?:,\s*|\])){1,9}")
+        .firstMatch(loader.body);
+    if (lookupTableMatch == null) {
+      return null;
+    }
+    final lookupTable = RegExp(r"'([^']+)'")
+        .allMatches(lookupTableMatch.group(0)!)
+        .map((match) => match.group(1)!)
+        .toList();
+
+    var encoded = _rot13(payload.first as String);
+    for (final marker in lookupTable) {
+      encoded = encoded.replaceAll(marker, '');
+    }
+
+    final shifted = utf8.decode(base64.decode(base64.normalize(encoded)));
+    final reversedBase64 = String.fromCharCodes(
+      shifted.codeUnits.map((codeUnit) => codeUnit - 3),
+    ).split('').reversed.join();
+    final decoded = json.decode(
+      utf8.decode(base64.decode(base64.normalize(reversedBase64))),
+    );
+    if (decoded is! Map) {
+      return null;
+    }
+
+    for (final key in const ['source', 'file', 'direct_access_url']) {
+      final value = decoded[key];
+      if (value is String && value.isNotEmpty) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  String _rot13(String value) {
+    return String.fromCharCodes(
+      value.codeUnits.map((codeUnit) {
+        if (codeUnit >= 65 && codeUnit <= 90) {
+          return (codeUnit - 52) % 26 + 65;
+        }
+        if (codeUnit >= 97 && codeUnit <= 122) {
+          return (codeUnit - 84) % 26 + 97;
+        }
+        return codeUnit;
+      }),
+    );
   }
 }

--- a/test/services/voe_extractor_test.dart
+++ b/test/services/voe_extractor_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mangayomi/services/anime_extractors/voe_extractor.dart';
+
+void main() {
+  test('extracts videos from the current encoded VOE payload', () async {
+    final requests = <Uri>[];
+    final client = MockClient((request) async {
+      requests.add(request.url);
+      return switch (request.url.toString()) {
+        'https://voe.example/e/video' => http.Response(_redirectPage, 200),
+        'https://mirror.example/e/video' => http.Response(_embedPage, 200),
+        'https://mirror.example/js/loader.js' => http.Response(_loader, 200),
+        'https://cdn.example/video/master.m3u8' => http.Response(
+          _masterPlaylist,
+          200,
+        ),
+        _ => http.Response('not found', 404),
+      };
+    });
+
+    final videos = await VoeExtractor(client: client)
+        .videosFromUrl('https://voe.example/e/video', 'German ');
+
+    expect(
+      requests,
+      containsAllInOrder([
+        Uri.parse('https://voe.example/e/video'),
+        Uri.parse('https://mirror.example/e/video'),
+        Uri.parse('https://mirror.example/js/loader.js'),
+        Uri.parse('https://cdn.example/video/master.m3u8'),
+      ]),
+    );
+    expect(videos, hasLength(2));
+    expect(videos[0].quality, 'German Voe: 720p');
+    expect(videos[0].url, 'https://cdn.example/video/720/index.m3u8');
+    expect(videos[1].quality, 'German Voe: 480p');
+    expect(videos[1].url, 'https://cdn.example/video/480/index.m3u8');
+  });
+}
+
+const _redirectPage = '''
+<script>
+  if (typeof localStorage !== 'undefined') {
+    window.location.href = 'https://mirror.example/e/video';
+  }
+</script>
+''';
+
+const _embedPage = '''
+<script type="application/json">["DQAkGQqLAyO@\$3BTkzo1H2Mz^^f0AH95JHcqp~@102G297FzM3%?FHcbomufMJ5*~EAH95pa1zry!!IYM3WAoSWfJ#&QIpsSx2MK1AsTt="]</script><script src="/js/loader.js"></script>
+''';
+
+const _loader = "const lookup = ['@\$', '^^', '~@', '%?', '*~', '!!', '#&'];";
+
+const _masterPlaylist = '''
+#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=2800000,RESOLUTION=1280x720
+720/index.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1400000,RESOLUTION=854x480
+480/index.m3u8
+''';


### PR DESCRIPTION
## Summary

- decode VOE's current `application/json` payload using the lookup table shipped in its loader
- preserve support for the existing legacy VOE formats
- resolve relative HLS variants with `Uri.resolve` so path separators are not dropped
- add a fixture-based regression test covering redirect, loader, decode, and playlist expansion

## Verification

- `flutter analyze lib/services/anime_extractors/voe_extractor.dart test/services/voe_extractor_test.dart`
- `flutter test test/services/voe_extractor_test.dart test/eval/js_errors_test.dart`
- live VOE embed probe through Mangayomi's HTTP client

Fixes #628