### PR TITLE
fix(restore): preserve Kotatsu category assignments

### DIFF
--- a/lib/modules/more/data_and_storage/providers/kotatsu_backup.dart
+++ b/lib/modules/more/data_and_storage/providers/kotatsu_backup.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
+
+class KotatsuCategoryRecord {
+  const KotatsuCategoryRecord({
+    required this.sourceId,
+    required this.name,
+    required this.position,
+    required this.hidden,
+  });
+
+  final int? sourceId;
+  final String? name;
+  final int position;
+  final bool hidden;
+}
+
+class KotatsuMangaRecord {
+  KotatsuMangaRecord({required this.manga});
+
+  final Map<String, dynamic> manga;
+  final Set<int> categoryIds = <int>{};
+}
+
+class KotatsuBackupData {
+  const KotatsuBackupData({required this.categories, required this.mangas});
+
+  final List<KotatsuCategoryRecord> categories;
+  final List<KotatsuMangaRecord> mangas;
+}
+
+/// Decodes the two Kotatsu sections needed by Mangayomi's library restore.
+///
+/// Kotatsu stores one favourite row per manga-category relationship. Grouping
+/// those rows here prevents a multi-category manga from being imported more
+/// than once while retaining every category assignment.
+KotatsuBackupData parseKotatsuBackup(Archive archive) {
+  final categoryJson = _decodeSection(archive, 'categories');
+  final categories = <KotatsuCategoryRecord>[];
+  for (var index = 0; index < categoryJson.length; index++) {
+    final value = categoryJson[index];
+    if (value is! Map) continue;
+    final category = Map<String, dynamic>.from(value);
+    categories.add(
+      KotatsuCategoryRecord(
+        // Current Kotatsu backups use category_id. Keep id as a fallback for
+        // backups created before that field was made explicit.
+        sourceId: _readInt(category['category_id'] ?? category['id']),
+        name: category['title'] as String?,
+        position: _readInt(category['sort_key']) ?? index,
+        hidden: !(category['show_in_lib'] as bool? ?? true),
+      ),
+    );
+  }
+
+  final mangasByKey = <String, KotatsuMangaRecord>{};
+  for (final value in _decodeSection(archive, 'favourites')) {
+    if (value is! Map) continue;
+    final favourite = Map<String, dynamic>.from(value);
+    final mangaValue = favourite['manga'];
+    if (mangaValue is! Map) continue;
+    final manga = Map<String, dynamic>.from(mangaValue);
+    final mangaId = _readInt(favourite['manga_id'] ?? manga['id']);
+    final key = mangaId != null
+        ? 'id:$mangaId'
+        : 'source:${manga['source']}\u0000url:${manga['url']}';
+    final record = mangasByKey.putIfAbsent(
+      key,
+      () => KotatsuMangaRecord(manga: manga),
+    );
+    final categoryId = _readInt(favourite['category_id']);
+    if (categoryId != null) record.categoryIds.add(categoryId);
+  }
+
+  return KotatsuBackupData(
+    categories: categories,
+    mangas: mangasByKey.values.toList(),
+  );
+}
+
+List<int> remapKotatsuCategoryIds(
+  KotatsuMangaRecord manga,
+  Map<int, int> categoryIdMap,
+) => manga.categoryIds.map((id) => categoryIdMap[id]).whereType<int>().toList();
+
+List<dynamic> _decodeSection(Archive archive, String name) {
+  for (final file in archive.files) {
+    if (file.name != name) continue;
+    final decoded = jsonDecode(utf8.decode(file.content as List<int>));
+    return decoded is List ? decoded : const [];
+  }
+  return const [];
+}
+
+int? _readInt(Object? value) {
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value);
+  return null;
+}

