### PR TITLE
fix(repositories): await extension repository writes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -488,7 +488,10 @@ class _MyAppState extends ConsumerState<MyApp>
                         return;
                       }
 
-                      void addRepos(ItemType type, List<String>? urls) {
+                      Future<void> addRepos(
+                        ItemType type,
+                        List<String>? urls,
+                      ) async {
                         if (urls == null) return;
                         final current = ref.read(
                           extensionsRepoStateProvider(type),
@@ -502,9 +505,11 @@ class _MyAppState extends ConsumerState<MyApp>
                               final clean = e.trim().toLowerCase();
                               return !existingUrls.contains(clean) &&
                                   !existingUrls.contains('$clean/') &&
-                                  !existingUrls.contains(clean.endsWith('/')
-                                      ? clean.substring(0, clean.length - 1)
-                                      : clean);
+                                  !existingUrls.contains(
+                                    clean.endsWith('/')
+                                        ? clean.substring(0, clean.length - 1)
+                                        : clean,
+                                  );
                             })
                             .map(
                               (e) => Repo(
@@ -516,14 +521,16 @@ class _MyAppState extends ConsumerState<MyApp>
                             .toList();
                         if (newRepos.isEmpty) return;
                         final updated = [...current, ...newRepos];
-                        ref
+                        await ref
                             .read(extensionsRepoStateProvider(type).notifier)
                             .set(updated);
                       }
 
-                      addRepos(ItemType.manga, mangaRepoUrls);
-                      addRepos(ItemType.anime, animeRepoUrls);
-                      addRepos(ItemType.novel, novelRepoUrls);
+                      await Future.wait([
+                        addRepos(ItemType.manga, mangaRepoUrls),
+                        addRepos(ItemType.anime, animeRepoUrls),
+                        addRepos(ItemType.novel, novelRepoUrls),
+                      ]);
                       botToast(l10n.repo_added);
                     },
                   ),

