### PR TITLE
fix(download): harden workers and HLS recovery

### DIFF
--- a/lib/services/download_manager/download_isolate_pool.dart
+++ b/lib/services/download_manager/download_isolate_pool.dart
@@ -29,6 +29,15 @@ class DownloadIsolatePool {
   final Set<int> _availableWorkers = {}; // Track available workers by index
   final int poolSize;
   bool _initialized = false;
+  Future<void>? _initializing;
+  final Map<String, _PoolWorker> _runningTasks = {};
+  void Function(SendPort)? _testWorkerEntryPoint;
+
+  @visibleForTesting
+  DownloadIsolatePool.forTesting({
+    this.poolSize = 1,
+    required void Function(SendPort) workerEntryPoint,
+  }) : _testWorkerEntryPoint = workerEntryPoint;
 
   DownloadIsolatePool._({this.poolSize = 3});
 
@@ -50,7 +59,18 @@ class DownloadIsolatePool {
   }
 
   /// Initialize the Isolate pool
-  Future<void> initialize() async {
+  Future<void> initialize() =>
+      _initializing ??= _initialize().catchError((Object error) {
+        for (final worker in _workers) {
+          worker.dispose();
+        }
+        _workers.clear();
+        _availableWorkers.clear();
+        _initializing = null;
+        throw error;
+      });
+
+  Future<void> _initialize() async {
     if (_initialized) return;
 
     if (kDebugMode) {
@@ -58,7 +78,10 @@ class DownloadIsolatePool {
     }
 
     for (int i = 0; i < poolSize; i++) {
-      final worker = await _PoolWorker.create(i);
+      final worker = await _PoolWorker.create(
+        i,
+        entryPoint: _testWorkerEntryPoint,
+      );
       _workers.add(worker);
       _availableWorkers.add(i); // All workers start as available
     }
@@ -70,6 +93,25 @@ class DownloadIsolatePool {
   }
 
   /// Submit a file download task (manga/anime)
+  Future<bool> _prepareSubmission(
+    String taskId,
+    void Function(Exception) onError,
+  ) async {
+    downloadTaskCancellation[taskId] = false;
+    try {
+      if (!_initialized) await initialize();
+    } catch (_) {
+      downloadTaskCancellation.remove(taskId);
+      rethrow;
+    }
+    if (downloadTaskCancellation[taskId] == true) {
+      downloadTaskCancellation.remove(taskId);
+      onError(Exception('Download cancelled'));
+      return false;
+    }
+    return true;
+  }
+
   Future<void> submitFileDownload({
     required String taskId,
     required List<PageUrl> pageUrls,
@@ -79,10 +121,7 @@ class DownloadIsolatePool {
     required void Function() onComplete,
     required void Function(Exception) onError,
   }) async {
-    if (!_initialized) await initialize();
-
-    // Mark the task as active (not cancelled)
-    downloadTaskCancellation[taskId] = false;
+    if (!await _prepareSubmission(taskId, onError)) return;
 
     final receivePort = ReceivePort();
     final task = _DownloadTask(
@@ -109,11 +148,6 @@ class DownloadIsolatePool {
     void Function(Exception) onError,
   ) {
     receivePort.listen((message) {
-      if (downloadTaskCancellation[taskId] == true) {
-        receivePort.close();
-        return;
-      }
-
       if (message is DownloadProgress) {
         onProgress(message);
       } else if (message is DownloadComplete || message is Exception) {
@@ -140,9 +174,7 @@ class DownloadIsolatePool {
     required void Function() onComplete,
     required void Function(Exception) onError,
   }) async {
-    if (!_initialized) await initialize();
-
-    downloadTaskCancellation[taskId] = false;
+    if (!await _prepareSubmission(taskId, onError)) return;
 
     final receivePort = ReceivePort();
     final task = _DownloadTask(
@@ -168,7 +200,15 @@ class DownloadIsolatePool {
 
   /// Cancel a download task
   void cancelTask(String taskId) {
-    downloadTaskCancellation[taskId] = true;
+    if (downloadTaskCancellation.containsKey(taskId)) {
+      downloadTaskCancellation[taskId] = true;
+    }
+    final queued = _taskQueue.where((task) => task.taskId == taskId).toList();
+    _taskQueue.removeWhere((task) => task.taskId == taskId);
+    for (final task in queued) {
+      task.sendPort.send(Exception('Download cancelled'));
+    }
+    _runningTasks[taskId]?.cancelCurrentTask();
   }
 
   /// Add a task to the queue and try to process it
@@ -191,7 +231,15 @@ class DownloadIsolatePool {
         );
       }
 
-      worker.executeTask(task).then((_) {
+      _runningTasks[task.taskId] = worker;
+      worker.executeTask(task).then((_) async {
+        _runningTasks.remove(task.taskId);
+        if (worker.terminated) {
+          _workers[workerIndex] = await _PoolWorker.create(
+            workerIndex,
+            entryPoint: _testWorkerEntryPoint,
+          );
+        }
         _availableWorkers.add(workerIndex); // Worker is free again
         if (kDebugMode) {
           print(
@@ -219,6 +267,8 @@ class DownloadIsolatePool {
     _availableWorkers.clear();
     downloadTaskCancellation.clear();
     _initialized = false;
+    _initializing = null;
+    _runningTasks.clear();
   }
 }
 
@@ -283,32 +333,58 @@ class _PoolWorker {
   late SendPort _sendPort;
   late ReceivePort _receivePort;
   final Completer<void> _ready = Completer();
+  void Function(Exception)? _cancelCurrent;
+  bool terminated = false;
+
+  void cancelCurrentTask() =>
+      _cancelCurrent?.call(Exception('Download cancelled'));
 
   _PoolWorker._(this.id);
 
-  static Future<_PoolWorker> create(int id) async {
+  static Future<_PoolWorker> create(
+    int id, {
+    void Function(SendPort)? entryPoint,
+  }) async {
     final worker = _PoolWorker._(id);
-    await worker._spawn();
+    await worker._spawn(entryPoint);
     return worker;
   }
 
-  Future<void> _spawn() async {
+  Future<void> _spawn(void Function(SendPort)? entryPoint) async {
     _receivePort = ReceivePort();
 
     _isolate = await Isolate.spawn(
-      _workerEntryPoint,
-      _WorkerInit(id, _receivePort.sendPort),
+      entryPoint ?? _workerEntryPoint,
+      _receivePort.sendPort,
+      onError: _receivePort.sendPort,
+      onExit: _receivePort.sendPort,
     );
 
     // Wait for the worker to be ready and get its SendPort
     final completer = Completer<SendPort>();
     _receivePort.listen((message) {
       if (message is SendPort) {
-        completer.complete(message);
+        if (!completer.isCompleted) completer.complete(message);
+      } else {
+        final error = DownloadPoolException(
+          'Download worker exited or failed to initialize',
+          message,
+        );
+        if (!completer.isCompleted) {
+          completer.completeError(error);
+        } else {
+          _cancelCurrent?.call(error);
+        }
       }
     });
 
-    _sendPort = await completer.future;
+    try {
+      _sendPort = await completer.future.timeout(const Duration(seconds: 30));
+    } catch (_) {
+      _isolate.kill(priority: Isolate.immediate);
+      _receivePort.close();
+      rethrow;
+    }
     _ready.complete();
   }
 
@@ -320,12 +396,24 @@ class _PoolWorker {
 
     // Create a port to receive messages from this worker
     final taskPort = ReceivePort();
+    _cancelCurrent = (error) {
+      // Cancellation must stop disk writes and settle the waiting downloader,
+      // otherwise its per-source gate remains held forever.
+      _cancelCurrent = null;
+      terminated = true;
+      _isolate.kill(priority: Isolate.immediate);
+      _receivePort.close();
+      taskPort.close();
+      task.sendPort.send(error);
+      if (!completer.isCompleted) completer.complete();
+    };
 
     taskPort.listen((message) {
       // Forward the message to the original task port
       task.sendPort.send(message);
 
       if (message is DownloadComplete || message is Exception) {
+        _cancelCurrent = null;
         taskPort.close();
         completer.complete();
       }
@@ -350,13 +438,6 @@ class _PoolWorker {
   }
 }
 
-/// Worker initialization message
-class _WorkerInit {
-  final int workerId;
-  final SendPort mainPort;
-  _WorkerInit(this.workerId, this.mainPort);
-}
-
 /// Task sent to the worker
 class _WorkerTask {
   final String taskId;
@@ -373,7 +454,7 @@ class _WorkerTask {
 }
 
 /// Isolate worker entry point
-void _workerEntryPoint(_WorkerInit init) async {
+void _workerEntryPoint(SendPort mainPort) async {
   // Initialize dependencies in the Isolate
   await RustLib.init();
 
@@ -388,10 +469,10 @@ void _workerEntryPoint(_WorkerInit init) async {
   final receivePort = ReceivePort();
 
   // Send the SendPort to the main isolate
-  init.mainPort.send(receivePort.sendPort);
+  mainPort.send(receivePort.sendPort);
 
   if (kDebugMode) {
-    print('[Worker ${init.workerId}] Ready');
+    print('[Download worker] Ready');
   }
 
   // Listen for tasks
@@ -405,7 +486,7 @@ void _workerEntryPoint(_WorkerInit init) async {
             httpClient,
           );
         } else if (message.type == _TaskType.m3u8Download) {
-          await _processM3u8Download(
+          await processM3u8Download(
             message.params as M3u8DownloadParams,
             message.replyPort,
             httpClient,
@@ -581,7 +662,7 @@ Future<void> _downloadFile(
 }
 
 /// Process an M3U8 download
-Future<void> _processM3u8Download(
+Future<void> processM3u8Download(
   M3u8DownloadParams params,
   SendPort replyPort,
   Client client,
@@ -589,47 +670,31 @@ Future<void> _processM3u8Download(
   int completed = 0;
   final total = params.segments.length;
   final queue = Queue<TsInfo>.from(params.segments);
-  final List<Future<void>> activeTasks = [];
-
-  try {
-    while (queue.isNotEmpty || activeTasks.isNotEmpty) {
-      while (queue.isNotEmpty &&
-          activeTasks.length < params.concurrentDownloads) {
-        final segment = queue.removeFirst();
-        final task = _downloadSegment(segment, params, client)
-            .then((_) {
-              completed++;
-              replyPort.send(
-                DownloadProgress(
-                  segment: segment,
-                  completed,
-                  total,
-                  params.itemType,
-                ),
-              );
-            })
-            .catchError((error) {
-              replyPort.send(
-                DownloadPoolException(
-                  'Error downloading segment ${segment.name}',
-                  error,
-                ),
-              );
-              throw error;
-            });
-
-        activeTasks.add(task);
-      }
-
-      if (activeTasks.isNotEmpty) {
-        await Future.wait(activeTasks.toList(), eagerError: true);
-        activeTasks.clear();
+  Object? failure;
+  Future<void> worker() async {
+    while (queue.isNotEmpty && failure == null) {
+      final segment = queue.removeFirst();
+      try {
+        await _downloadSegment(segment, params, client);
+        completed++;
+        replyPort.send(
+          DownloadProgress(completed, total, params.itemType, segment: segment),
+        );
+      } catch (error) {
+        failure ??= error;
       }
     }
+  }
 
+  // Refill each slot immediately; a slow segment must not hold up a batch.
+  // Settle all writers before reporting failure or reusing this worker.
+  await Future.wait(
+    List.generate(params.concurrentDownloads.clamp(1, 8), (_) => worker()),
+  );
+  if (failure != null) {
+    replyPort.send(DownloadPoolException('M3U8 download failed', failure));
+  } else {
     replyPort.send(DownloadComplete());
-  } catch (e) {
-    replyPort.send(DownloadPoolException('M3U8 download failed', e));
   }
 }
 
@@ -639,58 +704,60 @@ Future<void> _downloadSegment(
   M3u8DownloadParams params,
   Client client,
 ) async {
+  final file = File(path.join(params.tempDir, '${ts.name}.ts'));
+  final partial = File('${file.path}.part');
   try {
-    final file = File(path.join(params.tempDir, '${ts.name}.ts'));
-
-    // Streaming to save memory
-    var request = Request('GET', Uri.parse(ts.url));
-    if (params.headers != null) {
-      request.headers.addAll(params.headers!);
-    }
-    // Connection/response-headers timeout so a dropped connection can't hang
-    // the segment forever (see _downloadFile) — retry, then fail loudly.
-    StreamedResponse response = await _withRetry(
-      () => client.send(request).timeout(const Duration(seconds: 30)),
-      3,
-    );
-
-    // Accept any 2xx (including 206 Partial Content) — see comment in
-    // _downloadFile.
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw DownloadPoolException(
-        'Failed to download segment: ${ts.name} (status ${response.statusCode})',
-      );
-    }
-
-    final sink = file.openWrite();
-    try {
-      // Idle timeout: a segment whose connection stalls (no bytes for 30s)
-      // fails and retries instead of hanging the whole download forever.
-      await for (var chunk in response.stream.timeout(
-        const Duration(seconds: 30),
-        onTimeout: (sink) => sink.addError(
-          TimeoutException('Segment stalled (no data for 30s)'),
-        ),
-      )) {
-        sink.add(chunk);
+    await _withRetry(() async {
+      try {
+        final request = Request('GET', Uri.parse(ts.url));
+        request.headers.addAll(params.headers ?? {});
+        if (!request.headers.keys.any(
+          (name) => name.toLowerCase() == HttpHeaders.rangeHeader,
+        )) {
+          request.headers[HttpHeaders.rangeHeader] = 'bytes=0-';
+        }
+        final response = await client
+            .send(request)
+            .timeout(const Duration(seconds: 30));
+        if (response.statusCode != 200 && response.statusCode != 206) {
+          await response.stream.listen((_) {}).cancel();
+          throw DownloadPoolException(
+            'Failed to download segment: ${ts.name} (status ${response.statusCode})',
+          );
+        }
+        final sink = partial.openWrite();
+        try {
+          await sink.addStream(
+            response.stream.timeout(const Duration(seconds: 30)),
+          );
+          await sink.flush();
+        } finally {
+          await sink.close();
+        }
+        final length = await partial.length();
+        if (length == 0 ||
+            (response.contentLength != null &&
+                length != response.contentLength)) {
+          throw DownloadPoolException('Incomplete segment: ${ts.name}');
+        }
+        if (params.key != null) {
+          final bytes = await partial.readAsBytes();
+          final index = int.parse(ts.name.substringAfter('TS_'));
+          final decrypted = _aesDecrypt(
+            (params.mediaSequence ?? 0) + index - 1,
+            bytes,
+            params.key!,
+            iv: params.iv,
+          );
+          await partial.writeAsBytes(decrypted);
+        }
+        // Only complete, decrypted segments may be reused after a retry.
+        await partial.rename(file.path);
+      } catch (_) {
+        if (await partial.exists()) await partial.delete();
+        rethrow;
       }
-    } finally {
-      await sink.flush();
-      await sink.close();
-    }
-
-    // Decrypt if necessary
-    if (params.key != null) {
-      final bytes = await file.readAsBytes();
-      final index = int.parse(ts.name.substringAfter("TS_"));
-      final decrypted = _aesDecrypt(
-        (params.mediaSequence ?? 1) + (index - 1),
-        bytes,
-        params.key!,
-        iv: params.iv,
-      );
-      await file.writeAsBytes(decrypted);
-    }
+    }, 3);
   } catch (e) {
     throw DownloadPoolException('Failed to process segment: ${ts.name}', e);
   }

--- a/lib/services/download_manager/m3u8/m3u8_downloader.dart
+++ b/lib/services/download_manager/m3u8/m3u8_downloader.dart
@@ -1,11 +1,15 @@
 import 'dart:developer';
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
 import 'dart:io';
 import 'dart:async';
 import 'dart:isolate';
+
 import 'package:flutter/foundation.dart';
 import 'package:mangayomi/models/chapter.dart';
 import 'package:mangayomi/models/video.dart';
-import 'package:mangayomi/providers/storage_provider.dart';
 import 'package:mangayomi/services/http/m_client.dart';
 import 'package:mangayomi/services/http/rhttp/src/model/settings.dart';
 import 'package:mangayomi/services/download_manager/m3u8/models/download.dart';
@@ -40,7 +44,7 @@ class M3u8Downloader {
     required this.fileName,
     this.headers,
     required this.chapter,
-    this.concurrentDownloads = 1,
+    this.concurrentDownloads = 4,
     required this.subtitles,
     this.subDownloadDir,
   });
@@ -62,7 +66,7 @@ class M3u8Downloader {
     while (true) {
       try {
         attempts++;
-        return await operation();
+        return await operation().timeout(const Duration(seconds: 30));
       } catch (e) {
         if (attempts >= 3) {
           throw M3u8DownloaderException('Operation failed after 3 attempts', e);
@@ -73,15 +77,13 @@ class M3u8Downloader {
 
   Future<(List<TsInfo>, Uint8List?, Uint8List?, int?)> _getTsList() async {
     try {
-      final uri = Uri.parse(m3u8Url);
-      final m3u8Host = "${uri.scheme}://${uri.host}${path.dirname(uri.path)}";
-      final m3u8Body = await _withRetry(() => _getM3u8Body(m3u8Url));
-      final tsList = _parseTsList(m3u8Host, m3u8Body);
+      final (playlistUri, m3u8Body) = await _getMediaPlaylist();
+      final tsList = _parseTsList(playlistUri, m3u8Body);
       final mediaSequence = _extractMediaSequence(m3u8Body);
 
       _log("Total TS files to download: ${tsList.length}");
 
-      final (key, iv) = await _getM3u8KeyAndIv(m3u8Body);
+      final (key, iv) = await _getM3u8KeyAndIv(m3u8Body, playlistUri);
       if (key != null) _log("TS Key found");
       if (iv != null) _log("TS IV found");
       if (mediaSequence != null) _log("Media sequence: $mediaSequence");
@@ -93,19 +95,26 @@ class M3u8Downloader {
   }
 
   Future<void> download(void Function(DownloadProgress) onProgress) async {
-    final tempName =
-        '.tmp_${chapter.name!.replaceForbiddenCharacters('_').trim()}_${chapter.id ?? chapter.url.hashCode}';
-    final tempDir = path.join(downloadDir, tempName);
-    await StorageProvider().createDirectorySafely(tempDir);
+    // Do not repeat the episode title: Windows directory enumeration can fail
+    // on the resulting long path even when segment writes succeeded.
+    final tempDir = path.join(
+      path.dirname(fileName),
+      m3u8TempDirectoryName('${chapter.id}:$m3u8Url'),
+    );
+    await Directory(tempDir).create(recursive: true);
 
     try {
       final (tsList, key, iv, mediaSequence) = await _getTsList();
 
+      if (tsList.isEmpty) {
+        throw M3u8DownloaderException('Playlist contains no media segments');
+      }
       final tsListToDownload = await _filterExistingSegments(tsList, tempDir);
       _log('Downloading ${tsListToDownload.length} segments...');
 
       await _downloadSegmentsWithProgress(
         tsListToDownload,
+        tsList.length,
         tempDir,
         key,
         iv,
@@ -156,13 +165,15 @@ class M3u8Downloader {
     List<TsInfo> tsList,
     String tempDir,
   ) async {
-    return tsList
-        .where((ts) => !File(path.join(tempDir, '${ts.name}.ts')).existsSync())
-        .toList();
+    return tsList.where((ts) {
+      final file = File(path.join(tempDir, '${ts.name}.ts'));
+      return !file.existsSync() || file.lengthSync() == 0;
+    }).toList();
   }
 
   Future<void> _downloadSegmentsWithProgress(
     List<TsInfo> segments,
+    int totalSegments,
     String tempDir,
     Uint8List? key,
     Uint8List? iv,
@@ -186,23 +197,36 @@ class M3u8Downloader {
       headers: headers,
       itemType: chapter.manga.value!.itemType,
       onProgress: (progress) {
-        onProgress(progress);
+        onProgress(
+          DownloadProgress(
+            totalSegments - segments.length + progress.completed,
+            totalSegments,
+            progress.itemType,
+            segment: progress.segment,
+          ),
+        );
       },
       onComplete: () async {
-        // Merge the segments after downloading
-        await _mergeSegments(fileName, tempDir, onProgress);
+        try {
+          // Merge the segments after downloading
+          await _mergeSegments(fileName, tempDir, totalSegments, onProgress);
 
-        // Clean up the temporary directory
-        if (await Directory(tempDir).exists()) {
-          try {
-            await Directory(tempDir).delete(recursive: true);
-          } catch (e) {
-            _log('Warning: Failed to clean up temporary directory: $e');
+          // Clean up the temporary directory
+          if (await Directory(tempDir).exists()) {
+            try {
+              await Directory(tempDir).delete(recursive: true);
+            } catch (e) {
+              _log('Warning: Failed to clean up temporary directory: $e');
+            }
           }
-        }
 
-        if (!completer.isCompleted) {
-          completer.complete();
+          if (!completer.isCompleted) {
+            completer.complete();
+          }
+        } catch (error, stackTrace) {
+          if (!completer.isCompleted) {
+            completer.completeError(error, stackTrace);
+          }
         }
       },
       onError: (error) {
@@ -218,11 +242,12 @@ class M3u8Downloader {
   Future<void> _mergeSegments(
     String outputFile,
     String tempDir,
+    int totalSegments,
     void Function(DownloadProgress) onProgress,
   ) async {
     _log('Merging segments...');
     try {
-      await _mergeTsToMp4(outputFile, tempDir);
+      await _mergeTsToMp4(outputFile, tempDir, totalSegments);
       onProgress.call(
         DownloadProgress(
           1,
@@ -237,34 +262,13 @@ class M3u8Downloader {
     }
   }
 
-  Future<void> _mergeTsToMp4(String fileName, String directory) async {
+  Future<void> _mergeTsToMp4(
+    String fileName,
+    String directory,
+    int total,
+  ) async {
     try {
-      // Sustained file I/O — run in a worker isolate so merging a long
-      // episode doesn't stall the UI thread after the download finishes.
-      await Isolate.run(() async {
-        final dir = Directory(directory);
-        final files = await dir
-            .list()
-            .where((entity) => entity.path.endsWith('.ts'))
-            .toList();
-
-        files.sort((a, b) {
-          final aIndex = int.parse(
-            a.path.substringAfter("TS_").substringBefore("."),
-          );
-          final bIndex = int.parse(
-            b.path.substringAfter("TS_").substringBefore("."),
-          );
-          return aIndex.compareTo(bIndex);
-        });
-
-        final outFile = File(fileName).openWrite();
-        for (var file in files) {
-          final inFile = File(file.path).openRead();
-          await outFile.addStream(inFile);
-        }
-        await outFile.close();
-      });
+      await Isolate.run(() => mergeM3u8Segments(fileName, directory, total));
     } catch (e) {
       throw M3u8DownloaderException('Failed to merge TS files', e);
     }
@@ -278,31 +282,46 @@ class M3u8Downloader {
     return response.body;
   }
 
-  List<TsInfo> _parseTsList(String host, String body) {
+  Future<(Uri, String)> _getMediaPlaylist() async {
+    var playlistUri = Uri.parse(m3u8Url);
+    var body = await _withRetry(() => _getM3u8Body(playlistUri.toString()));
+
+    // A source may return a master playlist even when the selected video URL
+    // looks like a media playlist. Follow the highest-bandwidth variant before
+    // interpreting playlist entries as TS segments.
+    for (var depth = 0; depth < 5; depth++) {
+      final variantUrl = selectM3u8VariantUrl(playlistUri.toString(), body);
+      if (variantUrl == null) return (playlistUri, body);
+      playlistUri = Uri.parse(variantUrl);
+      body = await _withRetry(() => _getM3u8Body(playlistUri.toString()));
+    }
+    throw M3u8DownloaderException('Too many nested m3u8 playlists');
+  }
+
+  List<TsInfo> _parseTsList(Uri playlistUri, String body) {
     final lines = body.split('\n');
     final tsList = <TsInfo>[];
     var index = 0;
 
-    for (final line in lines) {
+    for (final rawLine in lines) {
+      final line = rawLine.trim();
       if (line.isEmpty || line.startsWith('#')) continue;
       index++;
-      final tsUrl = line.startsWith('http')
-          ? line
-          : '$host/${line.replaceFirst("/", "")}';
+      final tsUrl = resolveM3u8Reference(playlistUri.toString(), line);
       tsList.add(TsInfo('TS_$index', tsUrl));
     }
     return tsList;
   }
 
-  Future<(Uint8List?, Uint8List?)> _getM3u8KeyAndIv(String m3u8Body) async {
+  Future<(Uint8List?, Uint8List?)> _getM3u8KeyAndIv(
+    String m3u8Body,
+    Uri playlistUri,
+  ) async {
     try {
-      final uri = Uri.parse(m3u8Url);
-      final m3u8Host = '${uri.scheme}://${uri.host}${path.dirname(uri.path)}';
-
       for (final line in m3u8Body.split('\n')) {
         if (!line.contains('#EXT-X-KEY')) continue;
 
-        final (keyUrl, iv) = _extractKeyAttributes(line, m3u8Host);
+        final (keyUrl, iv) = _extractKeyAttributes(line, playlistUri);
         if (keyUrl == null) break;
 
         final response = await _withRetry(
@@ -318,7 +337,7 @@ class M3u8Downloader {
     }
   }
 
-  (String?, Uint8List?) _extractKeyAttributes(String content, String host) {
+  (String?, Uint8List?) _extractKeyAttributes(String content, Uri playlistUri) {
     final keyPattern = RegExp(
       r'#EXT-X-KEY:METHOD=AES-128(?:,URI="([^"]+)")?(?:,IV=0x([A-F0-9]+))?',
       caseSensitive: false,
@@ -327,8 +346,8 @@ class M3u8Downloader {
     if (match == null) return (null, null);
 
     String? uri = match.group(1);
-    if (uri != null && !uri.contains('http')) {
-      uri = '$host/${uri.replaceFirst("/", "")}';
+    if (uri != null) {
+      uri = resolveM3u8Reference(playlistUri.toString(), uri);
     }
 
     final ivStr = match.group(2);
@@ -348,6 +367,64 @@ class M3u8Downloader {
   }
 }
 
+/// Resolves a playlist reference using URI semantics rather than string
+/// concatenation. Mihon's video proxy routes child URLs through `/video/`; keep
+/// that route rooted whether a manifest includes its leading slash or not.
+String resolveM3u8Reference(String playlistUrl, String reference) {
+  final base = Uri.parse(playlistUrl);
+  final value = reference.trim();
+  if (value.isEmpty) return base.toString();
+
+  final parsed = Uri.parse(value);
+  if (parsed.hasScheme) return parsed.toString();
+  if (parsed.host.isNotEmpty) return base.resolve(value).toString();
+
+  if (base.pathSegments.isNotEmpty &&
+      base.pathSegments.first == 'video' &&
+      parsed.pathSegments.isNotEmpty &&
+      parsed.pathSegments.first == 'video') {
+    return base
+        .replace(
+          path: parsed.path.startsWith('/') ? parsed.path : '/${parsed.path}',
+          query: parsed.hasQuery ? parsed.query : null,
+          fragment: parsed.hasFragment ? parsed.fragment : null,
+        )
+        .toString();
+  }
+  return base.resolve(value).toString();
+}
+
+/// Returns the highest-bandwidth variant URL when [body] is a master playlist.
+/// A media playlist returns null so callers can parse its segment entries.
+String? selectM3u8VariantUrl(String playlistUrl, String body) {
+  final lines = body.split('\n');
+  String? bestUrl;
+  var bestBandwidth = -1;
+  int? pendingBandwidth;
+
+  for (final rawLine in lines) {
+    final line = rawLine.trim();
+    if (line.isEmpty) continue;
+    if (line.toUpperCase().startsWith('#EXT-X-STREAM-INF:')) {
+      final bandwidth = RegExp(
+        r'(?:^|,)BANDWIDTH=(\d+)',
+        caseSensitive: false,
+      ).firstMatch(line)?.group(1);
+      pendingBandwidth = int.tryParse(bandwidth ?? '') ?? 0;
+      continue;
+    }
+    if (pendingBandwidth == null || line.startsWith('#')) continue;
+
+    final resolved = resolveM3u8Reference(playlistUrl, line);
+    if (bestUrl == null || pendingBandwidth >= bestBandwidth) {
+      bestUrl = resolved;
+      bestBandwidth = pendingBandwidth;
+    }
+    pendingBandwidth = null;
+  }
+  return bestUrl;
+}
+
 class M3u8DownloaderException implements Exception {
   final String message;
   final dynamic originalError;
@@ -357,4 +434,36 @@ class M3u8DownloaderException implements Exception {
   @override
   String toString() =>
       'M3u8DownloaderException: $message${originalError != null ? ' ($originalError)' : ''}';
+}
+
+/// Short, source-specific name prevents long Windows paths and mixing variants.
+String m3u8TempDirectoryName(String url) =>
+    '.tmp_hls_${sha256.convert(utf8.encode(url)).toString().substring(0, 16)}';
+
+Future<void> mergeM3u8Segments(
+  String output,
+  String directory,
+  int total,
+) async {
+  if (total <= 0) throw StateError('No segments to merge');
+  final partial = File('$output.part');
+  final sink = partial.openWrite();
+  try {
+    try {
+      for (var index = 1; index <= total; index++) {
+        final file = File(path.join(directory, 'TS_$index.ts'));
+        if (!await file.exists() || await file.length() == 0) {
+          throw StateError('Missing or empty segment $index');
+        }
+        await sink.addStream(file.openRead());
+      }
+      await sink.flush();
+    } finally {
+      await sink.close();
+    }
+    await partial.rename(output);
+  } catch (_) {
+    if (await partial.exists()) await partial.delete();
+    rethrow;
+  }
 }

--- a/lib/services/download_manager/m_downloader.dart
+++ b/lib/services/download_manager/m_downloader.dart
@@ -64,7 +64,7 @@ class MDownloader {
     while (true) {
       try {
         attempts++;
-        return await operation();
+        return await operation().timeout(const Duration(seconds: 30));
       } catch (e) {
         if (attempts >= maxRetries) {
           throw MDownloaderException(

--- a/lib/services/get_video_list.dart
+++ b/lib/services/get_video_list.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:mangayomi/repositories/download_repository.dart';
+
 import 'package:mangayomi/models/chapter.dart';
 import 'package:mangayomi/models/video.dart';
 import 'package:mangayomi/modules/library/providers/file_scanner.dart';
@@ -53,7 +55,10 @@ Future<(List<Video>, bool, List<String>, Directory?)> getVideoList(
         ? await resolveLocalArchivePath(episode.archivePath!)
         : null;
     List<String> infoHashes = [];
-    if (await File(mp4animePath).exists() || isLocalArchive) {
+    // A partial file from a failed download is not a playable local source.
+    final incomplete =
+        downloadRepository.getByChapterId(episode.id)?.isDownload == false;
+    if ((!incomplete && await File(mp4animePath).exists()) || isLocalArchive) {
       final animeDir =
           resolvedArchivePath != null && episode.manga.value?.source == "local"
           ? Directory(p.dirname(resolvedArchivePath))

--- a/test/services/download_manager/download_isolate_pool_test.dart
+++ b/test/services/download_manager/download_isolate_pool_test.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/services/download_manager/download_isolate_pool.dart';
+import 'package:mangayomi/services/download_manager/m3u8/models/download.dart';
+
+void fakeWorker(SendPort mainPort) {
+  final port = ReceivePort();
+  mainPort.send(port.sendPort);
+  port.listen((dynamic task) {
+    final reply = task.replyPort as SendPort;
+    reply.send(DownloadProgress(0, 100, ItemType.anime));
+    if (task.taskId != 'blocked') reply.send(DownloadComplete());
+  });
+}
+
+void brokenWorker(SendPort mainPort) =>
+    throw StateError('Test startup failure');
+
+void main() {
+  test(
+    'cancellation during cold worker initialization prevents submission',
+    () async {
+      final pool = DownloadIsolatePool.forTesting(workerEntryPoint: fakeWorker);
+      final cancelled = Completer<Exception>();
+      try {
+        final submission = pool.submitFileDownload(
+          taskId: 'cold',
+          pageUrls: [],
+          concurrentDownloads: 1,
+          itemType: ItemType.anime,
+          onProgress: (_) => fail('Cancelled task started'),
+          onComplete: () => fail('Cancelled task completed'),
+          onError: cancelled.complete,
+        );
+        pool.cancelTask('cold');
+        await submission;
+        expect(
+          await cancelled.future.timeout(const Duration(seconds: 5)),
+          isA<Exception>(),
+        );
+        expect(pool.pendingTasks, 0);
+      } finally {
+        pool.dispose();
+      }
+    },
+  );
+  test(
+    'cancelling active and waiting tasks settles callers and releases worker',
+    () async {
+      final pool = DownloadIsolatePool.forTesting(workerEntryPoint: fakeWorker);
+      final started = Completer<void>();
+      final cancelled = Completer<Exception>();
+      final queuedCancelled = Completer<Exception>();
+      final completed = Completer<void>();
+      try {
+        final firstInit = pool.initialize();
+        expect(identical(firstInit, pool.initialize()), isTrue);
+        await firstInit;
+        await pool.submitFileDownload(
+          taskId: 'blocked',
+          pageUrls: [],
+          concurrentDownloads: 1,
+          itemType: ItemType.anime,
+          onProgress: (_) {
+            if (!started.isCompleted) started.complete();
+          },
+          onComplete: () => fail('Cancelled task completed'),
+          onError: cancelled.complete,
+        );
+        await started.future.timeout(const Duration(seconds: 5));
+        await pool.submitFileDownload(
+          taskId: 'queued',
+          pageUrls: [],
+          concurrentDownloads: 1,
+          itemType: ItemType.anime,
+          onProgress: (_) {},
+          onComplete: () => fail('Cancelled waiting task completed'),
+          onError: queuedCancelled.complete,
+        );
+        pool.cancelTask('queued');
+        expect(
+          await queuedCancelled.future.timeout(const Duration(seconds: 5)),
+          isA<Exception>(),
+        );
+        expect(pool.pendingTasks, 0);
+        pool.cancelTask('blocked');
+        expect(
+          await cancelled.future.timeout(const Duration(seconds: 5)),
+          isA<Exception>(),
+        );
+        await pool.submitFileDownload(
+          taskId: 'next',
+          pageUrls: [],
+          concurrentDownloads: 1,
+          itemType: ItemType.anime,
+          onProgress: (_) {},
+          onComplete: completed.complete,
+          onError: completed.completeError,
+        );
+        await completed.future.timeout(const Duration(seconds: 5));
+      } finally {
+        pool.dispose();
+      }
+    },
+  );
+
+  test('worker startup errors surface instead of hanging forever', () async {
+    final pool = DownloadIsolatePool.forTesting(workerEntryPoint: brokenWorker);
+    try {
+      await expectLater(
+        pool.initialize().timeout(const Duration(seconds: 5)),
+        throwsA(isA<DownloadPoolException>()),
+      );
+      // Initialization failure is retryable, not a cached failed Future.
+      await expectLater(
+        pool.initialize().timeout(const Duration(seconds: 5)),
+        throwsA(isA<DownloadPoolException>()),
+      );
+    } finally {
+      pool.dispose();
+    }
+  });
+}

--- a/test/services/download_manager/m3u8_downloader_test.dart
+++ b/test/services/download_manager/m3u8_downloader_test.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/services/download_manager/download_isolate_pool.dart';
+import 'package:mangayomi/services/download_manager/m3u8/models/ts_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/services/download_manager/m3u8/m3u8_downloader.dart';
+
+void main() {
+  test('temporary paths stay short and distinguish stream variants', () {
+    final url = 'https://example.com/${List.filled(300, 'episode').join()}';
+    expect(m3u8TempDirectoryName(url).length, lessThan(32));
+    expect(m3u8TempDirectoryName(url), m3u8TempDirectoryName(url));
+    expect(
+      m3u8TempDirectoryName('$url/other'),
+      isNot(m3u8TempDirectoryName(url)),
+    );
+  });
+
+  test('merge uses playlist order and ignores leftover files', () async {
+    final dir = await Directory.systemTemp.createTemp('hls_test');
+    addTearDown(() => dir.delete(recursive: true));
+    await File('${dir.path}/TS_2.ts').writeAsBytes([2]);
+    await File('${dir.path}/TS_1.ts').writeAsBytes([1]);
+    await File('${dir.path}/TS_3.ts').writeAsBytes([99]);
+    final output = '${dir.path}/video.mp4';
+    await mergeM3u8Segments(output, dir.path, 2);
+    expect(await File(output).readAsBytes(), [1, 2]);
+  });
+
+  test('failed merge preserves output and removes partial output', () async {
+    final dir = await Directory.systemTemp.createTemp('hls_test');
+    addTearDown(() => dir.delete(recursive: true));
+    await File('${dir.path}/TS_1.ts').writeAsBytes([1]);
+    final output = '${dir.path}/video.mp4';
+    await File(output).writeAsBytes([42]);
+    await expectLater(mergeM3u8Segments(output, dir.path, 2), throwsStateError);
+    expect(await File(output).readAsBytes(), [42]);
+    expect(await File('$output.part').exists(), isFalse);
+  });
+
+  test(
+    'segment retries HTTP errors and interrupted bodies before publishing',
+    () async {
+      final dir = await Directory.systemTemp.createTemp('hls_test');
+      final port = ReceivePort();
+      addTearDown(port.close);
+      addTearDown(() => dir.delete(recursive: true));
+      var attempts = 0;
+      final client = MockClient.streaming((request, _) async {
+        attempts++;
+        if (attempts == 1) return http.StreamedResponse(Stream.value([0]), 503);
+        if (attempts == 2) {
+          return http.StreamedResponse(() async* {
+            yield [9];
+            throw http.ClientException('connection interrupted');
+          }(), 200);
+        }
+        return http.StreamedResponse(
+          Stream.value([1, 2, 3]),
+          200,
+          contentLength: 3,
+        );
+      });
+      addTearDown(client.close);
+      await processM3u8Download(
+        M3u8DownloadParams(
+          segments: [TsInfo('TS_1', 'https://example.com/1.ts')],
+          tempDir: dir.path,
+          key: null,
+          iv: null,
+          mediaSequence: null,
+          headers: null,
+          concurrentDownloads: 2,
+          itemType: ItemType.anime,
+        ),
+        port.sendPort,
+        client,
+      );
+      expect(attempts, 3);
+      expect(await File('${dir.path}/TS_1.ts').readAsBytes(), [1, 2, 3]);
+      expect(await File('${dir.path}/TS_1.ts.part').exists(), isFalse);
+    },
+  );
+
+  test('free slots continue while another segment is stalled', () async {
+    final dir = await Directory.systemTemp.createTemp('hls_test');
+    final port = ReceivePort();
+    addTearDown(port.close);
+    addTearDown(() => dir.delete(recursive: true));
+    final releaseFirst = Completer<void>();
+    final thirdStarted = Completer<void>();
+    final client = MockClient.streaming((request, _) async {
+      if (request.url.path == '/1.ts') await releaseFirst.future;
+      if (request.url.path == '/3.ts') thirdStarted.complete();
+      return http.StreamedResponse(Stream.value([1]), 200);
+    });
+    addTearDown(client.close);
+    final download = processM3u8Download(
+      M3u8DownloadParams(
+        segments: List.generate(
+          3,
+          (i) => TsInfo('TS_${i + 1}', 'https://example.com/${i + 1}.ts'),
+        ),
+        tempDir: dir.path,
+        key: null,
+        iv: null,
+        mediaSequence: null,
+        headers: null,
+        concurrentDownloads: 2,
+        itemType: ItemType.anime,
+      ),
+      port.sendPort,
+      client,
+    );
+    try {
+      await thirdStarted.future.timeout(const Duration(seconds: 5));
+    } finally {
+      releaseFirst.complete();
+      await download;
+    }
+  });
+
+  test('resolves ordinary playlist references relative to the playlist', () {
+    expect(
+      resolveM3u8Reference(
+        'https://cdn.example/video/master.m3u8',
+        'segments/1.ts',
+      ),
+      'https://cdn.example/video/segments/1.ts',
+    );
+    expect(
+      resolveM3u8Reference(
+        'https://cdn.example/video/master.m3u8',
+        '/segments/1.ts',
+      ),
+      'https://cdn.example/segments/1.ts',
+    );
+  });
+
+  test('roots Mihon video proxy references at the video route', () {
+    expect(
+      resolveM3u8Reference(
+        'http://127.0.0.1:54758/video/master-token',
+        'video/variant-token.m3u8',
+      ),
+      'http://127.0.0.1:54758/video/variant-token.m3u8',
+    );
+    expect(
+      resolveM3u8Reference(
+        'http://127.0.0.1:54758/video/master-token.m3u8',
+        '/video/segment-token.ts',
+      ),
+      'http://127.0.0.1:54758/video/segment-token.ts',
+    );
+  });
+
+  test('selects the highest-bandwidth master playlist variant', () {
+    const body = '''
+#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=800000
+low/index.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2400000
+high/index.m3u8
+''';
+
+    expect(
+      selectM3u8VariantUrl('https://cdn.example/master.m3u8', body),
+      'https://cdn.example/high/index.m3u8',
+    );
+    expect(
+      selectM3u8VariantUrl(
+        'https://cdn.example/media.m3u8',
+        '#EXTM3U\n#EXTINF:4,\nsegment.ts\n',
+      ),
+      isNull,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- make download-isolate startup single-flight and surface worker startup failures instead of hanging
- cancel queued and active downloads completely, then replace terminated workers before processing the next task
- add bounded retry timeouts for file and HLS requests
- resolve master/media playlist references correctly and keep HLS concurrency slots filled
- publish only complete segments, merge them in playlist order through a partial output, and use short variant-specific temp paths
- avoid treating a partial video file from a failed download as a playable local episode

This extracts only the cross-platform download reliability fixes from Mangatan. It intentionally excludes Jimaku, OCR, dictionary, mining, and other Japanese-learning-specific functionality.

## Tests

- `flutter test test/services/download_manager/download_isolate_pool_test.dart test/services/download_manager/m3u8_downloader_test.dart` (11 passed)
- focused `dart analyze` on all changed source/test files (no issues)
- `git diff --check`