### PR TITLE
fix(reader): make bulk read actions uniform

### DIFF
--- a/lib/modules/manga/detail/chapter_bulk_actions.dart
+++ b/lib/modules/manga/detail/chapter_bulk_actions.dart
@@ -1,0 +1,11 @@
+import 'package:mangayomi/models/chapter.dart';
+
+/// Chooses one uniform state for the bulk read/unread action.
+///
+/// If every selected chapter is read, the action marks all of them unread.
+/// Otherwise it marks all selected chapters read.
+bool bulkChapterTargetReadState(Iterable<Chapter> chapters) {
+  final selected = chapters.toList(growable: false);
+  return selected.isEmpty ||
+      !selected.every((chapter) => chapter.isRead == true);
+}

--- a/lib/modules/manga/detail/manga_detail_view.dart
+++ b/lib/modules/manga/detail/manga_detail_view.dart
@@ -15,6 +15,7 @@ import 'package:mangayomi/models/track_search.dart';
 import 'package:mangayomi/modules/library/library_screen.dart';
 import 'package:mangayomi/modules/library/providers/library_filter_provider.dart';
 import 'package:mangayomi/modules/library/providers/local_archive.dart';
+import 'package:mangayomi/modules/manga/detail/chapter_bulk_actions.dart';
 import 'package:mangayomi/modules/manga/detail/providers/export_metadata.dart';
 import 'package:mangayomi/modules/manga/detail/providers/isar_providers.dart';
 import 'package:mangayomi/modules/manga/detail/providers/state_providers.dart';
@@ -906,6 +907,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                     ),
                     onPressed: () {
                       final chapters = ref.watch(chaptersListStateProvider);
+                      final markAsRead = bulkChapterTargetReadState(chapters);
                       final List<Chapter> updatedChapters = [];
                       final now = DateTime.now().millisecondsSinceEpoch;
                       Chapter? highestChapter;
@@ -913,7 +915,7 @@ class _MangaDetailViewState extends ConsumerState<MangaDetailView>
                       final recognition = ChapterRecognition();
                       final mangaTitle = widget.manga!.name ?? '';
                       for (var chapter in chapters) {
-                        chapter.isRead = !chapter.isRead!;
+                        chapter.isRead = markAsRead;
                         if (!chapter.isRead!) chapter.lastPageRead = "1";
                         chapter.updatedAt = now;
                         chapter.manga.value = widget.manga;

--- a/lib/modules/manga/detail/providers/state_providers.dart
+++ b/lib/modules/manga/detail/providers/state_providers.dart
@@ -1,6 +1,7 @@
 import 'package:mangayomi/models/chapter.dart';
 import 'package:mangayomi/models/manga.dart';
 import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/modules/manga/detail/chapter_bulk_actions.dart';
 import 'package:mangayomi/modules/manga/download/providers/download_provider.dart';
 import 'package:mangayomi/repositories/chapter_repository.dart';
 import 'package:mangayomi/repositories/download_repository.dart';
@@ -328,8 +329,9 @@ class ChapterSetIsReadState extends _$ChapterSetIsReadState {
   void set() {
     final allChapters = <Chapter>[];
     final chapters = ref.watch(chaptersListStateProvider);
+    final markAsRead = bulkChapterTargetReadState(chapters);
     for (var chapter in chapters) {
-      chapter.isRead = !chapter.isRead!;
+      chapter.isRead = markAsRead;
       chapter.updatedAt = DateTime.now().millisecondsSinceEpoch;
       chapter.manga.value = manga;
       allChapters.add(chapter);
@@ -409,7 +411,9 @@ class ScanlatorsFilterState extends _$ScanlatorsFilterState {
       }
     }
     filterScanlatorList.add(value);
-    settingsRepository.save(settings..filterScanlatorList = filterScanlatorList);
+    settingsRepository.save(
+      settings..filterScanlatorList = filterScanlatorList,
+    );
     state = (_getScanlators(), _getFilterScanlator()!, filterScanlators);
   }
 

--- a/test/modules/manga/detail/chapter_bulk_actions_test.dart
+++ b/test/modules/manga/detail/chapter_bulk_actions_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/models/chapter.dart';
+import 'package:mangayomi/modules/manga/detail/chapter_bulk_actions.dart';
+
+void main() {
+  Chapter chapter(bool isRead) =>
+      Chapter(mangaId: 1, name: 'Chapter', isRead: isRead);
+
+  test('multiple read chapters are uniformly marked unread', () {
+    expect(bulkChapterTargetReadState([chapter(true), chapter(true)]), isFalse);
+  });
+
+  test('mixed selection is uniformly marked read', () {
+    expect(bulkChapterTargetReadState([chapter(true), chapter(false)]), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

- make a mixed chapter selection resolve to one predictable bulk state instead of flipping each row independently
- mark all selected chapters read unless every selected chapter is already read; then mark all unread
- use the same rule in both the detail-screen action and its provider implementation

This extracts the generic reader portion of Mangatan's mixed bookmark/dictionary commit. Dictionary-specific changes are intentionally excluded.

## Tests

- `flutter test test/modules/manga/detail/chapter_bulk_actions_test.dart` (2 passed)
- focused `dart analyze` (no issues)
- `git diff --check`