### PR TITLE
fix(player): preserve local file URIs

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -24,6 +24,7 @@ import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/video.dart' as vid;
 import 'package:mangayomi/modules/anime/providers/anime_player_controller_provider.dart';
 import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
+import 'package:mangayomi/modules/anime/utils/playback_media.dart';
 import 'package:mangayomi/modules/anime/widgets/aniskip_countdown_btn.dart';
 import 'package:mangayomi/modules/anime/widgets/tv_player_controls.dart';
 import 'package:mangayomi/modules/anime/widgets/tv_player_settings_panel.dart';
@@ -965,7 +966,12 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
   Future<void> _openMedia(VideoPrefs prefs, [Duration? position]) async {
     final start = position ?? _currentPosition.value;
     await _player.open(
-      Media(prefs.videoTrack!.id, httpHeaders: prefs.headers, start: start),
+      playbackMedia(
+        prefs.videoTrack!.id,
+        isLocal: widget.isLocal,
+        httpHeaders: prefs.headers,
+        start: start,
+      ),
     );
     if (start > Duration.zero) {
       // media_kit's Media(start:) is unreliable for some sources — playback can

--- a/lib/modules/anime/utils/playback_media.dart
+++ b/lib/modules/anime/utils/playback_media.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:media_kit/media_kit.dart';
+
+/// Creates media without allowing media_kit's URI parser to reinterpret a
+/// local file path.
+///
+/// In particular, a Windows UNC path such as `\\server\share` must retain
+/// its host component so libmpv can open it.
+Media playbackMedia(
+  String resource, {
+  required bool isLocal,
+  Map<String, String>? httpHeaders,
+  Duration? start,
+  bool? windows,
+}) {
+  if (!isLocal) {
+    return Media(resource, httpHeaders: httpHeaders, start: start);
+  }
+
+  return _LocalFileMedia(
+    resource,
+    httpHeaders: httpHeaders,
+    start: start,
+    windows: windows ?? Platform.isWindows,
+  );
+}
+
+String localFileUri(String resource, {required bool windows}) {
+  final uri = Uri.tryParse(resource);
+  if (uri != null && uri.isScheme('file')) {
+    return uri.toString();
+  }
+  return Uri.file(resource, windows: windows).toString();
+}
+
+class _LocalFileMedia extends Media {
+  final String _uri;
+
+  _LocalFileMedia(
+    super.resource, {
+    super.httpHeaders,
+    super.start,
+    required bool windows,
+  }) : _uri = localFileUri(resource, windows: windows);
+
+  @override
+  String get uri => _uri;
+}

--- a/test/modules/anime/utils/playback_media_test.dart
+++ b/test/modules/anime/utils/playback_media_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/anime/utils/playback_media.dart';
+
+void main() {
+  group('localFileUri', () {
+    test('preserves a named Windows UNC host as URI authority', () {
+      expect(
+        localFileUri(r'\\NAS\media\Anime\Show\ep 01.mkv', windows: true),
+        'file://nas/media/Anime/Show/ep%2001.mkv',
+      );
+    });
+
+    test('preserves an IP Windows UNC host as URI authority', () {
+      expect(
+        localFileUri(r'\\192.168.1.10\anime\ep01.mkv', windows: true),
+        'file://192.168.1.10/anime/ep01.mkv',
+      );
+    });
+
+    test('converts drive paths including extensionless files', () {
+      expect(
+        localFileUri(r'C:\folder.d\video', windows: true),
+        'file:///C:/folder.d/video',
+      );
+    });
+
+    test('converts POSIX paths for macOS and Linux', () {
+      expect(
+        localFileUri('/Volumes/Anime/Show/ep 01.mkv', windows: false),
+        'file:///Volumes/Anime/Show/ep%2001.mkv',
+      );
+    });
+
+    test('does not reinterpret an existing file URI', () {
+      expect(
+        localFileUri('file://NAS/media/episode.mkv', windows: true),
+        'file://nas/media/episode.mkv',
+      );
+    });
+  });
+
+  test('local media bypasses dependency URI normalization', () {
+    final media = playbackMedia(
+      r'\\NAS\media\Anime\Show\ep01.mkv',
+      isLocal: true,
+      windows: true,
+    );
+
+    expect(media.uri, 'file://nas/media/Anime/Show/ep01.mkv');
+  });
+
+  test('remote media retains normal media_kit handling', () {
+    final media = playbackMedia(
+      'https://example.com/episode.m3u8',
+      isLocal: false,
+      windows: true,
+    );
+
+    expect(media.uri, 'https://example.com/episode.m3u8');
+  });
+}


### PR DESCRIPTION
## Summary

- convert local media paths to explicit file URIs before media_kit normalizes them
- preserve Windows UNC server/share authority, drive paths, spaces, and extensionless files
- leave remote stream handling unchanged

This is a cross-platform playback fix extracted from Mangatan's history and contains no immersion-specific code.

## Tests

- `flutter test test/modules/anime/utils/playback_media_test.dart` (7 passed)
- focused `dart analyze` (no issues)
- `git diff --check`