### PR TITLE
fix(player): fall back from unsupported audio tracks

### DIFF
--- a/lib/modules/anime/anime_player_view.dart
+++ b/lib/modules/anime/anime_player_view.dart
@@ -24,6 +24,8 @@ import 'package:mangayomi/models/settings.dart';
 import 'package:mangayomi/models/video.dart' as vid;
 import 'package:mangayomi/modules/anime/providers/anime_player_controller_provider.dart';
 import 'package:mangayomi/modules/anime/providers/auto_play_next_provider.dart';
+import 'package:mangayomi/modules/anime/utils/audio_track_fallback.dart';
+import 'package:mangayomi/modules/anime/utils/audio_track_label.dart';
 import 'package:mangayomi/modules/anime/widgets/aniskip_countdown_btn.dart';
 import 'package:mangayomi/modules/anime/widgets/tv_player_controls.dart';
 import 'package:mangayomi/modules/anime/widgets/tv_player_settings_panel.dart';
@@ -50,6 +52,7 @@ import 'package:mangayomi/services/get_video_list.dart';
 import 'package:mangayomi/services/torrent_server.dart';
 import 'package:mangayomi/utils/extensions/build_context_extensions.dart';
 import 'package:mangayomi/utils/language.dart';
+import 'package:mangayomi/utils/log/logger.dart';
 import 'package:mangayomi/utils/platform_utils.dart';
 import 'package:mangayomi/utils/share.dart';
 import 'package:mangayomi/utils/system_ui.dart';
@@ -344,6 +347,12 @@ class _AnimeStreamPageState extends riv.ConsumerState<AnimeStreamPage>
   int lastRpcTimestampUpdate = DateTime.now().millisecondsSinceEpoch;
 
   late final StreamSubscription<Duration> _currentPositionSub;
+  late final StreamSubscription<String> _playerErrorSub;
+  final Set<String> _failedAudioTrackKeys = {};
+  final Set<String> _failedAudioCodecs = {};
+  String? _requestedAudioLanguage;
+  bool _audioFallbackInProgress = false;
+  bool _audioFallbackErrorQueued = false;
 
   late final StreamSubscription<Duration> _currentTotalDurationSub = _player
       .stream