--- a/lib/modules/more/data_and_storage/providers/restore.dart
+++ b/lib/modules/more/data_and_storage/providers/restore.dart
@@ -21,6 +21,7 @@ import 'package:mangayomi/models/track.dart';
 import 'package:mangayomi/models/track_preference.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupAniyomi.pb.dart';
 import 'package:mangayomi/modules/more/data_and_storage/providers/proto/BackupMihon.pb.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/kotatsu_backup.dart';
 import 'package:mangayomi/modules/more/data_and_storage/widgets/backup_encryption_password_dialog.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/blend_level_state_provider.dart';
 import 'package:mangayomi/modules/more/settings/appearance/providers/flex_scheme_color_state_provider.dart';
@@ -940,62 +941,55 @@ ItemType _convertToItemTypeCategory(Map<String, dynamic> backup) {
 @riverpod
 Future<void> restoreKotatsuBackup(Ref ref, Archive archive) async {
   try {
-    for (var f in archive.files) {
-      List<Category> cats = [];
-      switch (f.name) {
-        case "categories":
-          final categories = jsonDecode(utf8.decode(f.content)) as List? ?? [];
-          await restoreRepository.run(() {
-            categoryRepository.clearSync();
-            for (var category in categories) {
-              final cat = Category(
-                id: category["id"],
-                name: category["title"],
-                forItemType: ItemType.manga,
-                hide: !(category["show_in_lib"] ?? true),
-              );
-              categoryRepository.putSync(cat);
-              cats.add(cat);
-            }
-          });
-        case "favourites":
-          final favourites = jsonDecode(utf8.decode(f.content)) as List? ?? [];
-          await restoreRepository.run(() {
-            mangaRepository.clearSync();
-            for (var favourite in favourites) {
-              final tempManga = favourite["manga"];
-              final manga = Manga(
-                source: tempManga["source"],
-                author: tempManga["author"],
-                artist: null,
-                genre:
-                    (tempManga["tags"] as List?)
-                        ?.map((t) => t["title"] as String)
-                        .toList() ??
-                    [],
-                imageUrl: tempManga["large_cover_url"],
-                lang: 'en',
-                link: tempManga["url"],
-                name: tempManga["title"],
-                status: Status.values.firstWhere(
-                  (s) =>
-                      s.name.toLowerCase() ==
-                      (tempManga["state"] as String?)?.toLowerCase(),
-                  orElse: () => Status.unknown,
-                ),
-                description: null,
-                categories: [favourite["category_id"]],
-                itemType: ItemType.manga,
-                favorite: true,
-                sourceId: null,
-              );
-              mangaRepository.putSync(manga);
-            }
-          });
-        default:
-          continue;
+    final backup = parseKotatsuBackup(archive);
+    await restoreRepository.run(() {
+      categoryRepository.clearSync();
+      mangaRepository.clearSync();
+
+      final categoryIdMap = <int, int>{};
+      for (final category in backup.categories) {
+        final restoredId = categoryRepository.putSync(
+          Category(
+            name: category.name,
+            forItemType: ItemType.manga,
+            pos: category.position,
+            hide: category.hidden,
+          ),
+        );
+        final sourceId = category.sourceId;
+        if (sourceId != null) categoryIdMap[sourceId] = restoredId;
       }
-    }
+
+      for (final favourite in backup.mangas) {
+        final tempManga = favourite.manga;
+        final manga = Manga(
+          source: tempManga["source"],
+          author: tempManga["author"],
+          artist: null,
+          genre:
+              (tempManga["tags"] as List?)
+                  ?.map((t) => t["title"] as String)
+                  .toList() ??
+              [],
+          imageUrl: tempManga["large_cover_url"],
+          lang: 'en',
+          link: tempManga["url"],
+          name: tempManga["title"],
+          status: Status.values.firstWhere(
+            (s) =>
+                s.name.toLowerCase() ==
+                (tempManga["state"] as String?)?.toLowerCase(),
+            orElse: () => Status.unknown,
+          ),
+          description: null,
+          categories: remapKotatsuCategoryIds(favourite, categoryIdMap),
+          itemType: ItemType.manga,
+          favorite: true,
+          sourceId: null,
+        );
+        mangaRepository.putSync(manga);
+      }
+    });
     await restoreRepository.run(() {
       chapterRepository.clearSync();
       downloadRepository.clearSync();

--- a/test/modules/more/data_and_storage/kotatsu_backup_test.dart
+++ b/test/modules/more/data_and_storage/kotatsu_backup_test.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/more/data_and_storage/providers/kotatsu_backup.dart';
+
+void main() {
+  Archive backupArchive({
+    required List<Map<String, dynamic>> categories,
+    required List<Map<String, dynamic>> favourites,
+    bool favouritesFirst = false,
+  }) {
+    final categoryFile = ArchiveFile.string(
+      'categories',
+      jsonEncode(categories),
+    );
+    final favouriteFile = ArchiveFile.string(
+      'favourites',
+      jsonEncode(favourites),
+    );
+    return Archive()
+      ..add(favouritesFirst ? favouriteFile : categoryFile)
+      ..add(favouritesFirst ? categoryFile : favouriteFile);
+  }
+
+  test(
+    'reads current Kotatsu category_id fields and preserves their order',
+    () {
+      final backup = parseKotatsuBackup(
+        backupArchive(
+          categories: [
+            {
+              'category_id': 42,
+              'title': 'Reading',
+              'sort_key': 7,
+              'show_in_lib': false,
+            },
+          ],
+          favourites: const [],
+        ),
+      );
+
+      expect(backup.categories, hasLength(1));
+      expect(backup.categories.single.sourceId, 42);
+      expect(backup.categories.single.name, 'Reading');
+      expect(backup.categories.single.position, 7);
+      expect(backup.categories.single.hidden, isTrue);
+    },
+  );
+
+  test('groups repeated favourites and remaps every category assignment', () {
+    Map<String, dynamic> manga(int id, String title) => {
+      'id': id,
+      'title': title,
+      'url': '/$title',
+      'source': 'TEST',
+    };
+
+    final backup = parseKotatsuBackup(
+      backupArchive(
+        categories: [
+          {'category_id': 42, 'title': 'Reading'},
+          {'category_id': 77, 'title': 'Favorites'},
+        ],
+        favourites: [
+          {'manga_id': 9001, 'category_id': 42, 'manga': manga(9001, 'Alpha')},
+          {'manga_id': 9001, 'category_id': 77, 'manga': manga(9001, 'Alpha')},
+          {'manga_id': 9002, 'category_id': 77, 'manga': manga(9002, 'Beta')},
+        ],
+        favouritesFirst: true,
+      ),
+    );
+
+    expect(backup.mangas, hasLength(2));
+    final alpha = backup.mangas.firstWhere(
+      (record) => record.manga['title'] == 'Alpha',
+    );
+    expect(alpha.categoryIds, {42, 77});
+    expect(remapKotatsuCategoryIds(alpha, {42: 3, 77: 8}), [3, 8]);
+  });
+
+  test('accepts the legacy category id field', () {
+    final backup = parseKotatsuBackup(
+      backupArchive(
+        categories: [
+          {'id': '12', 'title': 'Legacy'},
+        ],
+        favourites: const [],
+      ),
+    );
+
+    expect(backup.categories.single.sourceId, 12);
+  });
+}


### PR DESCRIPTION
## Summary

- Read Kotatsu's current `category_id` field while retaining support for the legacy `id` field.
- Remap Kotatsu category IDs to the IDs created by Isar.
- Group repeated favourite rows for the same manga and preserve every category membership.
- Preserve imported category order and visibility.
- Add regression tests for current and legacy schemas, archive order, and multi-category favourites.

## Root cause

Kotatsu exports one `favourites` row per manga-category relationship and names the category key `category_id`. Mangayomi read `id` and inserted every relationship as a separate manga, leaving category references unmatched and multi-category titles duplicated.

## Testing

- `flutter test test/modules/more/data_and_storage/kotatsu_backup_test.dart` passes, 3 tests.
- `flutter analyze` reports no issues.
- The full suite reached 322 passing tests. One unrelated onboarding repository-error test fails and also reproduces when run alone; this branch does not touch onboarding or repository networking.

Closes #620