--- a/lib/modules/more/settings/browse/providers/browse_state_provider.dart
+++ b/lib/modules/more/settings/browse/providers/browse_state_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -103,7 +104,8 @@ class ExtensionsRepoState extends _$ExtensionsRepoState {
   @override
   List<Repo> build(ItemType itemType) {
     final settings = settingsRepository.current;
-    final list = switch (itemType) {
+    final list =
+        switch (itemType) {
           ItemType.manga => settings.mangaExtensionsRepo,
           ItemType.anime => settings.animeExtensionsRepo,
           _ => settings.novelExtensionsRepo,
@@ -128,13 +130,13 @@ class ExtensionsRepoState extends _$ExtensionsRepoState {
       }
       return e;
     }).toList();
-    set(value);
+    unawaited(set(value));
   }
 
-  void set(List<Repo> value) {
+  Future<void> set(List<Repo> value) async {
     final deduplicated = _deduplicate(value);
     state = deduplicated;
-    settingsRepository.update((s) {
+    await settingsRepository.update((s) {
       switch (itemType) {
         case ItemType.manga:
           s.mangaExtensionsRepo = deduplicated;
@@ -146,15 +148,19 @@ class ExtensionsRepoState extends _$ExtensionsRepoState {
           s.novelExtensionsRepo = deduplicated;
       }
     });
+    unawaited(_refreshSources());
+  }
+
+  Future<void> _refreshSources() async {
     try {
-      final a = ref.refresh(
+      final refresh = ref.refresh(
         fetchItemSourcesListProvider(
           id: null,
           reFresh: false,
           itemType: itemType,
         ).future,
       );
-      Future.wait([a]);
+      await refresh;
     } catch (_) {}
   }
 }

--- a/lib/modules/more/settings/browse/source_repositories.dart
+++ b/lib/modules/more/settings/browse/source_repositories.dart
@@ -163,16 +163,20 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
                                           !repo.name!.endsWith('.json'))
                                       ? repo.name!
                                       : (repo.jsonUrl != null
-                                          ? (repo.jsonUrl!
-                                                  .replaceAll(
-                                                    RegExp(r'/[^/]+\.json$'),
-                                                    '',
-                                                  )
-                                                  .split('/')
-                                                  .where((s) => s.isNotEmpty)
-                                                  .lastOrNull ??
-                                              repo.jsonUrl!)
-                                          : "Invalid source - remove it"),
+                                            ? (repo.jsonUrl!
+                                                      .replaceAll(
+                                                        RegExp(
+                                                          r'/[^/]+\.json$',
+                                                        ),
+                                                        '',
+                                                      )
+                                                      .split('/')
+                                                      .where(
+                                                        (s) => s.isNotEmpty,
+                                                      )
+                                                      .lastOrNull ??
+                                                  repo.jsonUrl!)
+                                            : "Invalid source - remove it"),
                                   style: TextStyle(
                                     decoration: isHidden
                                         ? TextDecoration.lineThrough
@@ -283,7 +287,7 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
   /// #774: when a repo is removed, drop its *not-installed* sources so they
   /// don't linger as placeholders with a dead install button. Installed
   /// sources (non-empty [Source.sourceCode]) are kept so users don't lose them.
-  void _removeOrphanSources(Repo removedRepo) {
+  Future<void> _removeOrphanSources(Repo removedRepo) async {
     final repoUrl = removedRepo.jsonUrl;
     if (repoUrl == null) return;
     final orphanIds = sourceRepository
@@ -294,7 +298,7 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
         .map((s) => s.id!)
         .toList();
     if (orphanIds.isNotEmpty) {
-      sourceRepository.deleteAll(orphanIds);
+      await sourceRepository.deleteAll(orphanIds);
     }
   }
 
@@ -320,20 +324,19 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
                     ),
                     const SizedBox(width: 15),
                     TextButton(
-                      onPressed: () {
+                      onPressed: () async {
                         final removedRepo = _entries[index];
                         final mangaRepos = ref
                             .read(extensionsRepoStateProvider(widget.itemType))
                             .toList();
                         mangaRepos.removeWhere((url) => url == removedRepo);
-                        ref
+                        await ref
                             .read(
                               extensionsRepoStateProvider(widget.itemType)
                                   .notifier,
                             )
                             .set(mangaRepos);
-                        _removeOrphanSources(removedRepo);
-                        ref.watch(extensionsRepoStateProvider(widget.itemType));
+                        await _removeOrphanSources(removedRepo);
                         if (context.mounted) {
                           Navigator.pop(context);
                         }
@@ -464,13 +467,19 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
                                             .future,
                                       );
                                       if (repo == null) {
-                                        setState(() => isLoading = false);
+                                        if (context.mounted) {
+                                          setState(() => isLoading = false);
+                                        }
                                         botToast(l10n.unsupported_repo);
                                         return;
                                       }
-                                      final repoUrl = repo.jsonUrl?.trim().toLowerCase();
+                                      final repoUrl = repo.jsonUrl
+                                          ?.trim()
+                                          .toLowerCase();
                                       final isDuplicate = currentRepos.any((r) {
-                                        final rUrl = r.jsonUrl?.trim().toLowerCase();
+                                        final rUrl = r.jsonUrl
+                                            ?.trim()
+                                            .toLowerCase();
                                         return (rUrl != null &&
                                                 (rUrl == repoUrl ||
                                                     rUrl == clean ||
@@ -478,7 +487,8 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
                                                     '$rUrl/' == clean ||
                                                     (repoUrl != null &&
                                                         (rUrl == '$repoUrl/' ||
-                                                            '$rUrl/' == repoUrl)))) ||
+                                                            '$rUrl/' ==
+                                                                repoUrl)))) ||
                                             r == repo;
                                       });
                                       if (isDuplicate) {
@@ -486,11 +496,21 @@ class _SourceRepositoriesState extends ConsumerState<SourceRepositories> {
                                         botToast(l10n.repo_already_exists);
                                         return;
                                       }
-                                      repoNotifier.set([...currentRepos, repo]);
+                                      await repoNotifier.set([
+                                        ...currentRepos,
+                                        repo,
+                                      ]);
                                       botToast(l10n.repo_added);
                                     } catch (e, s) {
-                                      setState(() => isLoading = false);
-                                      toastError(e, stack: s, source: 'sourceRepositories');
+                                      if (context.mounted) {
+                                        setState(() => isLoading = false);
+                                      }
+                                      toastError(
+                                        e,
+                                        stack: s,
+                                        source: 'sourceRepositories',
+                                      );
+                                      return;
                                     }
 
                                     if (context.mounted) {

--- a/lib/modules/onboarding/onboarding_screen.dart
+++ b/lib/modules/onboarding/onboarding_screen.dart
@@ -450,14 +450,16 @@ class _OnboardingScreenState extends ConsumerState<_OnboardingBody>
         final rUrl = r.jsonUrl?.trim().toLowerCase();
         final newUrl = repo.jsonUrl?.trim().toLowerCase();
         return (rUrl != null &&
-                (rUrl == newUrl ||
-                    rUrl == '$newUrl/' ||
-                    '$rUrl/' == newUrl)) ||
+                (rUrl == newUrl || rUrl == '$newUrl/' || '$rUrl/' == newUrl)) ||
             r == repo;
       });
       if (!alreadyExists) {
-        ref.read(extensionsRepoStateProvider(_repoType).notifier).set([...currentRepos, repo]);
+        await ref.read(extensionsRepoStateProvider(_repoType).notifier).set([
+          ...currentRepos,
+          repo,
+        ]);
       }
