### PR TITLE
fix(player): preserve shortcuts when controls hide

### DIFF
--- a/lib/modules/anime/utils/player_focus.dart
+++ b/lib/modules/anime/utils/player_focus.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/widgets.dart';
+
+/// Keeps keyboard events inside the player when a focused control is removed.
+///
+/// Focus is moved only when [playerFocusNode] or one of its descendants
+/// already owns it, so closing unrelated UI does not steal focus.
+void restorePlayerFocusBeforeUnmount(FocusNode playerFocusNode) {
+  if (playerFocusNode.hasFocus) {
+    playerFocusNode.requestFocus();
+  }
+}

--- a/lib/modules/anime/widgets/desktop.dart
+++ b/lib/modules/anime/widgets/desktop.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mangayomi/modules/anime/anime_player_view.dart';
 import 'package:mangayomi/modules/anime/providers/anime_player_controller_provider.dart';
+import 'package:mangayomi/modules/anime/utils/player_focus.dart';
 import 'package:mangayomi/modules/anime/widgets/custom_seekbar.dart';
 import 'package:mangayomi/modules/anime/widgets/subtitle_view.dart';
 import 'package:mangayomi/modules/more/settings/player/providers/player_state_provider.dart';
@@ -67,6 +68,9 @@ class _DesktopControllerWidgetState
   final controlsHoverDuration = const Duration(seconds: 3);
   double buttonBarHeight = 100;
   final bottomButtonBarMargin = const EdgeInsets.only(left: 16.0, right: 8.0);
+  final FocusNode _playerFocusNode = FocusNode(
+    debugLabel: 'desktopPlayerShortcuts',
+  );
 
   final List<StreamSubscription> subscriptions = [];
   DateTime last = DateTime.now();
@@ -122,7 +126,18 @@ class _DesktopControllerWidgetState
     subscriptions.clear();
     _timer?.cancel();
     _tapTimer?.cancel();
+    _playerFocusNode.dispose();
     super.dispose();
+  }
+
+  void _unmountHiddenControls() {
+    if (visible) return;
+
+    // A focused control is about to leave the tree. Move focus to the
+    // persistent player node first; otherwise Flutter can fall back to the
+    // root focus scope and CallbackShortcuts stops receiving hotkeys.
+    restorePlayerFocusBeforeUnmount(_playerFocusNode);
+    setState(() => mount = false);
   }
 
   void onHover() {
@@ -300,6 +315,7 @@ class _DesktopControllerWidgetState
           ),
           Focus(
             autofocus: true,
+            focusNode: _playerFocusNode,
             child: Listener(
               onPointerSignal: modifyVolumeOnScroll
                   ? (e) {
@@ -392,11 +408,7 @@ class _DesktopControllerWidgetState
                         opacity: visible ? 1.0 : 0.0,
                         duration: controlsTransitionDuration,
                         onEnd: () {
-                          if (!visible) {
-                            setState(() {
-                              mount = false;
-                            });
-                          }
+                          _unmountHiddenControls();
                         },
                         child: Stack(
                           clipBehavior: Clip.none,

--- a/test/modules/anime/player_focus_test.dart
+++ b/test/modules/anime/player_focus_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/anime/utils/player_focus.dart';
+
+void main() {
+  testWidgets('restores player focus before a focused control is removed', (
+    tester,
+  ) async {
+    final playerFocusNode = FocusNode();
+    final controlFocusNode = FocusNode();
+    addTearDown(playerFocusNode.dispose);
+    addTearDown(controlFocusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Focus(
+          focusNode: playerFocusNode,
+          child: Focus(focusNode: controlFocusNode, child: const SizedBox()),
+        ),
+      ),
+    );
+    controlFocusNode.requestFocus();
+    await tester.pump();
+
+    expect(controlFocusNode.hasPrimaryFocus, isTrue);
+    expect(playerFocusNode.hasFocus, isTrue);
+
+    restorePlayerFocusBeforeUnmount(playerFocusNode);
+    await tester.pump();
+
+    expect(playerFocusNode.hasPrimaryFocus, isTrue);
+  });
+
+  testWidgets('does not steal focus from outside the player', (tester) async {
+    final playerFocusNode = FocusNode();
+    final externalFocusNode = FocusNode();
+    addTearDown(playerFocusNode.dispose);
+    addTearDown(externalFocusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Column(
+          children: [
+            Focus(focusNode: playerFocusNode, child: const SizedBox()),
+            Focus(focusNode: externalFocusNode, child: const SizedBox()),
+          ],
+        ),
+      ),
+    );
+    externalFocusNode.requestFocus();
+    await tester.pump();
+
+    restorePlayerFocusBeforeUnmount(playerFocusNode);
+    await tester.pump();
+
+    expect(externalFocusNode.hasPrimaryFocus, isTrue);
+    expect(playerFocusNode.hasFocus, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

- give the persistent desktop player surface its own focus node
- restore focus to that surface before a focused control is removed after fade-out
- avoid stealing focus when it belongs outside the player

Without this, Flutter can fall back to the root focus scope when hidden controls unmount, and player keyboard shortcuts stop responding.

This is a generic desktop-player fix extracted from Mangatan and includes none of its OCR/mining additions.

## Tests

- `flutter test test/modules/anime/player_focus_test.dart` (2 passed)
- focused `dart analyze` (no issues)
- `git diff --check`