@@ -769,11 +778,13 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
         if (_firstVid.audios?.isNotEmpty ?? false) {
           try {
             final at = _firstVid.audios!.first;
-            _player.setAudioTrack(
-              AudioTrack.uri(
-                at.file ?? "",
-                title: at.label,
-                language: at.label,
+            unawaited(
+              _setAudioTrack(
+                AudioTrack.uri(
+                  at.file ?? "",
+                  title: at.label,
+                  language: at.label,
+                ),
               ),
             );
           } catch (_) {}
@@ -923,6 +934,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     _currentPositionSub = _player.stream.position.listen(
       _unifiedPositionHandler,
     );
+    _playerErrorSub = _player.stream.error.listen(_reportPlaybackError);
     _completed;
     _currentTotalDurationSub;
     _loadAndroidFont().then((_) {
@@ -964,6 +976,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
 
   Future<void> _openMedia(VideoPrefs prefs, [Duration? position]) async {
     final start = position ?? _currentPosition.value;
+    _resetAudioFallbackState(resetRequestedLanguage: true);
     await _player.open(
       Media(prefs.videoTrack!.id, httpHeaders: prefs.headers, start: start),
     );
@@ -983,6 +996,162 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             .then((_) => mounted ? _player.seek(start) : null)
             .catchError((_) {}),
       );
+    }
+  }
+
+  Future<void> _setAudioTrack(AudioTrack track) async {
+    _resetAudioFallbackState();
+    _requestedAudioLanguage = track.language ?? _preferredAudioLanguage();
+    await _player.setAudioTrack(track);
+  }
+
+  String? _preferredAudioLanguage() {
+    for (final language in audioPreferredLang.split(',')) {
+      final value = language.trim();
+      if (value.isNotEmpty) return value;
+    }
+    return null;
+  }
+
+  List<AudioTrack> _audioTracksForFallback() {
+    final tracks = _player.state.tracks.audio.toList();
+    for (final sourceTrack in _firstVid.audios ?? const <vid.Track>[]) {
+      final file = sourceTrack.file;
+      if (file == null || file.isEmpty) continue;
+      tracks.add(
+        AudioTrack.uri(
+          file,
+          title: sourceTrack.label,
+          language: sourceTrack.label,
+        ),
+      );
+    }
+    return tracks;
+  }
+
+  void _resetAudioFallbackState({bool resetRequestedLanguage = false}) {
+    _failedAudioTrackKeys.clear();
+    _failedAudioCodecs.clear();
+    _audioFallbackErrorQueued = false;
+    if (resetRequestedLanguage) _requestedAudioLanguage = null;
+  }
+
+  Future<AudioTrack> _activeAudioTrack() async {
+    final selectedAudio = _player.state.track.audio;
+    if (selectedAudio.id != 'auto' && selectedAudio.id != 'no') {
+      return selectedAudio;
+    }
+
+    final platform = _player.platform;
+    if (platform is! NativePlayer) return selectedAudio;
+    final aid = await _nativeAudioProperty(platform, 'aid');
+    final explicitlySelected = _audioTrackForNativeId(aid);
+    if (explicitlySelected != null) return explicitlySelected;
+    final activeId = await _nativeAudioProperty(
+      platform,
+      'current-tracks/audio/id',
+    );
+    return _audioTrackForNativeId(activeId) ?? selectedAudio;
+  }
+
+  Future<String?> _nativeAudioProperty(
+    NativePlayer platform,
+    String property,
+  ) async {
+    try {
+      final value = (await platform.getProperty(property)).trim();
+      return value.isEmpty ? null : value;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<String?> _nativePreferredAudioLanguage() async {
+    final platform = _player.platform;
+    if (platform is! NativePlayer) return null;
+    final alang = await _nativeAudioProperty(platform, 'alang');
+    for (final language in alang?.split(',') ?? const <String>[]) {
+      final value = language.trim();
+      if (value.isNotEmpty && value != 'auto') return value;
+    }
+    return null;
+  }
+
+  AudioTrack? _audioTrackForNativeId(String? id) {
+    if (id == null || id == 'auto' || id == 'no' || id == '-1') return null;
+    for (final track in _player.state.tracks.audio) {
+      if (track.id == id) return track;
+    }
+    return AudioTrack(id, null, null);
+  }
+
+  bool _isVideoDecoderError(String? codec, AudioTrack activeAudio) {
+    final normalized = codec?.trim().toLowerCase();
+    if (normalized == null || normalized.isEmpty) return false;
+    if (activeAudio.codec?.trim().toLowerCase() == normalized) return false;
+    final hasAudioCodec = _player.state.tracks.audio.any(
+      (track) => track.codec?.trim().toLowerCase() == normalized,
+    );
+    final hasVideoCodec = _player.state.tracks.video.any(
+      (track) => track.codec?.trim().toLowerCase() == normalized,
+    );
+    return hasVideoCodec && !hasAudioCodec;
+  }
+
+  void _reportPlaybackError(String error) {
+    final message = error.trim();
+    if (message.isEmpty || !isAudioDecoderInitializationError(message)) return;
+    if (_audioFallbackInProgress) {
+      _audioFallbackErrorQueued = true;
+      return;
+    }
+    unawaited(_recoverFromAudioDecoderError(message));
+  }
+
+  Future<void> _recoverFromAudioDecoderError(String message) async {
+    _audioFallbackInProgress = true;
+    try {
+      final failedTrack = await _activeAudioTrack();
+      final failedCodec = audioDecoderCodecFromError(message);
+      if (_isVideoDecoderError(failedCodec, failedTrack)) return;
+
+      _failedAudioTrackKeys.add(audioTrackFallbackKey(failedTrack));
+      if (failedCodec != null) {
+        _failedAudioCodecs.add(failedCodec.toLowerCase());
+      }
+      final requestedLanguage =
+          failedTrack.language ??
+          _requestedAudioLanguage ??
+          _preferredAudioLanguage() ??
+          await _nativePreferredAudioLanguage();
+      final candidates = audioTrackFallbackCandidates(
+        failedTrack: failedTrack,
+        availableTracks: _audioTracksForFallback(),
+        requestedLanguage: requestedLanguage,
+        failedTrackKeys: _failedAudioTrackKeys,
+        failedCodecs: _failedAudioCodecs,
+      );
+      if (candidates.isEmpty) return;
+
+      final fallback = candidates.first;
+      _requestedAudioLanguage = requestedLanguage;
+      AppLogger.log(
+        'Audio decoder failed for ${audioTrackLabel(failedTrack)}; '
+        'trying ${audioTrackLabel(fallback)}.',
+        logLevel: LogLevel.warning,
+      );
+      await _player.setAudioTrack(fallback);
+    } catch (error, stackTrace) {
+      AppLogger.log(
+        'Audio track fallback failed: $error\n$stackTrace',
+        logLevel: LogLevel.error,
+      );
+    } finally {
+      _audioFallbackInProgress = false;
+      if (_audioFallbackErrorQueued) {
+        _audioFallbackErrorQueued = false;
+        unawaited(_recoverFromAudioDecoderError(message));
+      }
     }
   }
 
@@ -1056,6 +1225,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
     _player.stop();
     _completed.cancel();
     _currentPositionSub.cancel();
+    _playerErrorSub.cancel();
     _currentTotalDurationSub.cancel();
     _currentPosition.dispose();
     _currentTotalDuration.dispose();
@@ -1530,7 +1700,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
             onTap: () {
               Navigator.pop(context);
               try {
-                _player.setAudioTrack(aud.audio!);
+                unawaited(_setAudioTrack(aud.audio!));
               } catch (_) {}
             },
             child: textWidget(title, selected),
@@ -1729,7 +1899,7 @@ mp.register_script_message('call_button_${button.id}_long', button${button.id}lo
         selected: selected,
         onTap: () {
           try {
-            _player.setAudioTrack(aud.audio!);
+            unawaited(_setAudioTrack(aud.audio!));
           } catch (_) {}
         },
       );

--- a/lib/modules/anime/utils/audio_track_fallback.dart
+++ b/lib/modules/anime/utils/audio_track_fallback.dart
@@ -1,0 +1,77 @@
+import 'package:mangayomi/modules/anime/utils/audio_track_label.dart';
+import 'package:media_kit/media_kit.dart';
+
+final _audioDecoderErrorPattern = RegExp(
+  r'''failed to initialize a decoder for codec\s+['"]([^'"]+)['"]''',
+  caseSensitive: false,
+);
+
+final _genericAudioDecoderErrorPattern = RegExp(
+  r'\berror decoding audio\b',
+  caseSensitive: false,
+);
+
+String? audioDecoderCodecFromError(String message) {
+  return _audioDecoderErrorPattern.firstMatch(message)?.group(1)?.trim();
+}
+
+bool isAudioDecoderInitializationError(String message) {
+  return audioDecoderCodecFromError(message) != null ||
+      _genericAudioDecoderErrorPattern.hasMatch(message);
+}
+
+String audioTrackFallbackKey(AudioTrack track) {
+  return '${track.uri ? 'external' : 'embedded'}:${track.id}';
+}
+
+/// Orders playable alternatives while retaining the order provided by mpv.
+/// Tracks in the requested language are preferred, while tracks and codecs
+/// that already failed are excluded.
+List<AudioTrack> audioTrackFallbackCandidates({
+  required AudioTrack failedTrack,
+  required Iterable<AudioTrack> availableTracks,
+  String? requestedLanguage,
+  Set<String> failedTrackKeys = const {},
+  Set<String> failedCodecs = const {},
+}) {
+  final failedKey = audioTrackFallbackKey(failedTrack);
+  final failedCodec = _normalizedCodec(failedTrack.codec);
+  final excludedCodecs = <String>{
+    ...failedCodecs.map((codec) => codec.trim().toLowerCase()),
+    ?failedCodec,
+  };
+
+  final candidates = availableTracks
+      .where(
+        (track) =>
+            track.id != 'auto' &&
+            track.id != 'no' &&
+            audioTrackFallbackKey(track) != failedKey &&
+            !failedTrackKeys.contains(audioTrackFallbackKey(track)) &&
+            !_isExcludedCodec(track.codec, excludedCodecs),
+      )
+      .toList();
+
+  final language = requestedLanguage ?? failedTrack.language;
+  if (language == null || language.trim().isEmpty) return candidates;
+
+  final matching = candidates
+      .where((track) => audioTrackLanguagesMatch(track.language, language))
+      .toList();
+  if (matching.isEmpty) return candidates;
+
+  return [
+    ...matching,
+    ...candidates.where((track) => !matching.contains(track)),
+  ];
+}
+
+String? _normalizedCodec(String? codec) {
+  final normalized = codec?.trim().toLowerCase();
+  return normalized == null || normalized.isEmpty ? null : normalized;
+}
+
+bool _isExcludedCodec(String? codec, Set<String> excludedCodecs) {
+  final normalized = _normalizedCodec(codec);
+  return normalized != null && excludedCodecs.contains(normalized);
+}

--- a/lib/modules/anime/utils/audio_track_label.dart
+++ b/lib/modules/anime/utils/audio_track_label.dart
@@ -1,0 +1,110 @@
+import 'package:mangayomi/utils/language.dart';
+import 'package:media_kit/media_kit.dart';
+
+const _iso6393LanguageNames = {
+  'ara': 'Arabic',
+  'ces': 'Czech',
+  'chi': 'Chinese',
+  'dan': 'Danish',
+  'deu': 'German',
+  'ell': 'Greek',
+  'eng': 'English',
+  'fas': 'Persian',
+  'fin': 'Finnish',
+  'fra': 'French',
+  'fre': 'French',
+  'ger': 'German',
+  'gre': 'Greek',
+  'heb': 'Hebrew',
+  'hin': 'Hindi',
+  'hrv': 'Croatian',
+  'hun': 'Hungarian',
+  'ind': 'Indonesian',
+  'ita': 'Italian',
+  'jpn': 'Japanese',
+  'kor': 'Korean',
+  'nld': 'Dutch',
+  'nor': 'Norwegian',
+  'pol': 'Polish',
+  'por': 'Portuguese',
+  'ron': 'Romanian',
+  'rum': 'Romanian',
+  'rus': 'Russian',
+  'slk': 'Slovak',
+  'slo': 'Slovak',
+  'slv': 'Slovenian',
+  'spa': 'Spanish; Castilian',
+  'srp': 'Serbian',
+  'swe': 'Swedish',
+  'tha': 'Thai',
+  'tur': 'Turkish',
+  'ukr': 'Ukrainian',
+  'vie': 'Vietnamese',
+  'zho': 'Chinese',
+};
+
+String audioTrackLabel(AudioTrack? track) {
+  if (track == null || track.id == 'no') return 'None';
+  if (track.id == 'auto') return '';
+
+  final language = _languageName(track.language);
+  final title = track.title?.trim() ?? '';
+  final details = <String>[];
+  final codec = track.codec?.trim() ?? '';
+  if (codec.isNotEmpty) details.add(codec);
+
+  final channels = track.channelscount;
+  if (channels != null && channels > 0) {
+    details.add('${channels}ch');
+  } else {
+    final channelLayout = track.channels?.trim() ?? '';
+    if (channelLayout.isNotEmpty) details.add('${channelLayout}ch');
+  }
+
+  final sampleRate = track.samplerate;
+  if (sampleRate != null && sampleRate > 0) {
+    final kilohertz = sampleRate / 1000;
+    final rate = kilohertz == kilohertz.roundToDouble()
+        ? kilohertz.toInt().toString()
+        : kilohertz.toStringAsFixed(1);
+    details.add('${rate}kHz');
+  }
+
+  final parts = <String>[];
+  if (language.isNotEmpty) parts.add('[$language]');
+  if (title.isNotEmpty && title.toLowerCase() != language.toLowerCase()) {
+    parts.add(title);
+  }
+
+  final base = parts.join(' ');
+  if (details.isEmpty) return base.isNotEmpty ? base : track.id;
+  return base.isEmpty ? details.join(', ') : '$base ${details.join(', ')}';
+}
+
+bool audioTrackLanguagesMatch(String? first, String? second) {
+  final firstFamily = _languageFamily(first);
+  final secondFamily = _languageFamily(second);
+  return firstFamily.isNotEmpty && firstFamily == secondFamily;
+}
+
+String _languageFamily(String? value) {
+  final name = _languageName(value).toLowerCase().trim();
+  if (name.isEmpty) return '';
+  return name.split(RegExp(r'\s*[(;\-]'))[0].trim();
+}
+
+String _languageName(String? value) {
+  final language = value?.trim() ?? '';
+  if (language.isEmpty) return '';
+
+  final normalized = language.toLowerCase();
+  final iso6393Name = _iso6393LanguageNames[normalized];
+  if (iso6393Name != null) return iso6393Name;
+
+  for (final entry in languagesMapEnglish.entries) {
+    if (entry.key.toLowerCase() == normalized) return entry.key;
+  }
+
+  final completeName = completeLanguageNameEnglish(language);
+  return completeName == language.toUpperCase() ? language : completeName;
+}

--- a/test/modules/anime/audio_track_fallback_test.dart
+++ b/test/modules/anime/audio_track_fallback_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/anime/utils/audio_track_fallback.dart';
+import 'package:media_kit/media_kit.dart';
+
+void main() {
+  test('recognizes decoder initialization errors that name a codec', () {
+    const message = "Failed to initialize a decoder for codec 'truehd'.";
+
+    expect(isAudioDecoderInitializationError(message), isTrue);
+    expect(audioDecoderCodecFromError(message), 'truehd');
+  });
+
+  test('recognizes generic audio decode errors', () {
+    const message = 'Error decoding audio.';
+
+    expect(isAudioDecoderInitializationError(message), isTrue);
+    expect(audioDecoderCodecFromError(message), isNull);
+  });
+
+  test('prefers an alternative in the failed track language', () {
+    final failed = AudioTrack('2', 'English lossless', 'eng', codec: 'truehd');
+    final candidates = audioTrackFallbackCandidates(
+      failedTrack: failed,
+      availableTracks: [
+        failed,
+        AudioTrack('3', 'Japanese', 'jpn', codec: 'aac'),
+        AudioTrack('4', 'English stereo', 'en', codec: 'aac'),
+      ],
+      failedCodecs: {'truehd'},
+    );
+
+    expect(candidates.map((track) => track.id), ['4', '3']);
+  });
+
+  test('skips tracks using codecs and track ids that already failed', () {
+    final failed = AudioTrack('2', 'English', 'en', codec: 'eac3');
+    final candidates = audioTrackFallbackCandidates(
+      failedTrack: failed,
+      availableTracks: [
+        failed,
+        AudioTrack('3', 'English alternate', 'en', codec: 'eac3'),
+        AudioTrack('4', 'English stereo', 'en', codec: 'aac'),
+      ],
+      failedTrackKeys: {
+        audioTrackFallbackKey(AudioTrack('4', 'English', 'en')),
+      },
+      failedCodecs: {'eac3'},
+    );
+
+    expect(candidates, isEmpty);
+  });
+}

--- a/test/modules/anime/audio_track_label_test.dart
+++ b/test/modules/anime/audio_track_label_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mangayomi/modules/anime/utils/audio_track_label.dart';
+import 'package:media_kit/media_kit.dart';
+
+void main() {
+  test('formats embedded audio metadata', () {
+    final track = AudioTrack(
+      '4',
+      'Surround 7.1',
+      'fra',
+      codec: 'eac3',
+      channelscount: 8,
+      samplerate: 48000,
+    );
+
+    expect(audioTrackLabel(track), '[French] Surround 7.1 eac3, 8ch, 48kHz');
+  });
+
+  test('does not repeat a title that is already the language name', () {
+    expect(audioTrackLabel(AudioTrack('7', 'Japanese', 'jpn')), '[Japanese]');
+  });
+
+  test('normalizes two- and three-letter language codes', () {
+    expect(audioTrackLanguagesMatch('en', 'eng'), isTrue);
+    expect(audioTrackLanguagesMatch('jpn', 'English'), isFalse);
+  });
+
+  test('keeps None and external tracks readable', () {
+    expect(audioTrackLabel(AudioTrack.no()), 'None');
+    expect(
+      audioTrackLabel(
+        AudioTrack.uri('https://example.com/audio', language: 'en'),
+      ),
+      '[English]',
+    );
+  });
+}


### PR DESCRIPTION
Recovers from libmpv audio decoder failures by selecting another playable track, preserving the requested language, and avoiding failed codecs. Resolves the actual native track when mpv still reports auto. Includes eight focused fallback and language-normalization tests; targeted flutter analyze and git diff checks pass.