### PR TITLE
fix(library): keep read titles last in unread sort

### DIFF
--- a/lib/modules/library/providers/library_filter_provider.dart
+++ b/lib/modules/library/providers/library_filter_provider.dart
@@ -6,6 +6,29 @@ import 'package:mangayomi/repositories/track_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'library_filter_provider.g.dart';
 
+/// Sorts unread counts while keeping fully-read entries at the end.
+///
+/// Reversing the active unread values must not promote the inactive zero
+/// value above titles that still have something to read.
+List<T> sortByUnreadCount<T>(
+  Iterable<T> values, {
+  required int Function(T value) unreadCountOf,
+  bool descending = false,
+}) {
+  final sorted = values.toList();
+  final counts = <T, int>{
+    for (final value in sorted) value: unreadCountOf(value),
+  };
+  sorted.sort((a, b) {
+    final aCount = counts[a]!;
+    final bCount = counts[b]!;
+    if (aCount == 0 && bCount != 0) return 1;
+    if (bCount == 0 && aCount != 0) return -1;
+    return descending ? bCount.compareTo(aCount) : aCount.compareTo(bCount);
+  });
+  return sorted;
+}
+
 /// Pre-fetches all downloaded chapter IDs in a single Isar query.
 /// Returns a [Set<int>] for O(1) lookup instead of per-chapter queries.
 @riverpod
@@ -134,11 +157,11 @@ List<Manga> filteredLibraryManga(
           unreadCounts[manga.id!] = manga.unreadChaptersCount(settings);
         }
       }
-      mangas.sort((a, b) {
-        final aVal = a.id != null ? (unreadCounts[a.id] ?? 0) : 0;
-        final bVal = b.id != null ? (unreadCounts[b.id] ?? 0) : 0;
-        return aVal.compareTo(bVal);
-      });
+      mangas = sortByUnreadCount(
+        mangas,
+        unreadCountOf: (manga) =>
+            manga.id != null ? (unreadCounts[manga.id] ?? 0) : 0,
+      );
     } else if (sortType == 4) {
       final totalCounts = <int, int>{};
       for (final manga in mangas) {

--- a/lib/modules/library/tv_home/tv_anime_home_view.dart
+++ b/lib/modules/library/tv_home/tv_anime_home_view.dart
@@ -30,6 +30,7 @@ import 'package:mangayomi/repositories/history_repository.dart';
 import 'package:mangayomi/repositories/manga_repository.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/extensions/chapter_extensions.dart';
+import 'package:mangayomi/utils/extensions/manga_extensions.dart';
 import 'package:super_sliver_list/super_sliver_list.dart';
 
 // Poster width per density scale (0 compact · 1 comfortable · 2 large); row
@@ -311,7 +312,14 @@ class _TvAnimeHomeViewState extends ConsumerState<TvAnimeHomeView> {
             ),
           );
           final entries = (sortState.reverse ?? false)
-              ? filtered.reversed.toList()
+              ? sortState.index == 3
+                    ? sortByUnreadCount(
+                        filtered,
+                        unreadCountOf: (manga) =>
+                            manga.unreadChaptersCount(settings),
+                        descending: true,
+                      )
+                    : filtered.reversed.toList()
               : filtered;
 
           // Continue Watching = every anime you've actually played, from watch

--- a/lib/modules/library/widgets/library_body.dart
+++ b/lib/modules/library/widgets/library_body.dart
@@ -12,6 +12,7 @@ import 'package:mangayomi/modules/widgets/error_text.dart';
 import 'package:mangayomi/modules/widgets/progress_center.dart';
 import 'package:mangayomi/providers/l10n_providers.dart';
 import 'package:mangayomi/services/library_updater.dart';
+import 'package:mangayomi/utils/extensions/manga_extensions.dart';
 
 /// Displays the library body content for a given category (or uncategorized).
 ///
@@ -119,7 +120,16 @@ class LibraryBody extends ConsumerWidget {
           return Center(child: Text(l10n.empty_library));
         }
 
-        final entriesManga = reverse ? entries.reversed.toList() : entries;
+        final entriesManga = reverse
+            ? sortType == 3
+                  ? sortByUnreadCount(
+                      entries,
+                      unreadCountOf: (manga) =>
+                          manga.unreadChaptersCount(settings),
+                      descending: true,
+                    )
+                  : entries.reversed.toList()
+            : entries;
         return RefreshIndicator(
           onRefresh: () async {
             await updateLibrary(

--- a/test/modules/library/library_unread_sort_test.dart
+++ b/test/modules/library/library_unread_sort_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/library/providers/library_filter_provider.dart';
+
+void main() {
+  const unread = <String, int>{'read': 0, 'one': 1, 'three': 3, 'two': 2};
+
+  test('ascending unread sort keeps zero-unread entries last', () {
+    expect(
+      sortByUnreadCount(unread.keys, unreadCountOf: (key) => unread[key]!),
+      ['one', 'two', 'three', 'read'],
+    );
+  });
+
+  test('descending unread sort also keeps zero-unread entries last', () {
+    expect(
+      sortByUnreadCount(
+        unread.keys,
+        unreadCountOf: (key) => unread[key]!,
+        descending: true,
+      ),
+      ['three', 'two', 'one', 'read'],
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- keep zero-unread (fully read/watched) library entries after entries with unread chapters
- preserve that inactive-zero rule in both ascending and descending sort directions
- apply the same behavior to the standard library and TV anime home
- retain scanlator-aware unread counts from current upstream

This adapts Mangatan's generic unread-sort fix to Mangayomi's latest provider/repository architecture.

## Tests

- `flutter test test/modules/library/library_unread_sort_test.dart` (2 passed)
- focused `dart analyze` (no issues)
- `git diff --check`