+      if (!mounted) return;
       setState(() {
         _added = repo;
         _addedFor = _repoType;

--- a/test/services/community_repo_persistence_test.dart
+++ b/test/services/community_repo_persistence_test.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar_community/isar.dart';
+import 'package:mangayomi/main.dart' as app;
+import 'package:mangayomi/models/manga.dart';
+import 'package:mangayomi/models/settings.dart';
+import 'package:mangayomi/models/source.dart';
+import 'package:mangayomi/modules/more/settings/browse/providers/browse_state_provider.dart';
+import 'package:mangayomi/repositories/settings_repository.dart';
+
+void main() {
+  late Directory databaseDirectory;
+
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final overrides = HttpOverrides.current;
+    HttpOverrides.global = null;
+    try {
+      await Isar.initializeIsarCore(download: true);
+    } finally {
+      HttpOverrides.global = overrides;
+    }
+  });
+
+  setUp(() async {
+    databaseDirectory = await Directory.systemTemp.createTemp(
+      'mangayomi-community-repo-',
+    );
+    app.isar = await Isar.open(
+      [SettingsSchema, SourceSchema],
+      directory: databaseDirectory.path,
+      name: 'community_repo_${databaseDirectory.path.hashCode}',
+    );
+    app.isar.writeTxnSync(() {
+      app.isar.settings.putSync(Settings()..checkForExtensionUpdates = false);
+    });
+  });
+
+  tearDown(() async {
+    await app.isar.close(deleteFromDisk: true);
+    if (await databaseDirectory.exists()) {
+      await databaseDirectory.delete(recursive: true);
+    }
+  });
+
+  test('awaiting set guarantees that the repository is persisted', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(
+      extensionsRepoStateProvider(ItemType.manga).notifier,
+    );
+
+    await notifier.set([
+      Repo(name: 'Community', jsonUrl: 'https://example.com/manga.json'),
+    ]);
+
+    expect(
+      app.isar.settings.getSync(227)!.mangaExtensionsRepo!.single.jsonUrl,
+      'https://example.com/manga.json',
+    );
+  });
+
+  test('concurrent content-type writes are serialized without loss', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await Future.wait([
+      container.read(extensionsRepoStateProvider(ItemType.manga).notifier).set([
+        Repo(jsonUrl: 'https://example.com/manga.json'),
+      ]),
+      container.read(extensionsRepoStateProvider(ItemType.anime).notifier).set([
+        Repo(jsonUrl: 'https://example.com/anime.json'),
+      ]),
+      container.read(extensionsRepoStateProvider(ItemType.novel).notifier).set([
+        Repo(jsonUrl: 'https://example.com/novel.json'),
+      ]),
+    ]);
+
+    final settings = app.isar.settings.getSync(227)!;
+    expect(
+      settings.mangaExtensionsRepo!.single.jsonUrl,
+      'https://example.com/manga.json',
+    );
+    expect(
+      settings.animeExtensionsRepo!.single.jsonUrl,
+      'https://example.com/anime.json',
+    );
+    expect(
+      settings.novelExtensionsRepo!.single.jsonUrl,
+      'https://example.com/novel.json',
+    );
+  });
+
+  test('set waits behind an active settings transaction', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final transactionStarted = Completer<void>();
+    final releaseTransaction = Completer<void>();
+    final activeWrite = settingsRepository.transaction(() async {
+      transactionStarted.complete();
+      await releaseTransaction.future;
+    });
+    await transactionStarted.future;
+
+    var setCompleted = false;
+    final setFuture = container
+        .read(extensionsRepoStateProvider(ItemType.anime).notifier)
+        .set([Repo(jsonUrl: 'https://example.com/queued.json')])
+        .then((_) => setCompleted = true);
+    await Future<void>.delayed(Duration.zero);
+    expect(setCompleted, isFalse);
+
+    releaseTransaction.complete();
+    await Future.wait([activeWrite, setFuture]);
+    expect(setCompleted, isTrue);
+  });
+}


### PR DESCRIPTION
Makes extension repository persistence awaitable through deep links, onboarding, add dialogs, and removal. The notifier now waits for the existing settings write queue before reporting success, serializes simultaneous manga/anime/novel updates, refreshes sources after persistence, and waits for orphan cleanup before closing the dialog. Three Isar-backed regression tests pass, targeted Flutter analysis is clean, and git diff checks pass.