### PR TITLE
fix(player): retire native video surfaces safely

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -24,6 +24,7 @@ import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/video.dart' as vid;
 import 'package:mangayomi/modules/anime/providers/anime_player_controller_provider.dart';
 import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
+import 'package:mangayomi/modules/anime/utils/player_lifecycle.dart';
 import 'package:mangayomi/modules/anime/widgets/aniskip_countdown_btn.dart';
 import 'package:mangayomi/modules/anime/widgets/tv_player_controls.dart';
 import 'package:mangayomi/modules/anime/widgets/tv_player_settings_panel.dart';
@@ -78,10 +79,15 @@ class _AnimePlayerViewState extends riv.ConsumerState<AnimePlayerView> {
   late final Chapter episode = chapterRepository.getById(widget.episodeId);
   List<String> _infoHashList = [];
   bool desktopFullScreenPlayer = false;
+  bool _episodeReplacementInProgress = false;
   @override
   void dispose() {
-    if (isDesktop) {
-      setFullScreen(value: desktopFullScreenPlayer);
+    if (shouldExitDesktopFullscreenOnDispose(
+      isDesktop: isDesktop,
+      isFullscreen: desktopFullScreenPlayer,
+      isEpisodeReplacement: _episodeReplacementInProgress,
+    )) {
+      unawaited(setFullScreen(value: false));
     }
     for (var infoHash in _infoHashList) {
       MTorrentServer().removeTorrent(infoHash);
@@ -159,6 +165,9 @@ class _AnimePlayerViewState extends riv.ConsumerState<AnimePlayerView> {
           desktopFullScreenPlayer: (value) {
             desktopFullScreenPlayer = value;
           },
+          onEpisodeReplacement: () {
+            _episodeReplacementInProgress = true;
+          },
           mpvDirectory: mpvDirectory,
         );
       },
@@ -207,6 +216,7 @@ class AnimeStreamPage extends riv.ConsumerStatefulWidget {
   final List<String> infoHashList;
   final Directory? mpvDirectory;
   final void Function(bool) desktopFullScreenPlayer;
+  final VoidCallback onEpisodeReplacement;
   const AnimeStreamPage({
     super.key,
     required this.defaultSubtitle,
@@ -216,6 +226,7 @@ class AnimeStreamPage extends riv.ConsumerStatefulWidget {
     required this.isTorrent,
     this.infoHashList = const [],
     required this.desktopFullScreenPlayer,
+    required this.onEpisodeReplacement,
     required this.mpvDirectory,
   });
 
@@ -234,6 +245,8 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
         _AlwaysOnTopStateMixin,
         TickerProviderStateMixin,
         WidgetsBindingObserver {
+  bool _routeExitInProgress = false;
+  bool _videoTextureVisible = true;
   late final GlobalKey<VideoState> _key = GlobalKey<VideoState>();
   late final useLibass = ref.read(useLibassStateProvider);
   late final useMpvConfig = ref.read(useMpvConfigStateProvider);
@@ -734,11 +747,45 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     _customButtons.value = customButtons;
   }
 
-  void pushToNewEpisode(BuildContext context, Chapter episode) {
+  Future<void> pushToNewEpisode(BuildContext context, Chapter episode) async {
+    if (_routeExitInProgress) return;
+    _routeExitInProgress = true;
     widget.desktopFullScreenPlayer.call(ref.read(fullscreenProvider));
+    widget.onEpisodeReplacement();
+    await _retireVideoTexture();
     if (context.mounted) {
       pushReplacementMangaReaderView(context: context, chapter: episode);
     }
+  }
+
+  Future<void> _retireVideoTexture() async {
+    if (!_videoTextureVisible || !mounted) return;
+    await retirePlaybackSurface(
+      hideSurface: () {
+        if (mounted) setState(() => _videoTextureVisible = false);
+      },
+      waitForFrame: () => WidgetsBinding.instance.endOfFrame,
+    );
+  }
+
+  Future<void> _exitDesktopFullScreen() async {
+    final isFullScreen = await setFullScreen(value: false);
+    if (!mounted) return;
+    ref.read(fullscreenProvider.notifier).state = isFullScreen;
+    widget.desktopFullScreenPlayer.call(isFullScreen);
+  }
+
+  Future<void> _goBackToDetail() async {
+    if (_routeExitInProgress) return;
+    _routeExitInProgress = true;
+    if (isDesktop && ref.read(fullscreenProvider)) {
+      await _exitDesktopFullScreen();
+    }
+    restoreSystemUI();
+    await _retireVideoTexture();
+    if (!mounted) return;
+    _firstTime = true;
+    Navigator.pop(context);
   }
 
   void _unifiedPositionHandler(Duration position) {
@@ -860,7 +907,10 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
       _player,
       configuration: VideoControllerConfiguration(
         hwdec: hwdecMode,
-        enableHardwareAcceleration: enableHardwareAccel,
+        enableHardwareAcceleration: shouldUseHardwareAcceleratedVideoOutput(
+          userEnabled: enableHardwareAccel,
+          isWindows: Platform.isWindows,
+        ),
         vo: Platform.isAndroid
             ? useGpuNext
                   ? "gpu-next"
@@ -896,17 +946,19 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
         "$defaultSkipIntroLength",
       );
     } catch (_) {}
-    if (isDesktop && _firstTime) {
-      final globalFullscreen = ref.read(fullScreenPlayerStateProvider);
-      // Delay fullscreen until after the first frame so the window is ready.
-      // On Windows, calling setFullScreen before the widget tree is built
-      // can silently fail, leaving the title bar visible.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        setFullScreen(value: globalFullscreen);
-        ref.read(fullscreenProvider.notifier).state = globalFullscreen;
-        widget.desktopFullScreenPlayer.call(globalFullscreen);
-      });
-      _firstTime = false;
+    if (isDesktop) {
+      if (_firstTime) {
+        final globalFullscreen = ref.read(fullScreenPlayerStateProvider);
+        // Delay fullscreen until after the first frame so the window is ready.
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          setFullScreen(value: globalFullscreen);
+          ref.read(fullscreenProvider.notifier).state = globalFullscreen;
+          widget.desktopFullScreenPlayer.call(globalFullscreen);
+        });
+        _firstTime = false;
+      } else {
+        widget.desktopFullScreenPlayer.call(ref.read(fullscreenProvider));
+      }
     }
     if (!isDesktop) {
       final forceLandscape = ref.read(forceLandscapePlayerStateProvider);
@@ -1053,10 +1105,18 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     _subSpeedController.removeListener(_onSubSpeedChanged);
     WidgetsBinding.instance.removeObserver(this);
     _setCurrentPosition(true, saveWatchTime: true);
-    _player.stop();
-    _completed.cancel();
-    _currentPositionSub.cancel();
-    _currentTotalDurationSub.cancel();
+    final playerCleanup = disposePlaybackSession(
+      listenerCancellations: [
+        _completed.cancel(),
+        _currentPositionSub.cancel(),
+        _currentTotalDurationSub.cancel(),
+      ],
+      beforeDisposePlayer: Platform.isWindows
+          ? () => Future<void>.delayed(const Duration(milliseconds: 250))
+          : null,
+      disposePlayer: _player.dispose,
+    );
+    unawaited(playerCleanup.catchError((_) {}));
     _currentPosition.dispose();
     _currentTotalDuration.dispose();
     _video.dispose();
@@ -1073,7 +1133,6 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     discordRpc?.showIdleText();
     discordRpc?.showOriginalTimestamp();
     _streamController.keepAliveLink?.close();
-    _player.dispose();
     if (widget.isTorrent) {
       for (final hash in widget.infoHashList) {
         MTorrentServer().removeTorrent(hash);
@@ -1849,7 +1908,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
       // Direct pop, not maybePop: the on-screen back arrow always exits the
       // player, bypassing the PopScope that makes the remote Back hide the
       // panel first.
-      onBack: () => Navigator.pop(context),
+      onBack: _goBackToDetail,
       onRestart: () => _player.seek(Duration.zero),
       onSettings: () {
         // On TV the settings open as the docked side panel; phones/desktop keep
@@ -2251,21 +2310,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
         children: [
           BackButton(
             color: Colors.white,
-            onPressed: () {
-              if (isDesktop && fullScreen) {
-                setFullScreen(value: !fullScreen);
-                ref.read(fullscreenProvider.notifier).state = !fullScreen;
-                widget.desktopFullScreenPlayer.call(!fullScreen);
-              } else {
-                restoreSystemUI();
-              }
-              if (mounted) {
-                // Set variable to true, so the player uses the global
-                // "Use Fullscreen" setting again.
-                _firstTime = true;
-                Navigator.pop(context);
-              }
-            },
+            onPressed: _goBackToDetail,
           ),
           Flexible(
             child: ListTile(
@@ -2391,7 +2436,8 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     final splitSettings = isTv && _tvSettingsOpen;
     final Widget player = Stack(
       children: [
-        Video(
+        if (_videoTextureVisible)
+          Video(
           pip: const PipConfig(autoEnter: true),
           subtitleViewConfiguration: SubtitleViewConfiguration(
             visible: false,
@@ -2443,7 +2489,9 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
           width: splitSettings ? null : context.width(1),
           height: splitSettings ? null : context.height(1),
           resumeUponEnteringForegroundMode: true,
-        ),
+          )
+        else
+          const SizedBox.expand(),
         Stack(
           alignment: AlignmentDirectional.center,
           children: [

--- a/lib/modules/anime/utils/player_lifecycle.dart
+++ b/lib/modules/anime/utils/player_lifecycle.dart
@@ -1,0 +1,45 @@
+/// Cancels player listeners and optional platform cleanup before releasing the
+/// native player. `Player.dispose()` already stops playback; racing it with a
+/// separate stop call can terminate desktop builds during route disposal.
+Future<void> disposePlaybackSession({
+  required Iterable<Future<void>> listenerCancellations,
+  Future<void> Function()? beforeDisposePlayer,
+  required Future<void> Function() disposePlayer,
+}) async {
+  try {
+    await Future.wait(listenerCancellations);
+  } finally {
+    try {
+      await beforeDisposePlayer?.call();
+    } finally {
+      await disposePlayer();
+    }
+  }
+}
+
+/// Removes a platform texture from the render tree before native teardown.
+Future<void> retirePlaybackSurface({
+  required void Function() hideSurface,
+  required Future<void> Function() waitForFrame,
+  Duration rasterDrainDelay = const Duration(milliseconds: 100),
+}) async {
+  hideSurface();
+  await waitForFrame();
+  if (rasterDrainDelay > Duration.zero) {
+    await Future<void>.delayed(rasterDrainDelay);
+  }
+}
+
+bool shouldExitDesktopFullscreenOnDispose({
+  required bool isDesktop,
+  required bool isFullscreen,
+  required bool isEpisodeReplacement,
+}) => isDesktop && isFullscreen && !isEpisodeReplacement;
+
+/// Windows' GPU-backed external texture can outlive Flutter's graphics
+/// context during navigation or standby. Pixel-buffer output avoids that
+/// engine crash while leaving media decode acceleration controlled by hwdec.
+bool shouldUseHardwareAcceleratedVideoOutput({
+  required bool userEnabled,
+  required bool isWindows,
+}) => userEnabled && !isWindows;

--- a/test/modules/anime/player_lifecycle_test.dart
+++ b/test/modules/anime/player_lifecycle_test.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/anime/utils/player_lifecycle.dart';
+
+void main() {
+  test('episode replacement preserves desktop fullscreen', () {
+    expect(
+      shouldExitDesktopFullscreenOnDispose(
+        isDesktop: true,
+        isFullscreen: true,
+        isEpisodeReplacement: true,
+      ),
+      isFalse,
+    );
+  });
+
+  test('leaving the player exits desktop fullscreen', () {
+    expect(
+      shouldExitDesktopFullscreenOnDispose(
+        isDesktop: true,
+        isFullscreen: true,
+        isEpisodeReplacement: false,
+      ),
+      isTrue,
+    );
+  });
+
+  test('Windows avoids the crashing GPU texture output', () {
+    expect(
+      shouldUseHardwareAcceleratedVideoOutput(
+        userEnabled: true,
+        isWindows: true,
+      ),
+      isFalse,
+    );
+  });
+
+  test('surface is hidden before waiting for the raster thread', () async {
+    final events = <String>[];
+    await retirePlaybackSurface(
+      hideSurface: () => events.add('hidden'),
+      waitForFrame: () async => events.add('frame'),
+      rasterDrainDelay: Duration.zero,
+    );
+    expect(events, ['hidden', 'frame']);
+  });
+
+  test('player disposal waits for listener cancellation', () async {
+    final cancellation = Completer<void>();
+    var disposeCalls = 0;
+    final cleanup = disposePlaybackSession(
+      listenerCancellations: [cancellation.future],
+      disposePlayer: () async => disposeCalls++,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(disposeCalls, 0);
+    cancellation.complete();
+    await cleanup;
+    expect(disposeCalls, 1);
+  });
+
+  test('player is disposed even when cancellation fails', () async {
+    var disposeCalls = 0;
+    await expectLater(
+      disposePlaybackSession(
+        listenerCancellations: [Future<void>.error(StateError('failed'))],
+        disposePlayer: () async => disposeCalls++,
+      ),
+      throwsStateError,
+    );
+    expect(disposeCalls, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- remove the video texture from Flutter's render tree before route replacement/back navigation
- cancel stream subscriptions before disposing the native media_kit player
- avoid racing Player.stop() and Player.dispose()
- preserve desktop fullscreen across episode replacement, while exiting it when actually leaving the player
- use pixel-buffer video output on Windows to avoid ANGLE/D3D external-texture crashes
- guard duplicate route exits

## Tests
- flutter test test/modules/anime/player_lifecycle_test.dart
- targeted dart analyze on changed files

This combines Mangatan's generic player crash fixes from the historical lifecycle/Windows/fullscreen commits. OCR, Jimaku, mining, and dictionary code are excluded.